### PR TITLE
[feat] 공통 데이터 규격(AttackSurface, Payload) 추가

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class HttpMethod(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+    OPTIONS = "OPTIONS"
+
+
+class ParamLocation(str, Enum):
+    QUERY = "query"
+    BODY_FORM = "body_form"
+    BODY_JSON = "body_json"
+    HEADER = "header"
+    COOKIE = "cookie"
+
+
+@dataclass(slots=True)
+class AttackSurface:
+    """
+    Shared DTO between crawler/parser and fuzzer engine.
+    """
+
+    url: str
+    method: HttpMethod = HttpMethod.GET
+    param_location: ParamLocation = ParamLocation.QUERY
+    parameters: dict[str, Any] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
+    cookies: dict[str, str] = field(default_factory=dict)
+    source_url: str | None = None
+    description: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class Payload:
+    """
+    Structured payload metadata used by payload provider/reporter.
+    """
+
+    value: str
+    attack_type: str
+    risk_level: str
+
+
+@dataclass(slots=True, frozen=True)
+class FuzzingTask:
+    """
+    One concrete fuzzing unit generated from a surface.
+    """
+
+    surface: AttackSurface
+    target_param: str
+    payload: Payload


### PR DESCRIPTION
## PR 목적
- 팀 A와 팀 B가 공통으로 사용할 데이터 규격(DTO)를 정의한 `core/models.py` 파일을 추가
- 팀 A가 AttackSurface 객체를 즉시 import하여 개발 및 테스트를 진행할 수 있도록, 데이터 모델만 우선적으로 분리하여 병합

## 주요 변경 사항
- AttackSurface 데이터 클래스 추가: 팀 A가 타겟을 포장해서 넘겨줄 규격
- Payload 데이터 클래스 추가: 팀 B 내부에서 사용할 페이로드 및 상세 정보 규격
- str 상속 Enum 구현

## 리뷰어 참고 사항
- 팀 A: 파싱한 데이터를 AttackSurface 객체 형태로 조립해 주시면 될 거 같습니다.
- 팀 B(허윤): 페이로드 함수에서 리턴하실 때 Payload 형태로 값과 attack_type, risk_level 까지 포함해서 넘겨주시면 차후 취약점 리포트 생성할 때 도움이 될 거 같습니다.

## 다음 작업
- 본 PR 병합 후, feature/fuzzer-engine 브랜치에서 비동기 퍼저 코어 로직 작업 진행 예정입니다.