### PR TITLE
 [feat] crawler engine 구현 완료 

### DIFF
--- a/crawler/engine.py
+++ b/crawler/engine.py
@@ -1,0 +1,207 @@
+# crawler/engine.py
+
+import asyncio
+from urllib.parse import urljoin, urlparse
+from datetime import datetime
+from bs4 import BeautifulSoup
+
+from core.models import PageData
+from utils.logger import get_logger
+
+from .session_manager import SessionManager
+from .url_filter import URLFilter
+
+logger = get_logger(__name__)
+
+
+class CrawlConfig:
+    def __init__(self, max_depth=3, max_urls=100, delay=0.5, timeout=10, workers=5):
+        self.max_depth = max_depth
+        self.max_urls = max_urls
+        self.delay = delay
+        self.timeout = timeout
+        self.workers = workers  # 동시 작업자 수
+
+
+class CrawlStats:
+    def __init__(self):
+        self.urls_visited = 0
+        self.urls_queued = 0
+        self.errors = 0
+        self.start_time = datetime.now()
+
+    def get_duration(self):
+        return (datetime.now() - self.start_time).total_seconds()
+
+    def to_dict(self):
+        return {
+            "urls_visited": self.urls_visited,
+            "urls_queued": self.urls_queued,
+            "errors": self.errors,
+            "duration": self.get_duration()
+        }
+
+
+class CrawlerEngine:
+
+    def __init__(self, queue_manager, config=None):
+        self.queue_manager = queue_manager
+        self.config = config or CrawlConfig()
+
+        self.session_manager = SessionManager()
+        self.url_filter = URLFilter()
+
+        self._visited = set()
+        self._queue = asyncio.Queue()
+        self._stats = CrawlStats()
+        self._running = False
+
+    async def start(self, start_url):
+        """크롤링 시작"""
+        logger.info("========== 크롤링 시작 ==========")
+        logger.info("대상: %s", start_url)
+
+        self._visited.clear()
+        self._stats = CrawlStats()
+        self._running = True
+
+        # 도메인 제한
+        domain = urlparse(start_url).netloc
+        self.url_filter.add_allowed_domain(domain)
+
+        # 시작 URL 추가
+        await self._queue.put((start_url, 0))
+        self._stats.urls_queued = 1
+
+        # 세션 생성
+        await self.session_manager.create_session()
+
+        try:
+            # 워커 생성
+            workers = []
+            for _ in range(self.config.workers):
+                task = asyncio.create_task(self._worker())
+                workers.append(task)
+
+            # 모든 워커 완료 대기
+            await asyncio.gather(*workers)
+
+        finally:
+            await self.session_manager.close()
+            self._running = False
+
+        logger.info("========== 크롤링 종료 ==========")
+        logger.info("방문: %d, 에러: %d, 시간: %.2f초",
+                   self._stats.urls_visited,
+                   self._stats.errors,
+                   self._stats.get_duration())
+
+        return self._stats
+
+    async def _worker(self):
+        """크롤링 워커"""
+        while self._running:
+            try:
+                # 타임아웃으로 URL 가져오기
+                url, depth = await asyncio.wait_for(
+                    self._queue.get(),
+                    timeout=3.0
+                )
+            except asyncio.TimeoutError:
+                # 큐가 비면 종료
+                break
+
+            # 최대 URL 수 체크
+            if self._stats.urls_visited >= self.config.max_urls:
+                break
+
+            # URL 처리
+            await self._process(url, depth)
+
+            # 딜레이
+            await asyncio.sleep(self.config.delay)
+
+    async def _process(self, url, depth):
+        """단일 URL 처리"""
+        # 정규화
+        url = self.url_filter.normalize_url(url)
+
+        # 중복 체크
+        if url in self._visited:
+            return
+
+        # 필터 체크
+        if not self.url_filter.should_crawl(url):
+            return
+
+        # 방문 기록
+        self._visited.add(url)
+        self._stats.urls_visited += 1
+
+        logger.info("[%d] %s (depth=%d)", self._stats.urls_visited, url, depth)
+
+        try:
+            # HTTP 요청
+            response = await self.session_manager.get(url, timeout=self.config.timeout)
+
+            if response is None:
+                self._stats.errors += 1
+                return
+
+            html = response.get("text", "")
+            final_url = response.get("url", url)
+
+            # Parser로 넘김 (PageData)
+            page = PageData(
+                url=final_url,
+                html=html,
+                depth=depth
+            )
+            self.queue_manager.add_page(page)
+
+            # 링크 추출 및 큐 추가
+            if depth < self.config.max_depth:
+                links = self._extract_links(html, final_url)
+                for link in links:
+                    if link not in self._visited:
+                        await self._queue.put((link, depth + 1))
+                        self._stats.urls_queued += 1
+
+        except Exception as e:
+            logger.error("처리 실패 (%s): %s", url, e)
+            self._stats.errors += 1
+
+    def _extract_links(self, html, base_url):
+        """간단한 링크 추출"""
+        links = []
+
+        try:
+            soup = BeautifulSoup(html, "html.parser")
+
+            for a in soup.find_all("a", href=True):
+                href = a["href"]
+
+                # 빈 링크, 앵커, JS 제외
+                if not href or href.startswith(("#", "javascript:", "mailto:")):
+                    continue
+
+                # 절대 URL로 변환
+                full_url = urljoin(base_url, href)
+
+                # 필터 통과 시 추가
+                if self.url_filter.should_crawl(full_url):
+                    links.append(full_url)
+
+        except Exception as e:
+            logger.warning("링크 추출 실패: %s", e)
+
+        return links
+
+    def stop(self):
+        """크롤링 중지"""
+        self._running = False
+        logger.info("크롤링 중지 요청")
+
+    def get_stats(self):
+        """통계 반환"""
+        return self._stats.to_dict()

--- a/crawler/init.py
+++ b/crawler/init.py
@@ -1,0 +1,17 @@
+"""
+Crawler 모듈
+웹사이트 탐색 및 공격 표면 수집
+"""
+
+from .engine import CrawlerEngine, CrawlConfig, CrawlStats
+from .session_manager import SessionManager, AuthConfig
+from .url_filter import URLFilter
+
+__all__ = [
+    'CrawlerEngine',
+    'CrawlConfig',
+    'CrawlStats',
+    'SessionManager',
+    'AuthConfig',
+    'URLFilter'
+]

--- a/crawler/session_manager.py
+++ b/crawler/session_manager.py
@@ -1,0 +1,503 @@
+"""
+세션 관리자
+HTTP 세션, 쿠키, 인증 상태를 관리
+
+담당: 팀 A - 인원 1 (크롤러 엔진 & 네트워크 담당)
+"""
+
+import aiohttp
+import asyncio
+import ssl
+import base64
+import re
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class AuthConfig:
+    """인증 설정"""
+
+    def __init__(
+        self,
+        auth_type="none",
+        username=None,
+        password=None,
+        token=None,
+        login_url=None,
+        login_data=None,
+        csrf_field=None,
+        success_indicator=None
+    ):
+        """
+        인증 설정 초기화
+
+        Args:
+            auth_type: 인증 방식 (none, basic, bearer, cookie, form)
+            username: 사용자명
+            password: 비밀번호
+            token: Bearer 토큰
+            login_url: 로그인 URL
+            login_data: 로그인 폼 데이터
+            csrf_field: CSRF 필드명
+            success_indicator: 로그인 성공 확인용 문자열
+        """
+        self.auth_type = auth_type
+        self.username = username
+        self.password = password
+        self.token = token
+        self.login_url = login_url
+        self.csrf_field = csrf_field
+        self.success_indicator = success_indicator
+
+        if login_data is None:
+            self.login_data = {}
+        else:
+            self.login_data = login_data
+
+
+class SessionManager:
+    """
+    HTTP 세션 관리자
+
+    주요 기능:
+    - 세션 쿠키 유지 (로그인 상태 유지)
+    - 다양한 인증 방식 지원 (Basic, Bearer, Form)
+    - 요청 재시도 로직
+    - SSL 설정
+    - 프록시 지원
+    """
+
+    # 기본 User-Agent
+    DEFAULT_USER_AGENT = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+
+    def __init__(
+        self,
+        auth_config=None,
+        proxy=None,
+        verify_ssl=False,
+        user_agent=None
+    ):
+        """
+        세션 관리자 초기화
+
+        Args:
+            auth_config: 인증 설정 (AuthConfig 객체)
+            proxy: 프록시 서버 URL (예: http://127.0.0.1:8080)
+            verify_ssl: SSL 인증서 검증 여부
+            user_agent: 커스텀 User-Agent
+        """
+        if auth_config is None:
+            self.auth_config = AuthConfig()
+        else:
+            self.auth_config = auth_config
+
+        self.proxy = proxy
+        self.verify_ssl = verify_ssl
+
+        # 세션 객체
+        self._session = None
+
+        # 쿠키 저장소
+        self._cookies = {}
+
+        # 기본 헤더
+        if user_agent is None:
+            ua = self.DEFAULT_USER_AGENT
+        else:
+            ua = user_agent
+
+        self._headers = {
+            "User-Agent": ua,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+            "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1"
+        }
+
+        # 인증 상태
+        self._is_authenticated = False
+
+        logger.debug("세션 관리자 초기화 완료")
+
+    async def create_session(self):
+        """
+        새 HTTP 세션 생성
+
+        Returns:
+            aiohttp.ClientSession 인스턴스
+        """
+        # 기존 세션이 있고 열려있으면 반환
+        if self._session is not None and not self._session.closed:
+            return self._session
+
+        # SSL 컨텍스트 설정
+        ssl_context = None
+        if not self.verify_ssl:
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
+        # 타임아웃 설정
+        timeout = aiohttp.ClientTimeout(
+            total=30,
+            connect=10,
+            sock_read=10
+        )
+
+        # TCP 커넥터 설정
+        connector = aiohttp.TCPConnector(
+            ssl=ssl_context,
+            limit=100,
+            limit_per_host=10,
+            ttl_dns_cache=300
+        )
+
+        # 쿠키 저장소
+        cookie_jar = aiohttp.CookieJar(unsafe=True)
+
+        # 세션 생성
+        self._session = aiohttp.ClientSession(
+            connector=connector,
+            timeout=timeout,
+            headers=self._headers,
+            cookie_jar=cookie_jar
+        )
+
+        logger.info("HTTP 세션 생성 완료")
+
+        # 인증 처리
+        if self.auth_config.auth_type != "none":
+            await self._authenticate()
+
+        return self._session
+
+    async def _authenticate(self):
+        """인증 수행"""
+        auth_type = self.auth_config.auth_type
+
+        try:
+            if auth_type == "basic":
+                self._basic_auth()
+            elif auth_type == "bearer":
+                self._bearer_auth()
+            elif auth_type == "form":
+                await self._form_login()
+            elif auth_type == "cookie":
+                self._cookie_auth()
+
+            self._is_authenticated = True
+            logger.info("인증 완료 (방식: %s)", auth_type)
+
+        except Exception as e:
+            logger.error("인증 실패: %s", e)
+            self._is_authenticated = False
+
+    def _basic_auth(self):
+        """HTTP Basic 인증"""
+        if self.auth_config.username and self.auth_config.password:
+            credentials = self.auth_config.username + ":" + self.auth_config.password
+            encoded = base64.b64encode(credentials.encode()).decode()
+            self._headers["Authorization"] = "Basic " + encoded
+
+    def _bearer_auth(self):
+        """Bearer 토큰 인증"""
+        if self.auth_config.token:
+            self._headers["Authorization"] = "Bearer " + self.auth_config.token
+
+    def _cookie_auth(self):
+        """쿠키 기반 인증 (미리 설정된 쿠키 사용)"""
+        # 외부에서 set_cookie()로 설정된 쿠키 사용
+        pass
+
+    async def _form_login(self):
+        """폼 기반 로그인"""
+        if not self.auth_config.login_url:
+            logger.warning("로그인 URL이 설정되지 않음")
+            return
+
+        login_data = self.auth_config.login_data.copy()
+
+        # CSRF 토큰 처리
+        if self.auth_config.csrf_field:
+            csrf_token = await self._extract_csrf_token(
+                self.auth_config.login_url,
+                self.auth_config.csrf_field
+            )
+            if csrf_token:
+                login_data[self.auth_config.csrf_field] = csrf_token
+                logger.debug("CSRF 토큰 추출 완료")
+
+        # 로그인 요청
+        try:
+            async with self._session.post(
+                self.auth_config.login_url,
+                data=login_data,
+                allow_redirects=True
+            ) as response:
+                response_text = await response.text()
+
+                # 로그인 성공 확인
+                if self.auth_config.success_indicator:
+                    if self.auth_config.success_indicator in response_text:
+                        logger.info("폼 로그인 성공")
+                    else:
+                        logger.warning("폼 로그인 실패 (성공 지시자 없음)")
+                elif response.status == 200:
+                    logger.info("폼 로그인 완료 (상태 코드: 200)")
+                else:
+                    logger.warning("폼 로그인 응답: %d", response.status)
+
+        except Exception as e:
+            logger.error("폼 로그인 오류: %s", e)
+
+    async def _extract_csrf_token(self, url, field_name):
+        """
+        페이지에서 CSRF 토큰 추출
+
+        Args:
+            url: 토큰이 있는 페이지 URL
+            field_name: CSRF 필드 이름
+
+        Returns:
+            CSRF 토큰 값 또는 None
+        """
+        try:
+            async with self._session.get(url) as response:
+                html = await response.text()
+
+                # input 태그에서 추출
+                patterns = [
+                    r'name=["\']?' + field_name + r'["\']?\s+value=["\']?([^"\'>\s]+)',
+                    r'value=["\']?([^"\'>\s]+)["\']?\s+name=["\']?' + field_name,
+                    r'name="' + field_name + r'"[^>]*value="([^"]+)"',
+                    r"name='" + field_name + r"'[^>]*value='([^']+)'",
+                ]
+
+                for pattern in patterns:
+                    match = re.search(pattern, html, re.IGNORECASE)
+                    if match:
+                        return match.group(1)
+
+                # meta 태그에서 추출
+                meta_pattern = r'<meta[^>]*name=["\']?' + field_name + r'["\']?[^>]*content=["\']?([^"\']+)'
+                match = re.search(meta_pattern, html, re.IGNORECASE)
+                if match:
+                    return match.group(1)
+
+        except Exception as e:
+            logger.warning("CSRF 토큰 추출 실패: %s", e)
+
+        return None
+
+    async def get(
+        self,
+        url,
+        timeout=10,
+        allow_redirects=True,
+        headers=None,
+        **kwargs
+    ):
+        """
+        GET 요청
+
+        Args:
+            url: 요청 URL
+            timeout: 타임아웃 (초)
+            allow_redirects: 리다이렉트 허용 여부
+            headers: 추가 헤더
+
+        Returns:
+            응답 딕셔너리 또는 None
+        """
+        return await self._request(
+            method="GET",
+            url=url,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            headers=headers,
+            **kwargs
+        )
+
+    async def post(
+        self,
+        url,
+        data=None,
+        json_data=None,
+        timeout=10,
+        allow_redirects=True,
+        headers=None,
+        **kwargs
+    ):
+        """
+        POST 요청
+
+        Args:
+            url: 요청 URL
+            data: Form 데이터
+            json_data: JSON 데이터
+            timeout: 타임아웃 (초)
+            allow_redirects: 리다이렉트 허용 여부
+            headers: 추가 헤더
+
+        Returns:
+            응답 딕셔너리 또는 None
+        """
+        return await self._request(
+            method="POST",
+            url=url,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            headers=headers,
+            data=data,
+            json=json_data,
+            **kwargs
+        )
+
+    async def _request(
+        self,
+        method,
+        url,
+        timeout=10,
+        allow_redirects=True,
+        max_retries=3,
+        headers=None,
+        **kwargs
+    ):
+        """
+        HTTP 요청 수행 (재시도 로직 포함)
+
+        Args:
+            method: HTTP 메서드
+            url: 요청 URL
+            timeout: 타임아웃 (초)
+            allow_redirects: 리다이렉트 허용
+            max_retries: 최대 재시도 횟수
+            headers: 추가 헤더
+
+        Returns:
+            응답 정보 딕셔너리 또는 None
+        """
+        if self._session is None:
+            await self.create_session()
+
+        # 타임아웃 설정
+        request_timeout = aiohttp.ClientTimeout(total=timeout)
+
+        # 헤더 병합
+        request_headers = self._headers.copy()
+        if headers is not None:
+            request_headers.update(headers)
+
+        # 재시도 로직
+        for attempt in range(max_retries):
+            try:
+                async with self._session.request(
+                    method=method,
+                    url=url,
+                    timeout=request_timeout,
+                    allow_redirects=allow_redirects,
+                    headers=request_headers,
+                    proxy=self.proxy,
+                    **kwargs
+                ) as response:
+                    # 응답 텍스트 읽기
+                    try:
+                        text = await response.text()
+                    except Exception:
+                        text = ""
+
+                    # 쿠키 저장
+                    for cookie in response.cookies.values():
+                        self._cookies[cookie.key] = cookie.value
+
+                    return {
+                        "status": response.status,
+                        "headers": dict(response.headers),
+                        "cookies": dict(response.cookies),
+                        "url": str(response.url),
+                        "text": text,
+                        "content_type": response.content_type,
+                        "method": method
+                    }
+
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "요청 타임아웃 (시도 %d/%d): %s",
+                    attempt + 1, max_retries, url
+                )
+            except aiohttp.ClientError as e:
+                logger.warning(
+                    "요청 실패 (시도 %d/%d): %s",
+                    attempt + 1, max_retries, e
+                )
+            except Exception as e:
+                logger.error("예상치 못한 오류: %s", e)
+                break
+
+            # 재시도 전 대기 (지수 백오프)
+            if attempt < max_retries - 1:
+                wait_time = (2 ** attempt) * 0.5
+                await asyncio.sleep(wait_time)
+
+        return None
+
+    def set_cookie(self, name, value):
+        """
+        쿠키 설정
+
+        Args:
+            name: 쿠키 이름
+            value: 쿠키 값
+        """
+        self._cookies[name] = value
+        if self._session is not None:
+            self._session.cookie_jar.update_cookies({name: value})
+        logger.debug("쿠키 설정: %s", name)
+
+    def set_cookies(self, cookies):
+        """
+        여러 쿠키 한번에 설정
+
+        Args:
+            cookies: 쿠키 딕셔너리
+        """
+        for name, value in cookies.items():
+            self.set_cookie(name, value)
+
+    def set_header(self, name, value):
+        """
+        헤더 설정
+
+        Args:
+            name: 헤더 이름
+            value: 헤더 값
+        """
+        self._headers[name] = value
+        logger.debug("헤더 설정: %s", name)
+
+    def get_cookies(self):
+        """현재 쿠키 반환"""
+        return self._cookies.copy()
+
+    def get_headers(self):
+        """현재 헤더 반환"""
+        return self._headers.copy()
+
+    @property
+    def is_authenticated(self):
+        """인증 상태"""
+        return self._is_authenticated
+
+    async def close(self):
+        """세션 종료"""
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
+            logger.info("HTTP 세션 종료")

--- a/crawler/url_filter.py
+++ b/crawler/url_filter.py
@@ -1,0 +1,277 @@
+"""
+URL 필터
+크롤링 대상 URL을 필터링하고 정규화
+
+담당: 팀 A - 인원 1 (크롤러 엔진 & 네트워크 담당)
+"""
+
+import re
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode, unquote
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class URLFilter:
+    """
+    URL 필터링 및 정규화
+
+    주요 기능:
+    - 허용된 도메인만 크롤링
+    - 파일 확장자 필터링 (이미지, CSS, JS 등 제외)
+    - URL 정규화 (중복 방지)
+    - 위험한 URL 패턴 제외 (logout, delete 등)
+    """
+
+    # 제외할 파일 확장자
+    EXCLUDED_EXTENSIONS = {
+        # 이미지
+        '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.svg', '.ico', '.webp',
+        # 스타일/스크립트
+        '.css', '.js', '.map',
+        # 폰트
+        '.woff', '.woff2', '.ttf', '.eot', '.otf',
+        # 문서
+        '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
+        # 압축
+        '.zip', '.rar', '.tar', '.gz', '.7z',
+        # 미디어
+        '.mp3', '.mp4', '.avi', '.mov', '.wmv', '.flv', '.webm',
+        # 실행 파일
+        '.exe', '.dll', '.so', '.dmg', '.apk'
+    }
+
+    # 기본 제외 패턴 (위험한 동작)
+    DEFAULT_EXCLUDED_PATTERNS = [
+        r'/logout',
+        r'/signout',
+        r'/sign-out',
+        r'/log-out',
+        r'/delete',
+        r'/remove',
+        r'/unsubscribe',
+        r'/deactivate',
+        r'\?.*logout',
+        r'\?.*delete',
+        r'\?.*remove',
+    ]
+
+    def __init__(
+            self,
+            allowed_domains=None,
+            excluded_patterns=None,
+            max_url_length=2048
+    ):
+        """
+        URL 필터 초기화
+
+        Args:
+            allowed_domains: 허용할 도메인 목록
+            excluded_patterns: 제외할 URL 패턴 (정규식)
+            max_url_length: 최대 URL 길이
+        """
+        if allowed_domains is None:
+            self.allowed_domains = set()
+        else:
+            self.allowed_domains = set(allowed_domains)
+
+        self.excluded_domains = set()
+        self.max_url_length = max_url_length
+        self.allowed_schemes = {'http', 'https'}
+
+        # 제외 패턴 컴파일
+        patterns = self.DEFAULT_EXCLUDED_PATTERNS.copy()
+        if excluded_patterns is not None:
+            patterns.extend(excluded_patterns)
+
+        self._excluded_regex = []
+        for pattern in patterns:
+            compiled = re.compile(pattern, re.IGNORECASE)
+            self._excluded_regex.append(compiled)
+
+        logger.debug("URL 필터 초기화: 허용 도메인=%s", self.allowed_domains)
+
+    def should_crawl(self, url):
+        """
+        URL을 크롤링해야 하는지 결정
+
+        Args:
+            url: 검사할 URL
+
+        Returns:
+            크롤링 여부 (True/False)
+        """
+        try:
+            parsed = urlparse(url)
+
+            # 1. 스킴 체크 (http, https만 허용)
+            if parsed.scheme not in self.allowed_schemes:
+                logger.debug("스킴 불허: %s", url)
+                return False
+
+            # 2. URL 길이 체크
+            if len(url) > self.max_url_length:
+                logger.debug("URL 너무 김: %s...", url[:50])
+                return False
+
+            # 3. 도메인 체크
+            if not self._is_domain_allowed(parsed.netloc):
+                logger.debug("도메인 불허: %s", parsed.netloc)
+                return False
+
+            # 4. 확장자 체크
+            if self._has_excluded_extension(parsed.path):
+                logger.debug("확장자 제외: %s", url)
+                return False
+
+            # 5. 제외 패턴 체크
+            if self._matches_excluded_pattern(url):
+                logger.debug("패턴 제외: %s", url)
+                return False
+
+            return True
+
+        except Exception as e:
+            logger.warning("URL 필터링 오류 (%s): %s", url, e)
+            return False
+
+    def _is_domain_allowed(self, domain):
+        """도메인 허용 여부 확인"""
+        # 제외 도메인 체크
+        if domain in self.excluded_domains:
+            return False
+
+        # 허용 도메인이 설정된 경우에만 체크
+        if self.allowed_domains:
+            # 정확히 일치하거나 서브도메인인 경우 허용
+            for allowed in self.allowed_domains:
+                if domain == allowed:
+                    return True
+                if domain.endswith('.' + allowed):
+                    return True
+            return False
+
+        # 허용 도메인이 설정되지 않으면 모두 허용
+        return True
+
+    def _has_excluded_extension(self, path):
+        """제외 확장자 여부 확인"""
+        path_lower = path.lower()
+        for ext in self.EXCLUDED_EXTENSIONS:
+            if path_lower.endswith(ext):
+                return True
+        return False
+
+    def _matches_excluded_pattern(self, url):
+        """제외 패턴 매칭 여부"""
+        for regex in self._excluded_regex:
+            if regex.search(url):
+                return True
+        return False
+
+    def normalize_url(self, url):
+        """
+        URL 정규화 (중복 방지용)
+
+        정규화 규칙:
+        - 스킴/호스트 소문자 변환
+        - 기본 포트 제거 (80, 443)
+        - 쿼리 파라미터 정렬
+        - 프래그먼트(#) 제거
+        - 중복 슬래시 제거
+
+        Args:
+            url: 원본 URL
+
+        Returns:
+            정규화된 URL
+        """
+        try:
+            parsed = urlparse(url)
+
+            # 스킴 소문자
+            scheme = parsed.scheme.lower()
+
+            # 호스트 소문자 + 기본 포트 제거
+            netloc = parsed.netloc.lower()
+            if ':80' in netloc and scheme == 'http':
+                netloc = netloc.replace(':80', '')
+            elif ':443' in netloc and scheme == 'https':
+                netloc = netloc.replace(':443', '')
+
+            # 경로 정규화
+            path = parsed.path
+            if not path:
+                path = '/'
+            path = re.sub(r'/+', '/', path)  # 중복 슬래시 제거
+            path = unquote(path)  # URL 디코딩
+
+            # 쿼리 파라미터 정렬
+            query = ''
+            if parsed.query:
+                params = parse_qs(parsed.query, keep_blank_values=True)
+                sorted_params = sorted(params.items())
+                query_list = []
+                for k, v in sorted_params:
+                    if len(v) == 1:
+                        query_list.append((k, v[0]))
+                    else:
+                        query_list.append((k, v))
+                query = urlencode(query_list, doseq=True)
+
+            # 프래그먼트 제거하고 재조합
+            normalized = urlunparse((scheme, netloc, path, '', query, ''))
+
+            return normalized
+
+        except Exception as e:
+            logger.warning("URL 정규화 실패 (%s): %s", url, e)
+            return url
+
+    def add_allowed_domain(self, domain):
+        """
+        허용 도메인 추가
+
+        Args:
+            domain: 추가할 도메인
+        """
+        domain = domain.lower().strip()
+        self.allowed_domains.add(domain)
+        logger.info("허용 도메인 추가: %s", domain)
+
+    def add_excluded_domain(self, domain):
+        """
+        제외 도메인 추가
+
+        Args:
+            domain: 제외할 도메인
+        """
+        domain = domain.lower().strip()
+        self.excluded_domains.add(domain)
+        logger.info("제외 도메인 추가: %s", domain)
+
+    def add_excluded_pattern(self, pattern):
+        """
+        제외 패턴 추가
+
+        Args:
+            pattern: 제외할 정규식 패턴
+        """
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+            self._excluded_regex.append(compiled)
+            logger.info("제외 패턴 추가: %s", pattern)
+        except re.error as e:
+            logger.error("잘못된 정규식 패턴 (%s): %s", pattern, e)
+
+    def extract_domain(self, url):
+        """URL에서 도메인 추출"""
+        try:
+            return urlparse(url).netloc.lower()
+        except Exception:
+            return ""
+
+    def is_same_domain(self, url1, url2):
+        """두 URL이 같은 도메인인지 확인"""
+        return self.extract_domain(url1) == self.extract_domain(url2)


### PR DESCRIPTION
PR 목적 (What)
웹사이트를 자동으로 탐색하고 페이지를 수집하는 크롤러 모듈(CrawlerEngine, SessionManager, URLFilter)을 구현
시작 URL부터 링크를 따라가며 BFS 방식으로 탐색하고, 수집한 페이지를 파서에게 전달할 수 있도록 QueueManager와 연동
주요 변경 사항 (How)
crawler/engine.py 구현

BFS 탐색 로직: asyncio.Queue를 활용하여 시작 URL부터 링크를 너비 우선으로 탐색. max_depth 설정으로 탐색 깊이 제한 가능.
중복 방문 방지: set 자료구조(_visited)를 사용하여 이미 방문한 URL 재방문 차단.
동시 처리: workers 설정으로 여러 URL을 동시에 처리하여 크롤링 속도 향상.
딜레이 처리: delay 설정으로 요청 간격 조절하여 서버 부하 방지.
QueueManager 연동: 수집한 페이지를 PageData 객체로 변환하여 queue_manager.add_page()로 전달.
crawler/session_manager.py 구현

세션/쿠키 유지: aiohttp.ClientSession을 사용하여 로그인 상태 유지.
다양한 인증 지원: Basic, Bearer, Form 로그인 방식 지원. CSRF 토큰 자동 추출 기능 포함.
재시도 로직: 요청 실패 시 지수 백오프(0.5초, 1초, 2초)로 최대 3회 재시도.
SSL 설정: verify_ssl 옵션으로 인증서 검증 비활성화 가능 (테스트 환경용).
crawler/url_filter.py 구현

URL 필터링: 이미지(.jpg, .png), 스크립트(.js, .css), 위험한 동작(/logout, /delete) 등 크롤링 불필요한 URL 자동 제외.
도메인 제한: add_allowed_domain()으로 특정 도메인만 크롤링하도록 제한.
URL 정규화: 대소문자 통일, 기본 포트 제거, 쿼리 파라미터 정렬 등으로 중복 URL 방지.
crawler/__init__.py 패키지화

다른 모듈에서 from crawler import CrawlerEngine, CrawlConfig 형태로 깔끔하게 호출할 수 있도록 패키지 구조 정리.

리뷰어 참고 사항
@팀A 인원2 (이시은 님): 크롤러가 수집한 페이지는 PageData(url, html, depth) 형태로 QueueManager에 저장됩니다. 파서 구현 시 queue_manager.get_page()로 가져와서 HTML 분석하시면 됩니다.