### PR TITLE
[refactor] 수동 로직 제거 및 IPv4/IPv6 TypeError 방어 로직 최적화

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class HttpMethod(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+    OPTIONS = "OPTIONS"
+
+
+class ParamLocation(str, Enum):
+    QUERY = "query"
+    BODY_FORM = "body_form"
+    BODY_JSON = "body_json"
+    HEADER = "header"
+    COOKIE = "cookie"
+
+
+@dataclass(slots=True)
+class AttackSurface:
+    """
+    Shared DTO between crawler/parser and fuzzer engine.
+    """
+
+    url: str
+    method: HttpMethod = HttpMethod.GET
+    param_location: ParamLocation = ParamLocation.QUERY
+    parameters: dict[str, Any] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
+    cookies: dict[str, str] = field(default_factory=dict)
+    source_url: str | None = None
+    description: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class Payload:
+    """
+    Structured payload metadata used by payload provider/reporter.
+    """
+
+    value: str
+    attack_type: str
+    risk_level: str
+
+
+@dataclass(slots=True, frozen=True)
+class FuzzingTask:
+    """
+    One concrete fuzzing unit generated from a surface.
+    """
+
+    surface: AttackSurface
+    target_param: str
+    payload: Payload

--- a/core/models.py
+++ b/core/models.py
@@ -1,8 +1,11 @@
+# core/models.py
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import Any
+import hashlib
 
 
 class HttpMethod(str, Enum):
@@ -12,6 +15,7 @@ class HttpMethod(str, Enum):
     PATCH = "PATCH"
     DELETE = "DELETE"
     OPTIONS = "OPTIONS"
+    HEAD = "HEAD"
 
 
 class ParamLocation(str, Enum):
@@ -20,14 +24,26 @@ class ParamLocation(str, Enum):
     BODY_JSON = "body_json"
     HEADER = "header"
     COOKIE = "cookie"
+    PATH = "path"
 
+
+class CrawlStatus(str, Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+# ============================================================
+# Team B에서 사용하는 DTO (기존 유지)
+# ============================================================
 
 @dataclass(slots=True)
 class AttackSurface:
     """
     Shared DTO between crawler/parser and fuzzer engine.
     """
-
     url: str
     method: HttpMethod = HttpMethod.GET
     param_location: ParamLocation = ParamLocation.QUERY
@@ -36,6 +52,46 @@ class AttackSurface:
     cookies: dict[str, str] = field(default_factory=dict)
     source_url: str | None = None
     description: str | None = None
+    
+    # 추가 필드 (크롤러에서 사용)
+    depth: int = 0
+    content_type: str | None = None
+    
+    def get_id(self) -> str:
+        """고유 식별자 생성"""
+        params_str = str(sorted(self.parameters.keys()))
+        raw = f"{self.url}:{self.method.value}:{self.param_location.value}:{params_str}"
+        return hashlib.md5(raw.encode()).hexdigest()[:16]
+    
+    def to_dict(self) -> dict[str, Any]:
+        """직렬화"""
+        return {
+            'id': self.get_id(),
+            'url': self.url,
+            'method': self.method.value,
+            'param_location': self.param_location.value,
+            'parameters': self.parameters,
+            'headers': self.headers,
+            'cookies': self.cookies,
+            'source_url': self.source_url,
+            'description': self.description,
+            'depth': self.depth,
+        }
+    
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttackSurface:
+        """역직렬화"""
+        return cls(
+            url=data['url'],
+            method=HttpMethod(data.get('method', 'GET')),
+            param_location=ParamLocation(data.get('param_location', 'query')),
+            parameters=data.get('parameters', {}),
+            headers=data.get('headers', {}),
+            cookies=data.get('cookies', {}),
+            source_url=data.get('source_url'),
+            description=data.get('description'),
+            depth=data.get('depth', 0),
+        )
 
 
 @dataclass(slots=True, frozen=True)
@@ -43,7 +99,6 @@ class Payload:
     """
     Structured payload metadata used by payload provider/reporter.
     """
-
     value: str
     attack_type: str
     risk_level: str
@@ -54,7 +109,153 @@ class FuzzingTask:
     """
     One concrete fuzzing unit generated from a surface.
     """
-
     surface: AttackSurface
     target_param: str
     payload: Payload
+
+
+# ============================================================
+# Team A - Crawler 전용 DTO
+# ============================================================
+
+@dataclass(slots=True)
+class CrawlTask:
+    """크롤링 작업 단위"""
+    url: str
+    depth: int = 0
+    parent_url: str | None = None
+    retry_count: int = 0
+    priority: int = 0  # 높을수록 우선
+    created_at: datetime = field(default_factory=datetime.now)
+    
+    def __lt__(self, other: CrawlTask) -> bool:
+        """우선순위 큐 비교"""
+        return self.priority > other.priority
+    
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'url': self.url,
+            'depth': self.depth,
+            'parent_url': self.parent_url,
+            'retry_count': self.retry_count,
+            'priority': self.priority,
+        }
+    
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CrawlTask:
+        return cls(
+            url=data['url'],
+            depth=data.get('depth', 0),
+            parent_url=data.get('parent_url'),
+            retry_count=data.get('retry_count', 0),
+            priority=data.get('priority', 0),
+        )
+
+
+@dataclass(slots=True)
+class CrawlResult:
+    """크롤러 → 파서 전달 데이터"""
+    url: str
+    final_url: str
+    status_code: int
+    headers: dict[str, str]
+    body: str
+    content_type: str
+    response_time: float
+    depth: int
+    parent_url: str | None = None
+    timestamp: datetime = field(default_factory=datetime.now)
+    cookies: dict[str, str] = field(default_factory=dict)
+    content_length: int = 0
+    is_dynamic: bool = False
+    redirect_chain: list[str] = field(default_factory=list)
+    
+    def get_hash(self) -> str:
+        """컨텐츠 해시"""
+        return hashlib.md5(self.body.encode()).hexdigest()
+    
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'url': self.url,
+            'final_url': self.final_url,
+            'status_code': self.status_code,
+            'content_type': self.content_type,
+            'response_time': self.response_time,
+            'depth': self.depth,
+            'parent_url': self.parent_url,
+            'timestamp': self.timestamp.isoformat(),
+            'content_length': self.content_length,
+            'is_dynamic': self.is_dynamic,
+            'body_hash': self.get_hash(),
+        }
+
+
+@dataclass
+class CrawlStats:
+    """크롤링 통계"""
+    total_requests: int = 0
+    successful_requests: int = 0
+    failed_requests: int = 0
+    skipped_requests: int = 0
+    
+    total_forms_found: int = 0
+    total_links_found: int = 0
+    total_apis_found: int = 0
+    total_attack_surfaces: int = 0
+    
+    bytes_downloaded: int = 0
+    
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    
+    errors_by_type: dict[str, int] = field(default_factory=dict)
+    status_codes: dict[int, int] = field(default_factory=dict)
+    
+    @property
+    def duration(self) -> float:
+        if self.start_time and self.end_time:
+            return (self.end_time - self.start_time).total_seconds()
+        elif self.start_time:
+            return (datetime.now() - self.start_time).total_seconds()
+        return 0.0
+    
+    @property
+    def requests_per_second(self) -> float:
+        return self.total_requests / self.duration if self.duration > 0 else 0.0
+    
+    @property
+    def success_rate(self) -> float:
+        return (self.successful_requests / self.total_requests * 100) if self.total_requests > 0 else 0.0
+    
+    def record_error(self, error_type: str) -> None:
+        self.errors_by_type[error_type] = self.errors_by_type.get(error_type, 0) + 1
+    
+    def record_status(self, status_code: int) -> None:
+        self.status_codes[status_code] = self.status_codes.get(status_code, 0) + 1
+    
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'total_requests': self.total_requests,
+            'successful_requests': self.successful_requests,
+            'failed_requests': self.failed_requests,
+            'skipped_requests': self.skipped_requests,
+            'success_rate': f"{self.success_rate:.2f}%",
+            'duration': f"{self.duration:.2f}s",
+            'requests_per_second': f"{self.requests_per_second:.2f}",
+            'bytes_downloaded': self.bytes_downloaded,
+            'forms_found': self.total_forms_found,
+            'links_found': self.total_links_found,
+            'attack_surfaces': self.total_attack_surfaces,
+            'errors_by_type': self.errors_by_type,
+            'status_codes': self.status_codes,
+        }
+    # core/models.py 맨 아래에 추가
+
+# ============================================================
+# 팀 A → 팀 B 전달용 콜백 타입
+# ============================================================
+
+from typing import Callable, Awaitable
+
+# AttackSurface를 받는 콜백 타입
+SurfaceCallback = Callable[[AttackSurface], Awaitable[None] | None]

--- a/parser/html_parser.py
+++ b/parser/html_parser.py
@@ -19,7 +19,6 @@ from urllib.parse import urlparse
 import aiohttp
 from bs4 import BeautifulSoup, FeatureNotFound
 
-# 로깅 설정: 호출자가 로그 설정을 제어할 수 있도록 NullHandler 사용
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -32,18 +31,23 @@ ALLOWED_CONTENT_TYPES: frozenset[str] = frozenset({
     "text/xml",
     "application/xml",
 })
-# SSRF 방지를 위해 접속을 차단할 내부 네트워크 대역
-BLOCKED_NETWORKS: tuple = (
+
+# SSRF 방지용 차단 네트워크 (IPv4/IPv6 분리로 TypeError 방지)
+BLOCKED_NETWORKS_V4: tuple = (
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("224.0.0.0/4"),
+)
+
+BLOCKED_NETWORKS_V6: tuple = (
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
 )
+
 DEFAULT_HEADERS: MappingProxyType = MappingProxyType({
     "User-Agent": "AsyncScanner-Bot/1.0",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -74,9 +78,9 @@ class AsyncHTMLParser:
     """SSRF 방어 기능을 갖춘 비동기 HTML 파서 코어 엔진"""
 
     def __init__(
-            self,
-            timeout: int = DEFAULT_TIMEOUT,
-            headers: Optional[dict] = None
+        self,
+        timeout: int = DEFAULT_TIMEOUT,
+        headers: Optional[dict] = None
     ):
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.headers = dict(DEFAULT_HEADERS) if headers is None else dict(headers)
@@ -104,7 +108,7 @@ class AsyncHTMLParser:
     async def _is_safe_url(url: str) -> bool:
         """
         URL 안전성 검증: 스킴 확인 + DNS 해석 + 내부 IP 대역 차단
-
+        
         주의: 이 검증은 1차 방어 수준이며, 완전한 DNS Rebinding 방어를 위해서는
         DNS 조회 후 연결 IP를 고정하고 재조회를 차단하는 추가 조치가 필요함
         """
@@ -125,10 +129,16 @@ class AsyncHTMLParser:
                 timeout=DNS_TIMEOUT,
             )
 
-            # 해석된 모든 IP가 차단 대역에 속하는지 검사
             for _, _, _, _, sockaddr in addrinfo:
                 ip = ipaddress.ip_address(sockaddr[0])
-                if any(ip in network for network in BLOCKED_NETWORKS):
+                
+                # IPv4/IPv6에 맞는 네트워크 목록 선택 (TypeError 방지)
+                if ip.version == 4:
+                    blocked_networks = BLOCKED_NETWORKS_V4
+                else:
+                    blocked_networks = BLOCKED_NETWORKS_V6
+                
+                if any(ip in network for network in blocked_networks):
                     return False
 
             return True
@@ -165,18 +175,16 @@ class AsyncHTMLParser:
 
     async def _read_content(self, response: aiohttp.ClientResponse) -> bytes:
         """스트리밍 방식으로 응답을 읽어 메모리 과부하(OOM) 방지"""
-        # Content-Length 헤더를 통한 사전 검사 (버그 수정됨)
         content_length_header = response.headers.get("Content-Length")
         if content_length_header:
             try:
                 content_length = int(content_length_header)
             except (ValueError, TypeError):
                 content_length = None
-
+            
             if content_length is not None and content_length > MAX_CONTENT_LENGTH:
                 raise ValueError(f"컨텐츠 크기 제한 초과: {content_length} bytes")
 
-        # 청크 단위로 읽으며 실제 크기 실시간 감시
         buffer = bytearray()
         async for chunk in response.content.iter_chunked(CHUNK_SIZE):
             buffer.extend(chunk)
@@ -188,10 +196,10 @@ class AsyncHTMLParser:
     async def parse(self, url: str) -> ParseResult:
         """
         URL로부터 HTML을 가져와 파싱
-
-        요청사항 반영: aiohttp 내장 리다이렉트 사용 (allow_redirects=True)
+        
+        aiohttp 내장 리다이렉트 사용 (allow_redirects=True)
         보안: 초기 URL + 최종 URL 검증으로 SSRF 방어
-
+        
         주의: 중간 리다이렉트 경로는 검증하지 않음. 완전한 SSRF 방어가 필요하면
         allow_redirects=False로 수동 추적 방식을 사용해야 함.
         """
@@ -203,7 +211,6 @@ class AsyncHTMLParser:
             }
 
         try:
-            # 1. 초기 URL 안전성 검증
             if not await self._is_safe_url(url):
                 return {
                     "success": False,
@@ -211,15 +218,13 @@ class AsyncHTMLParser:
                     "base_url": url,
                 }
 
-            # 2. aiohttp 내장 리다이렉트 사용 (요청사항 반영)
             async with self.session.get(
-                    url,
-                    allow_redirects=True,
-                    max_redirects=MAX_REDIRECTS
+                url,
+                allow_redirects=True,
+                max_redirects=MAX_REDIRECTS
             ) as response:
                 final_url = str(response.url)
 
-                # 3. 최종 URL 안전성 검증 (리다이렉트 후)
                 if not await self._is_safe_url(final_url):
                     return {
                         "success": False,
@@ -227,7 +232,6 @@ class AsyncHTMLParser:
                         "base_url": final_url,
                     }
 
-                # 4. HTTP 오류 상태 확인
                 if response.status >= 400:
                     return {
                         "success": False,
@@ -236,7 +240,6 @@ class AsyncHTMLParser:
                         "status_code": response.status,
                     }
 
-                # 5. Content-Type 검증
                 content_type = response.headers.get("Content-Type", "")
                 if not self._is_valid_content_type(content_type):
                     return {
@@ -246,17 +249,14 @@ class AsyncHTMLParser:
                         "status_code": response.status,
                     }
 
-                # 6. 데이터 안전하게 읽기 (OOM 방어)
                 raw = await self._read_content(response)
 
-                # 7. 인코딩 처리
                 encoding = response.charset or "utf-8"
                 try:
                     html = raw.decode(encoding)
                 except (UnicodeDecodeError, LookupError):
                     html = raw.decode("utf-8", errors="replace")
 
-                # 8. HTML 파싱
                 soup = self._parse_html(html)
 
                 return {
@@ -295,14 +295,13 @@ class AsyncHTMLParser:
                 "base_url": url,
             }
 
+    @staticmethod
     def parse_html_string(
-            self,
-            html: str,
-            base_url: str = "",
-            max_length: int = MAX_CONTENT_LENGTH
+        html: str,
+        base_url: str = "",
+        max_length: int = MAX_CONTENT_LENGTH
     ) -> ParseResult:
         """HTML 문자열을 직접 파싱 (크기 검사 포함)"""
-        # None 또는 비문자열 입력 방어
         if not isinstance(html, str):
             return {
                 "success": False,
@@ -319,7 +318,7 @@ class AsyncHTMLParser:
                     "base_url": base_url,
                 }
 
-            soup = self._parse_html(html)
+            soup = AsyncHTMLParser._parse_html(html)
             return {
                 "success": True,
                 "soup": soup,

--- a/parser/html_parser.py
+++ b/parser/html_parser.py
@@ -1,0 +1,284 @@
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse
+import logging
+import urllib3
+from typing import Dict, List, Optional, Union
+
+# SSL 경고 무시 (verify=False 사용 시 출력 방지)
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# 로깅 설정
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class HTMLParser:
+    """웹 취약점 스캐너용 HTML 파서"""
+    
+    def __init__(self, timeout=10, verify_ssl=True):
+        """
+        HTMLParser 초기화
+        
+        Args:
+            timeout (int): HTTP 요청 타임아웃
+            verify_ssl (bool): SSL 인증서 검증 여부 (False로 설정하면 자체서명 인증서도 허용)
+        """
+        self.timeout = timeout
+        self.verify_ssl = verify_ssl
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Scanner-Bot-v1.0)',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
+            'Accept-Encoding': 'gzip, deflate',
+            'Connection': 'keep-alive'
+        }
+
+    def parse_from_url(self, url: str) -> Dict:
+        """
+        URL에서 HTML을 가져와 파싱
+        
+        Args:
+            url (str): 대상 URL
+            
+        Returns:
+            dict: 파싱 결과
+        """
+        try:
+            logger.info(f"URL 파싱 시작: {url}")
+            
+            # URL 형식 검증 및 정규화
+            if not url.startswith(('http://', 'https://')):
+                url = 'http://' + url
+            
+            # HTTP 요청
+            response = requests.get(
+                url, 
+                headers=self.headers, 
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+                allow_redirects=True
+            )
+            
+            # HTTP 상태 코드 검사
+            response.raise_for_status()  # 4xx, 5xx 에러 시 예외 발생
+            
+            # 인코딩 자동 설정 (한글 깨짐 방지)
+            if response.encoding is None or response.encoding == 'ISO-8859-1':
+                response.encoding = response.apparent_encoding
+            
+            # HTML 파싱 (lxml이 없으면 html.parser로 fallback)
+            try:
+                soup = BeautifulSoup(response.text, 'lxml')
+            except Exception:
+                logger.warning("lxml 파서 사용 실패, html.parser로 fallback")
+                soup = BeautifulSoup(response.text, 'html.parser')
+            
+            logger.info(f"파싱 성공: {response.url} (상태코드: {response.status_code})")
+            
+            return {
+                'success': True,
+                'soup': soup,
+                'base_url': response.url,  # 리다이렉트된 최종 URL
+                'status_code': response.status_code,
+                'headers': dict(response.headers),  # 응답 헤더 정보
+                'content_type': response.headers.get('content-type', ''),
+                'error': None
+            }
+            
+        except requests.exceptions.Timeout:
+            error_msg = f"요청 타임아웃: {url}"
+            logger.error(error_msg)
+            return {'success': False, 'error': error_msg, 'base_url': url}
+            
+        except requests.exceptions.ConnectionError as e:
+            error_msg = f"연결 실패: {url} - {str(e)}"
+            logger.error(error_msg)
+            return {'success': False, 'error': error_msg, 'base_url': url}
+            
+        except requests.exceptions.HTTPError as e:
+            error_msg = f"HTTP 오류: {url} - {str(e)}"
+            logger.error(error_msg)
+            return {
+                'success': False, 
+                'error': error_msg, 
+                'base_url': url,
+                'status_code': e.response.status_code if e.response else None
+            }
+            
+        except Exception as e:
+            error_msg = f"예상치 못한 오류: {url} - {str(e)}"
+            logger.error(error_msg)
+            return {'success': False, 'error': error_msg, 'base_url': url}
+
+    def parse_html_string(self, html_string: str, base_url: Optional[str] = None) -> Dict:
+        """
+        HTML 문자열을 직접 파싱
+        
+        Args:
+            html_string (str): HTML 문자열
+            base_url (str, optional): 상대 URL 해석용 기준 URL
+            
+        Returns:
+            dict: 파싱 결과
+        """
+        try:
+            if not html_string or not html_string.strip():
+                return {
+                    'success': False,
+                    'error': '빈 HTML 문자열',
+                    'base_url': base_url
+                }
+            
+            # HTML 파싱
+            try:
+                soup = BeautifulSoup(html_string, 'lxml')
+            except Exception:
+                soup = BeautifulSoup(html_string, 'html.parser')
+            
+            logger.info("HTML 문자열 파싱 완료")
+            
+            return {
+                'success': True,
+                'soup': soup,
+                'base_url': base_url,
+                'error': None
+            }
+            
+        except Exception as e:
+            error_msg = f"HTML 파싱 오류: {str(e)}"
+            logger.error(error_msg)
+            return {
+                'success': False,
+                'error': error_msg,
+                'base_url': base_url
+            }
+
+    def extract_links(self, soup: BeautifulSoup, base_url: str, 
+                     same_domain_only: bool = True) -> List[str]:
+        """
+        취약점 스캔 대상 링크들을 수집
+        
+        Args:
+            soup (BeautifulSoup): 파싱된 HTML 객체
+            base_url (str): 기준 URL
+            same_domain_only (bool): 같은 도메인만 수집할지 여부
+            
+        Returns:
+            List[str]: 링크 목록
+        """
+        links = set()
+        base_domain = urlparse(base_url).netloc
+        
+        # <a> 태그의 href 속성
+        for a_tag in soup.find_all('a', href=True):
+            href = a_tag['href'].strip()
+            if not href or href.startswith(('#', 'javascript:', 'mailto:', 'tel:')):
+                continue
+            
+            full_url = urljoin(base_url, href)
+            
+            # 같은 도메인만 수집하는 옵션
+            if same_domain_only:
+                if urlparse(full_url).netloc == base_domain:
+                    links.add(full_url)
+            else:
+                links.add(full_url)
+        
+        # <form> 태그의 action 속성도 포함
+        for form_tag in soup.find_all('form', action=True):
+            action = form_tag['action'].strip()
+            if action:
+                full_url = urljoin(base_url, action)
+                if same_domain_only:
+                    if urlparse(full_url).netloc == base_domain:
+                        links.add(full_url)
+                else:
+                    links.add(full_url)
+        
+        logger.info(f"링크 추출 완료: {len(links)}개")
+        return sorted(list(links))
+
+    def extract_forms(self, soup: BeautifulSoup, base_url: str) -> List[Dict]:
+        """
+        폼 정보 추출 (취약점 스캔용)
+        
+        Args:
+            soup (BeautifulSoup): 파싱된 HTML 객체
+            base_url (str): 기준 URL
+            
+        Returns:
+            List[Dict]: 폼 정보 목록
+        """
+        forms = []
+        
+        for i, form_tag in enumerate(soup.find_all('form')):
+            form_data = {
+                'index': i,
+                'action': urljoin(base_url, form_tag.get('action', '')),
+                'method': form_tag.get('method', 'get').lower(),
+                'inputs': [],
+                'has_csrf_token': False
+            }
+            
+            # 입력 필드들 수집
+            for input_tag in form_tag.find_all(['input', 'textarea', 'select']):
+                input_data = {
+                    'name': input_tag.get('name', ''),
+                    'type': input_tag.get('type', 'text'),
+                    'value': input_tag.get('value', ''),
+                    'required': input_tag.has_attr('required')
+                }
+                form_data['inputs'].append(input_data)
+                
+                # CSRF 토큰 검사
+                if input_data['name'] and any(token in input_data['name'].lower() 
+                                            for token in ['csrf', 'token', '_token']):
+                    form_data['has_csrf_token'] = True
+            
+            forms.append(form_data)
+        
+        logger.info(f"폼 추출 완료: {len(forms)}개")
+        return forms
+
+# 편의 함수들
+def parse_url(url: str, timeout: int = 10, verify_ssl: bool = True) -> Dict:
+    """URL 파싱 편의 함수"""
+    parser = HTMLParser(timeout=timeout, verify_ssl=verify_ssl)
+    return parser.parse_from_url(url)
+
+def parse_html(html_string: str, base_url: Optional[str] = None) -> Dict:
+    """HTML 문자열 파싱 편의 함수"""
+    parser = HTMLParser()
+    return parser.parse_html_string(html_string, base_url)
+
+# 테스트 코드
+if __name__ == "__main__":
+    print("=== 웹 취약점 스캐너용 HTML Parser 테스트 ===")
+    
+    # 1. URL 파싱 테스트
+    print("\n1. URL 파싱 테스트:")
+    result = parse_url("https://httpbin.org/forms/post", verify_ssl=True)
+    
+    if result['success']:
+        print(f"✅ 파싱 성공!")
+        print(f"   최종 URL: {result['base_url']}")
+        print(f"   상태 코드: {result['status_code']}")
+        print(f"   Content-Type: {result['content_type']}")
+        
+        # 링크 추출 테스트
+        parser = HTMLParser()
+        links = parser.extract_links(result['soup'], result['base_url'])
+        print(f"   추출된 링크: {len(links)}개")
+        
+        # 폼 추출 테스트
+        forms = parser.extract_forms(result['soup'], result['base_url'])
+        print(f"   추출된 폼: {len(forms)}개")
+        if forms:
+            print(f"   첫 번째 폼: {forms[0]['method'].upper()} {forms[0]['action']}")
+    else:
+        print(f"❌ 파싱 실패: {result['error']}")
+    
+    # 2. SSL 비활성화 테스트
+    print("\n2. SSL 검증 비활성화 테스트:")
+    result = parse_url("https://self-signed.badssl.com", verify_ssl=False)
+    print(f"SSL 비활성화 결과: {'성공' if result['success'] else '실패'}")

--- a/parser/html_parser.py
+++ b/parser/html_parser.py
@@ -1,125 +1,495 @@
-import requests
-from bs4 import BeautifulSoup
-from urllib.parse import urljoin, urlparse
-import logging
-import urllib3
-from typing import Dict, List, Optional, Union
+"""
+Async HTML Parser Module for Web Vulnerability Scanner
+비동기 HTTP 요청을 통한 고성능 HTML 파싱 모듈
+"""
 
-# SSL 경고 무시 (verify=False 사용 시 출력 방지)
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+import asyncio
+import logging
+import ipaddress
+import socket
+from urllib.parse import urlparse, urljoin
+from bs4 import BeautifulSoup
+from typing import Optional, Dict, Set, Any, List
+import aiohttp
+import aiofiles
+from aiohttp import ClientTimeout, ClientSession, TCPConnector
+import ssl
+
+# 상수 정의
+class AsyncParserConstants:
+    # 파서 우선순위
+    PARSERS = ['lxml', 'html.parser', 'html5lib']
+    
+    # HTTP 설정
+    DEFAULT_TIMEOUT = 10
+    MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
+    CHUNK_SIZE = 8192
+    MAX_CONNECTIONS = 100
+    MAX_CONNECTIONS_PER_HOST = 30
+    
+    # 허용할 Content-Type
+    ALLOWED_CONTENT_TYPES = {
+        'text/html',
+        'application/xhtml+xml',
+        'text/xml',
+        'application/xml'
+    }
+    
+    # 차단할 내부 네트워크 대역
+    BLOCKED_NETWORKS = [
+        '127.0.0.0/8',      # localhost
+        '10.0.0.0/8',       # Private Class A
+        '172.16.0.0/12',    # Private Class B
+        '192.168.0.0/16',   # Private Class C
+        '169.254.0.0/16',   # Link-local
+        '224.0.0.0/4',      # Multicast
+        '::1/128',          # IPv6 localhost
+        'fc00::/7',         # IPv6 private
+        'fe80::/10',        # IPv6 link-local
+    ]
+    
+    # HTTP 헤더
+    DEFAULT_HEADERS = {
+        'User-Agent': 'Mozilla/5.0 (AsyncScanner-Bot-v1.0)',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
+        'Accept-Encoding': 'gzip, deflate',
+        'Cache-Control': 'no-cache'
+    }
 
 # 로깅 설정
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
-class HTMLParser:
-    """웹 취약점 스캐너용 HTML 파서"""
+class AsyncSSRFProtection:
+    """비동기 SSRF 공격 방지 클래스"""
     
-    def __init__(self, timeout=10, verify_ssl=True):
+    def __init__(self, allowed_schemes: Optional[Set[str]] = None):
+        self.allowed_schemes = allowed_schemes or {'http', 'https'}
+        self.blocked_networks = [ipaddress.ip_network(net) for net in AsyncParserConstants.BLOCKED_NETWORKS]
+        self._dns_cache = {}  # 성능을 위한 DNS 캐시
+        
+    async def is_safe_url(self, url: str) -> bool:
         """
-        HTMLParser 초기화
+        비동기로 URL 안전성 검증
+        
+        Args:
+            url (str): 검증할 URL
+            
+        Returns:
+            bool: 안전한 URL 여부
+        """
+        try:
+            # 1. URL 정규화
+            normalized_url = self._normalize_url_strict(url)
+            parsed = urlparse(normalized_url)
+            
+            # 2. 스킴 검증
+            if parsed.scheme not in self.allowed_schemes:
+                logger.warning(f"허용되지 않은 스킴: {parsed.scheme}")
+                return False
+            
+            # 3. 호스트명 검증
+            if not parsed.hostname:
+                logger.warning("호스트명이 없습니다")
+                return False
+            
+            # 4. DNS 해석 및 IP 검증 (비동기)
+            resolved_ips = await self._resolve_hostname_async(parsed.hostname)
+            for ip_str in resolved_ips:
+                try:
+                    ip = ipaddress.ip_address(ip_str)
+                    if self._is_blocked_ip(ip):
+                        logger.warning(f"차단된 IP로 해석됨: {parsed.hostname} -> {ip}")
+                        return False
+                except ValueError:
+                    logger.warning(f"잘못된 IP 주소: {ip_str}")
+                    return False
+            
+            # 5. 호스트명 패턴 검증
+            if not self._is_safe_hostname(parsed.hostname):
+                return False
+            
+            return True
+            
+        except Exception as e:
+            logger.error(f"URL 검증 오류: {str(e)}")
+            return False
+    
+    def _normalize_url_strict(self, url: str) -> str:
+        """엄격한 URL 정규화"""
+        if not url or not isinstance(url, str):
+            raise ValueError("잘못된 URL")
+        
+        # 공백 및 제어 문자 제거
+        url = url.strip()
+        url = ''.join(char for char in url if ord(char) >= 32)
+        
+        # 프로토콜 상대 URL 처리
+        if url.startswith('//'):
+            url = 'https:' + url
+        
+        # 스킴이 없으면 추가
+        parsed = urlparse(url)
+        if not parsed.scheme:
+            url = 'https://' + url
+        
+        return url
+    
+    async def _resolve_hostname_async(self, hostname: str) -> List[str]:
+        """비동기 DNS 해석"""
+        # 캐시 확인
+        if hostname in self._dns_cache:
+            logger.debug(f"DNS 캐시 사용: {hostname}")
+            return self._dns_cache[hostname]
+        
+        try:
+            # IPv4 주소인지 먼저 확인
+            ipaddress.ip_address(hostname)
+            self._dns_cache[hostname] = [hostname]
+            return [hostname]
+        except ValueError:
+            pass
+        
+        resolved_ips = []
+        
+        try:
+            # asyncio를 이용한 비동기 DNS 해석
+            loop = asyncio.get_event_loop()
+            
+            # IPv4 해석
+            try:
+                ipv4_result = await loop.getaddrinfo(
+                    hostname, None, 
+                    family=socket.AF_INET,
+                    type=socket.SOCK_STREAM
+                )
+                for result in ipv4_result:
+                    ip = result[4][0]
+                    if ip not in resolved_ips:
+                        resolved_ips.append(ip)
+            except socket.gaierror:
+                pass
+            
+            # IPv6 해석
+            try:
+                ipv6_result = await loop.getaddrinfo(
+                    hostname, None,
+                    family=socket.AF_INET6,
+                    type=socket.SOCK_STREAM
+                )
+                for result in ipv6_result:
+                    ip = result[4][0]
+                    if ip not in resolved_ips:
+                        resolved_ips.append(ip)
+            except socket.gaierror:
+                pass
+            
+            if not resolved_ips:
+                raise ValueError(f"DNS 해석 실패: {hostname}")
+            
+            # 캐시에 저장 (성공한 경우만)
+            self._dns_cache[hostname] = resolved_ips
+            logger.debug(f"비동기 DNS 해석 결과: {hostname} -> {resolved_ips}")
+            
+            return resolved_ips
+            
+        except Exception as e:
+            logger.error(f"비동기 DNS 해석 오류: {hostname} - {str(e)}")
+            raise
+    
+    def _is_blocked_ip(self, ip: ipaddress._BaseAddress) -> bool:
+        """IP가 차단된 네트워크 대역에 속하는지 확인"""
+        for network in self.blocked_networks:
+            if ip in network:
+                return True
+        return False
+    
+    def _is_safe_hostname(self, hostname: str) -> bool:
+        """호스트명이 안전한지 확인"""
+        dangerous_patterns = [
+            'localhost',
+            '0.0.0.0',
+            'metadata.google.internal',  # GCP 메타데이터
+            '169.254.169.254',          # AWS 메타데이터
+            'metadata.azure.com',        # Azure 메타데이터
+        ]
+        
+        hostname_lower = hostname.lower()
+        for pattern in dangerous_patterns:
+            if pattern in hostname_lower:
+                logger.warning(f"위험한 호스트명 패턴 감지: {hostname}")
+                return False
+        
+        return True
+
+class AsyncHTMLParser:
+    """비동기 HTML 파서"""
+    
+    def __init__(self, 
+                 timeout: int = AsyncParserConstants.DEFAULT_TIMEOUT,
+                 verify_ssl: bool = True,
+                 max_content_length: int = AsyncParserConstants.MAX_CONTENT_LENGTH,
+                 max_connections: int = AsyncParserConstants.MAX_CONNECTIONS):
+        """
+        AsyncHTMLParser 초기화
         
         Args:
             timeout (int): HTTP 요청 타임아웃
-            verify_ssl (bool): SSL 인증서 검증 여부 (False로 설정하면 자체서명 인증서도 허용)
+            verify_ssl (bool): SSL 인증서 검증 여부
+            max_content_length (int): 최대 콘텐츠 크기
+            max_connections (int): 최대 동시 연결 수
         """
         self.timeout = timeout
         self.verify_ssl = verify_ssl
-        self.headers = {
-            'User-Agent': 'Mozilla/5.0 (Scanner-Bot-v1.0)',
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
-            'Accept-Encoding': 'gzip, deflate',
-            'Connection': 'keep-alive'
-        }
-
-    def parse_from_url(self, url: str) -> Dict:
+        self.max_content_length = max_content_length
+        self.max_connections = max_connections
+        
+        self.ssrf_protection = AsyncSSRFProtection()
+        self.session = None
+        self._closed = False
+        
+    async def __aenter__(self):
+        """비동기 컨텍스트 매니저 진입"""
+        await self._ensure_session()
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """비동기 컨텍스트 매니저 종료"""
+        await self.close()
+    
+    async def _ensure_session(self):
+        """세션이 없으면 생성"""
+        if self.session is None or self.session.closed:
+            self.session = await self._create_session()
+    
+    async def _create_session(self) -> ClientSession:
+        """비동기 HTTP 세션 생성"""
+        # SSL 컨텍스트 설정
+        ssl_context = None
+        if not self.verify_ssl:
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+        
+        # 커넥터 설정
+        connector = TCPConnector(
+            limit=self.max_connections,
+            limit_per_host=AsyncParserConstants.MAX_CONNECTIONS_PER_HOST,
+            ssl=ssl_context,
+            enable_cleanup_closed=True
+        )
+        
+        # 타임아웃 설정
+        timeout = ClientTimeout(
+            total=self.timeout,
+            connect=self.timeout // 3,
+            sock_read=self.timeout // 2
+        )
+        
+        session = ClientSession(
+            headers=AsyncParserConstants.DEFAULT_HEADERS,
+            connector=connector,
+            timeout=timeout,
+            raise_for_status=False  # 수동으로 처리
+        )
+        
+        return session
+    
+    async def parse_from_url(self, url: str) -> Dict[str, Any]:
         """
-        URL에서 HTML을 가져와 파싱
+        비동기로 URL에서 HTML을 가져와 파싱
         
         Args:
             url (str): 대상 URL
             
         Returns:
-            dict: 파싱 결과
+            Dict[str, Any]: 파싱 결과
         """
         try:
-            logger.info(f"URL 파싱 시작: {url}")
+            logger.info(f"비동기 URL 파싱 시작: {url}")
             
-            # URL 형식 검증 및 정규화
-            if not url.startswith(('http://', 'https://')):
-                url = 'http://' + url
+            # 1. 세션 확인
+            await self._ensure_session()
             
-            # HTTP 요청
-            response = requests.get(
-                url, 
-                headers=self.headers, 
-                timeout=self.timeout,
-                verify=self.verify_ssl,
-                allow_redirects=True
-            )
+            # 2. 초기 URL 검증
+            if not await self.ssrf_protection.is_safe_url(url):
+                return {
+                    'success': False,
+                    'error': 'SSRF 보안 정책에 의해 차단된 URL',
+                    'base_url': url
+                }
             
-            # HTTP 상태 코드 검사
-            response.raise_for_status()  # 4xx, 5xx 에러 시 예외 발생
+            # 3. 비동기 HTTP 요청 (리다이렉트 수동 처리)
+            final_response = await self._follow_safe_redirects_async(url)
             
-            # 인코딩 자동 설정 (한글 깨짐 방지)
-            if response.encoding is None or response.encoding == 'ISO-8859-1':
-                response.encoding = response.apparent_encoding
+            # 4. 응답 검증
+            if not self._validate_response_headers(final_response):
+                return {
+                    'success': False,
+                    'error': '허용되지 않는 응답 형식',
+                    'base_url': str(final_response.url)
+                }
             
-            # HTML 파싱 (lxml이 없으면 html.parser로 fallback)
-            try:
-                soup = BeautifulSoup(response.text, 'lxml')
-            except Exception:
-                logger.warning("lxml 파서 사용 실패, html.parser로 fallback")
-                soup = BeautifulSoup(response.text, 'html.parser')
+            # 5. HTTP 상태 코드 검사
+            if final_response.status >= 400:
+                return {
+                    'success': False,
+                    'error': f'HTTP {final_response.status} 오류',
+                    'base_url': str(final_response.url),
+                    'status_code': final_response.status
+                }
             
-            logger.info(f"파싱 성공: {response.url} (상태코드: {response.status_code})")
+            # 6. 비동기 콘텐츠 읽기
+            content = await self._read_content_safely_async(final_response)
+            
+            # 7. 인코딩 감지 및 텍스트 변환
+            html_text = await self._decode_content_async(final_response, content)
+            
+            # 8. HTML 파싱
+            soup = self._parse_html_with_fallback(html_text)
+            
+            logger.info(f"비동기 파싱 성공: {final_response.url} (상태코드: {final_response.status})")
             
             return {
                 'success': True,
                 'soup': soup,
-                'base_url': response.url,  # 리다이렉트된 최종 URL
-                'status_code': response.status_code,
-                'headers': dict(response.headers),  # 응답 헤더 정보
-                'content_type': response.headers.get('content-type', ''),
+                'base_url': str(final_response.url),
+                'status_code': final_response.status,
+                'headers': dict(final_response.headers),
+                'content_type': final_response.headers.get('content-type', ''),
                 'error': None
             }
             
-        except requests.exceptions.Timeout:
-            error_msg = f"요청 타임아웃: {url}"
+        except asyncio.TimeoutError:
+            error_msg = f"비동기 요청 타임아웃: {url}"
             logger.error(error_msg)
             return {'success': False, 'error': error_msg, 'base_url': url}
             
-        except requests.exceptions.ConnectionError as e:
-            error_msg = f"연결 실패: {url} - {str(e)}"
+        except aiohttp.ClientError as e:
+            error_msg = f"비동기 HTTP 클라이언트 오류: {url} - {str(e)}"
             logger.error(error_msg)
             return {'success': False, 'error': error_msg, 'base_url': url}
-            
-        except requests.exceptions.HTTPError as e:
-            error_msg = f"HTTP 오류: {url} - {str(e)}"
-            logger.error(error_msg)
-            return {
-                'success': False, 
-                'error': error_msg, 
-                'base_url': url,
-                'status_code': e.response.status_code if e.response else None
-            }
             
         except Exception as e:
-            error_msg = f"예상치 못한 오류: {url} - {str(e)}"
+            error_msg = f"예상치 못한 비동기 오류: {url} - {str(e)}"
             logger.error(error_msg)
             return {'success': False, 'error': error_msg, 'base_url': url}
-
-    def parse_html_string(self, html_string: str, base_url: Optional[str] = None) -> Dict:
+    
+    async def _follow_safe_redirects_async(self, url: str, max_redirects: int = 10) -> aiohttp.ClientResponse:
+        """비동기 안전한 리다이렉트 추적"""
+        redirect_count = 0
+        current_url = url
+        visited_urls = set()  # 리다이렉트 루프 방지
+        
+        while redirect_count < max_redirects:
+            # 리다이렉트 루프 감지
+            if current_url in visited_urls:
+                raise Exception(f"리다이렉트 루프 감지: {current_url}")
+            
+            visited_urls.add(current_url)
+            
+            # 비동기 요청
+            response = await self.session.get(current_url, allow_redirects=False)
+            
+            # 리다이렉트가 아니면 종료
+            if not (300 <= response.status < 400):
+                return response
+            
+            # Location 헤더 확인
+            location = response.headers.get('Location')
+            if not location:
+                return response
+            
+            # 절대 URL로 변환
+            next_url = str(response.url.join(aiohttp.URL(location)))
+            
+            # 리다이렉트 대상 URL 안전성 검증
+            if not await self.ssrf_protection.is_safe_url(next_url):
+                raise Exception(f"리다이렉트 대상이 안전하지 않음: {next_url}")
+            
+            logger.debug(f"비동기 안전한 리다이렉트: {current_url} -> {next_url}")
+            
+            current_url = next_url
+            redirect_count += 1
+            response.close()  # 이전 응답 정리
+        
+        raise Exception("리다이렉트 횟수 초과")
+    
+    def _validate_response_headers(self, response: aiohttp.ClientResponse) -> bool:
+        """응답 헤더 검증"""
+        # Content-Length 검증
+        content_length = response.headers.get('content-length')
+        if content_length:
+            try:
+                length = int(content_length)
+                if length > self.max_content_length:
+                    logger.warning(f"콘텐츠 크기가 너무 큼: {length} bytes")
+                    return False
+            except ValueError:
+                pass
+        
+        # Content-Type 검증
+        content_type = response.headers.get('content-type', '').lower()
+        if not content_type:
+            logger.warning("Content-Type 헤더가 없음")
+            return False
+        
+        main_type = content_type.split(';')[0].strip()
+        if main_type not in AsyncParserConstants.ALLOWED_CONTENT_TYPES:
+            logger.warning(f"허용되지 않는 Content-Type: {content_type}")
+            return False
+        
+        return True
+    
+    async def _read_content_safely_async(self, response: aiohttp.ClientResponse) -> bytes:
+        """비동기로 안전하게 콘텐츠 읽기"""
+        chunks = []
+        total_size = 0
+        
+        async for chunk in response.content.iter_chunked(AsyncParserConstants.CHUNK_SIZE):
+            chunks.append(chunk)
+            total_size += len(chunk)
+            
+            if total_size > self.max_content_length:
+                raise Exception(f"콘텐츠 크기 한계 초과: {total_size} bytes")
+        
+        return b''.join(chunks)
+    
+    async def _decode_content_async(self, response: aiohttp.ClientResponse, content: bytes) -> str:
+        """비동기 인코딩 감지 및 디코딩"""
+        # 1. aiohttp 자동 감지 사용
+        try:
+            return await response.text()
+        except Exception:
+            pass
+        
+        # 2. 수동 디코딩
+        encoding = 'utf-8'
+        
+        # HTTP 헤더에서 인코딩 확인
+        content_type = response.headers.get('content-type', '')
+        if 'charset=' in content_type:
+            try:
+                encoding = content_type.split('charset=')[1].split(';')[0].strip()
+            except:
+                pass
+        
+        try:
+            return content.decode(encoding, errors='ignore')
+        except:
+            return content.decode('utf-8', errors='ignore')
+    
+    async def parse_html_string(self, html_string: str, base_url: Optional[str] = None) -> Dict[str, Any]:
         """
-        HTML 문자열을 직접 파싱
+        HTML 문자열을 직접 파싱 (비동기 버전)
         
         Args:
             html_string (str): HTML 문자열
             base_url (str, optional): 상대 URL 해석용 기준 URL
             
         Returns:
-            dict: 파싱 결과
+            Dict[str, Any]: 파싱 결과
         """
         try:
             if not html_string or not html_string.strip():
@@ -129,13 +499,23 @@ class HTMLParser:
                     'base_url': base_url
                 }
             
-            # HTML 파싱
-            try:
-                soup = BeautifulSoup(html_string, 'lxml')
-            except Exception:
-                soup = BeautifulSoup(html_string, 'html.parser')
+            # 크기 제한 검증
+            if len(html_string.encode('utf-8')) > self.max_content_length:
+                return {
+                    'success': False,
+                    'error': f'HTML 크기가 너무 큼: {len(html_string)} bytes',
+                    'base_url': base_url
+                }
             
-            logger.info("HTML 문자열 파싱 완료")
+            # HTML 파싱 (CPU 집약적이므로 executor에서 실행)
+            loop = asyncio.get_event_loop()
+            soup = await loop.run_in_executor(
+                None, 
+                self._parse_html_with_fallback, 
+                html_string
+            )
+            
+            logger.info("비동기 HTML 문자열 파싱 완료")
             
             return {
                 'success': True,
@@ -145,140 +525,154 @@ class HTMLParser:
             }
             
         except Exception as e:
-            error_msg = f"HTML 파싱 오류: {str(e)}"
+            error_msg = f"비동기 HTML 파싱 오류: {str(e)}"
             logger.error(error_msg)
             return {
                 'success': False,
                 'error': error_msg,
                 'base_url': base_url
             }
-
-    def extract_links(self, soup: BeautifulSoup, base_url: str, 
-                     same_domain_only: bool = True) -> List[str]:
+    
+    async def parse(self, html: str) -> BeautifulSoup:
         """
-        취약점 스캔 대상 링크들을 수집
+        프로젝트 요구사항에 맞는 비동기 파싱 함수
         
         Args:
-            soup (BeautifulSoup): 파싱된 HTML 객체
-            base_url (str): 기준 URL
-            same_domain_only (bool): 같은 도메인만 수집할지 여부
+            html (str): HTML 문자열
             
         Returns:
-            List[str]: 링크 목록
+            BeautifulSoup: 파싱된 객체
+            
+        Raises:
+            ValueError: 빈 HTML 입력 시
+            Exception: 파싱 실패 시
         """
-        links = set()
-        base_domain = urlparse(base_url).netloc
+        if not html or not html.strip():
+            raise ValueError("빈 HTML 입력")
         
-        # <a> 태그의 href 속성
-        for a_tag in soup.find_all('a', href=True):
-            href = a_tag['href'].strip()
-            if not href or href.startswith(('#', 'javascript:', 'mailto:', 'tel:')):
+        # CPU 집약적 작업을 executor에서 실행
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, 
+            self._parse_html_with_fallback, 
+            html
+        )
+    
+    def _parse_html_with_fallback(self, html_string: str) -> BeautifulSoup:
+        """여러 파서를 시도하여 HTML 파싱 (동기 버전)"""
+        for parser in AsyncParserConstants.PARSERS:
+            try:
+                soup = BeautifulSoup(html_string, parser)
+                logger.debug(f"파싱 성공 (파서: {parser})")
+                return soup
+            except Exception as e:
+                logger.debug(f"{parser} 파서 실패: {str(e)}")
                 continue
-            
-            full_url = urljoin(base_url, href)
-            
-            # 같은 도메인만 수집하는 옵션
-            if same_domain_only:
-                if urlparse(full_url).netloc == base_domain:
-                    links.add(full_url)
-            else:
-                links.add(full_url)
         
-        # <form> 태그의 action 속성도 포함
-        for form_tag in soup.find_all('form', action=True):
-            action = form_tag['action'].strip()
-            if action:
-                full_url = urljoin(base_url, action)
-                if same_domain_only:
-                    if urlparse(full_url).netloc == base_domain:
-                        links.add(full_url)
+        # 모든 파서 실패 시 기본 파서로 재시도
+        logger.warning("모든 파서 실패, html.parser로 강제 시도")
+        return BeautifulSoup(html_string, 'html.parser')
+    
+    async def close(self):
+        """비동기 세션 정리"""
+        if not self._closed and self.session and not self.session.closed:
+            await self.session.close()
+            self._closed = True
+    
+    def __del__(self):
+        """소멸자에서 세션 정리 시도"""
+        if not self._closed and self.session and not self.session.closed:
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    loop.create_task(self.close())
                 else:
-                    links.add(full_url)
-        
-        logger.info(f"링크 추출 완료: {len(links)}개")
-        return sorted(list(links))
+                    loop.run_until_complete(self.close())
+            except:
+                pass
 
-    def extract_forms(self, soup: BeautifulSoup, base_url: str) -> List[Dict]:
-        """
-        폼 정보 추출 (취약점 스캔용)
-        
-        Args:
-            soup (BeautifulSoup): 파싱된 HTML 객체
-            base_url (str): 기준 URL
-            
-        Returns:
-            List[Dict]: 폼 정보 목록
-        """
-        forms = []
-        
-        for i, form_tag in enumerate(soup.find_all('form')):
-            form_data = {
-                'index': i,
-                'action': urljoin(base_url, form_tag.get('action', '')),
-                'method': form_tag.get('method', 'get').lower(),
-                'inputs': [],
-                'has_csrf_token': False
-            }
-            
-            # 입력 필드들 수집
-            for input_tag in form_tag.find_all(['input', 'textarea', 'select']):
-                input_data = {
-                    'name': input_tag.get('name', ''),
-                    'type': input_tag.get('type', 'text'),
-                    'value': input_tag.get('value', ''),
-                    'required': input_tag.has_attr('required')
-                }
-                form_data['inputs'].append(input_data)
-                
-                # CSRF 토큰 검사
-                if input_data['name'] and any(token in input_data['name'].lower() 
-                                            for token in ['csrf', 'token', '_token']):
-                    form_data['has_csrf_token'] = True
-            
-            forms.append(form_data)
-        
-        logger.info(f"폼 추출 완료: {len(forms)}개")
-        return forms
+# 비동기 편의 함수들
+async def parse_url_async(url: str, 
+                         timeout: int = AsyncParserConstants.DEFAULT_TIMEOUT, 
+                         verify_ssl: bool = True) -> Dict[str, Any]:
+    """비동기 URL 파싱 편의 함수"""
+    async with AsyncHTMLParser(timeout=timeout, verify_ssl=verify_ssl) as parser:
+        return await parser.parse_from_url(url)
 
-# 편의 함수들
-def parse_url(url: str, timeout: int = 10, verify_ssl: bool = True) -> Dict:
-    """URL 파싱 편의 함수"""
-    parser = HTMLParser(timeout=timeout, verify_ssl=verify_ssl)
-    return parser.parse_from_url(url)
+async def parse_html_async(html_string: str, base_url: Optional[str] = None) -> Dict[str, Any]:
+    """비동기 HTML 문자열 파싱 편의 함수"""
+    async with AsyncHTMLParser() as parser:
+        return await parser.parse_html_string(html_string, base_url)
 
-def parse_html(html_string: str, base_url: Optional[str] = None) -> Dict:
-    """HTML 문자열 파싱 편의 함수"""
-    parser = HTMLParser()
-    return parser.parse_html_string(html_string, base_url)
+async def parse_async(html: str) -> BeautifulSoup:
+    """비동기 프로젝트 요구사항용 파싱 함수"""
+    async with AsyncHTMLParser() as parser:
+        return await parser.parse(html)
+
+# 다중 URL 동시 처리 함수
+async def parse_multiple_urls(urls: List[str], 
+                            max_concurrent: int = 10,
+                            timeout: int = AsyncParserConstants.DEFAULT_TIMEOUT) -> List[Dict[str, Any]]:
+    """
+    여러 URL을 동시에 비동기 처리
+    
+    Args:
+        urls (List[str]): URL 리스트
+        max_concurrent (int): 최대 동시 처리 수
+        timeout (int): 각 요청의 타임아웃
+        
+    Returns:
+        List[Dict[str, Any]]: 각 URL의 파싱 결과
+    """
+    semaphore = asyncio.Semaphore(max_concurrent)
+    
+    async def parse_single_url(url: str) -> Dict[str, Any]:
+        async with semaphore:
+            async with AsyncHTMLParser(timeout=timeout) as parser:
+                return await parser.parse_from_url(url)
+    
+    tasks = [parse_single_url(url) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    
+    # 예외 처리
+    processed_results = []
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            processed_results.append({
+                'success': False,
+                'error': f'비동기 처리 오류: {str(result)}',
+                'base_url': urls[i]
+            })
+        else:
+            processed_results.append(result)
+    
+    return processed_results
 
 # 테스트 코드
 if __name__ == "__main__":
-    print("=== 웹 취약점 스캐너용 HTML Parser 테스트 ===")
-    
-    # 1. URL 파싱 테스트
-    print("\n1. URL 파싱 테스트:")
-    result = parse_url("https://httpbin.org/forms/post", verify_ssl=True)
-    
-    if result['success']:
-        print(f"✅ 파싱 성공!")
-        print(f"   최종 URL: {result['base_url']}")
-        print(f"   상태 코드: {result['status_code']}")
-        print(f"   Content-Type: {result['content_type']}")
+    async def test_async_parser():
+        print("=== 비동기 HTML Parser 테스트 ===")
         
-        # 링크 추출 테스트
-        parser = HTMLParser()
-        links = parser.extract_links(result['soup'], result['base_url'])
-        print(f"   추출된 링크: {len(links)}개")
+        # 단일 URL 테스트
+        print("\n1. 단일 URL 비동기 파싱:")
+        result = await parse_url_async("https://httpbin.org/html")
+        print(f"결과: {'성공' if result['success'] else '실패'}")
+        if result['success']:
+            print(f"제목: {result['soup'].title.string if result['soup'].title else 'None'}")
         
-        # 폼 추출 테스트
-        forms = parser.extract_forms(result['soup'], result['base_url'])
-        print(f"   추출된 폼: {len(forms)}개")
-        if forms:
-            print(f"   첫 번째 폼: {forms[0]['method'].upper()} {forms[0]['action']}")
-    else:
-        print(f"❌ 파싱 실패: {result['error']}")
+        # 다중 URL 동시 처리 테스트
+        print("\n2. 다중 URL 동시 처리:")
+        test_urls = [
+            "https://httpbin.org/html",
+            "https://httpbin.org/json",  # 차단되어야 함
+            "https://example.com",
+        ]
+        
+        results = await parse_multiple_urls(test_urls, max_concurrent=3)
+        for i, result in enumerate(results):
+            print(f"URL {i+1}: {'성공' if result['success'] else '실패'}")
+            if not result['success']:
+                print(f"  오류: {result['error']}")
     
-    # 2. SSL 비활성화 테스트
-    print("\n2. SSL 검증 비활성화 테스트:")
-    result = parse_url("https://self-signed.badssl.com", verify_ssl=False)
-    print(f"SSL 비활성화 결과: {'성공' if result['success'] else '실패'}")
+    # 이벤트 루프 실행
+    asyncio.run(test_async_parser())

--- a/parser/html_parser.py
+++ b/parser/html_parser.py
@@ -1,678 +1,335 @@
 """
-Async HTML Parser Module for Web Vulnerability Scanner
-비동기 HTTP 요청을 통한 고성능 HTML 파싱 모듈
+html_parser.py
+비동기 HTML 파서 코어 엔진 (보안 강화 운영 버전)
+- 단일 책임 원칙을 준수하는 파서 엔진
+- SSRF 방어 로직 통합 (초기 + 최종 URL 검증)
+- 불변(Immutable) 설정 상수 관리
+- 불필요한 헬퍼/테스트 코드/소멸자 제거 완료
 """
 
+from __future__ import annotations
+
 import asyncio
-import logging
 import ipaddress
-import socket
-from urllib.parse import urlparse, urljoin
-from bs4 import BeautifulSoup
-from typing import Optional, Dict, Set, Any, List
+import logging
+from types import MappingProxyType
+from typing import Optional, TypedDict
+from urllib.parse import urlparse
+
 import aiohttp
-import aiofiles
-from aiohttp import ClientTimeout, ClientSession, TCPConnector
-import ssl
+from bs4 import BeautifulSoup, FeatureNotFound
 
-# 상수 정의
-class AsyncParserConstants:
-    # 파서 우선순위
-    PARSERS = ['lxml', 'html.parser', 'html5lib']
-    
-    # HTTP 설정
-    DEFAULT_TIMEOUT = 10
-    MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
-    CHUNK_SIZE = 8192
-    MAX_CONNECTIONS = 100
-    MAX_CONNECTIONS_PER_HOST = 30
-    
-    # 허용할 Content-Type
-    ALLOWED_CONTENT_TYPES = {
-        'text/html',
-        'application/xhtml+xml',
-        'text/xml',
-        'application/xml'
-    }
-    
-    # 차단할 내부 네트워크 대역
-    BLOCKED_NETWORKS = [
-        '127.0.0.0/8',      # localhost
-        '10.0.0.0/8',       # Private Class A
-        '172.16.0.0/12',    # Private Class B
-        '192.168.0.0/16',   # Private Class C
-        '169.254.0.0/16',   # Link-local
-        '224.0.0.0/4',      # Multicast
-        '::1/128',          # IPv6 localhost
-        'fc00::/7',         # IPv6 private
-        'fe80::/10',        # IPv6 link-local
-    ]
-    
-    # HTTP 헤더
-    DEFAULT_HEADERS = {
-        'User-Agent': 'Mozilla/5.0 (AsyncScanner-Bot-v1.0)',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'ko-KR,ko;q=0.9,en;q=0.8',
-        'Accept-Encoding': 'gzip, deflate',
-        'Cache-Control': 'no-cache'
-    }
-
-# 로깅 설정
-logging.basicConfig(level=logging.WARNING)
+# 로깅 설정: 호출자가 로그 설정을 제어할 수 있도록 NullHandler 사용
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
-class AsyncSSRFProtection:
-    """비동기 SSRF 공격 방지 클래스"""
-    
-    def __init__(self, allowed_schemes: Optional[Set[str]] = None):
-        self.allowed_schemes = allowed_schemes or {'http', 'https'}
-        self.blocked_networks = [ipaddress.ip_network(net) for net in AsyncParserConstants.BLOCKED_NETWORKS]
-        self._dns_cache = {}  # 성능을 위한 DNS 캐시
-        
-    async def is_safe_url(self, url: str) -> bool:
-        """
-        비동기로 URL 안전성 검증
-        
-        Args:
-            url (str): 검증할 URL
-            
-        Returns:
-            bool: 안전한 URL 여부
-        """
-        try:
-            # 1. URL 정규화
-            normalized_url = self._normalize_url_strict(url)
-            parsed = urlparse(normalized_url)
-            
-            # 2. 스킴 검증
-            if parsed.scheme not in self.allowed_schemes:
-                logger.warning(f"허용되지 않은 스킴: {parsed.scheme}")
-                return False
-            
-            # 3. 호스트명 검증
-            if not parsed.hostname:
-                logger.warning("호스트명이 없습니다")
-                return False
-            
-            # 4. DNS 해석 및 IP 검증 (비동기)
-            resolved_ips = await self._resolve_hostname_async(parsed.hostname)
-            for ip_str in resolved_ips:
-                try:
-                    ip = ipaddress.ip_address(ip_str)
-                    if self._is_blocked_ip(ip):
-                        logger.warning(f"차단된 IP로 해석됨: {parsed.hostname} -> {ip}")
-                        return False
-                except ValueError:
-                    logger.warning(f"잘못된 IP 주소: {ip_str}")
-                    return False
-            
-            # 5. 호스트명 패턴 검증
-            if not self._is_safe_hostname(parsed.hostname):
-                return False
-            
-            return True
-            
-        except Exception as e:
-            logger.error(f"URL 검증 오류: {str(e)}")
-            return False
-    
-    def _normalize_url_strict(self, url: str) -> str:
-        """엄격한 URL 정규화"""
-        if not url or not isinstance(url, str):
-            raise ValueError("잘못된 URL")
-        
-        # 공백 및 제어 문자 제거
-        url = url.strip()
-        url = ''.join(char for char in url if ord(char) >= 32)
-        
-        # 프로토콜 상대 URL 처리
-        if url.startswith('//'):
-            url = 'https:' + url
-        
-        # 스킴이 없으면 추가
-        parsed = urlparse(url)
-        if not parsed.scheme:
-            url = 'https://' + url
-        
-        return url
-    
-    async def _resolve_hostname_async(self, hostname: str) -> List[str]:
-        """비동기 DNS 해석"""
-        # 캐시 확인
-        if hostname in self._dns_cache:
-            logger.debug(f"DNS 캐시 사용: {hostname}")
-            return self._dns_cache[hostname]
-        
-        try:
-            # IPv4 주소인지 먼저 확인
-            ipaddress.ip_address(hostname)
-            self._dns_cache[hostname] = [hostname]
-            return [hostname]
-        except ValueError:
-            pass
-        
-        resolved_ips = []
-        
-        try:
-            # asyncio를 이용한 비동기 DNS 해석
-            loop = asyncio.get_event_loop()
-            
-            # IPv4 해석
-            try:
-                ipv4_result = await loop.getaddrinfo(
-                    hostname, None, 
-                    family=socket.AF_INET,
-                    type=socket.SOCK_STREAM
-                )
-                for result in ipv4_result:
-                    ip = result[4][0]
-                    if ip not in resolved_ips:
-                        resolved_ips.append(ip)
-            except socket.gaierror:
-                pass
-            
-            # IPv6 해석
-            try:
-                ipv6_result = await loop.getaddrinfo(
-                    hostname, None,
-                    family=socket.AF_INET6,
-                    type=socket.SOCK_STREAM
-                )
-                for result in ipv6_result:
-                    ip = result[4][0]
-                    if ip not in resolved_ips:
-                        resolved_ips.append(ip)
-            except socket.gaierror:
-                pass
-            
-            if not resolved_ips:
-                raise ValueError(f"DNS 해석 실패: {hostname}")
-            
-            # 캐시에 저장 (성공한 경우만)
-            self._dns_cache[hostname] = resolved_ips
-            logger.debug(f"비동기 DNS 해석 결과: {hostname} -> {resolved_ips}")
-            
-            return resolved_ips
-            
-        except Exception as e:
-            logger.error(f"비동기 DNS 해석 오류: {hostname} - {str(e)}")
-            raise
-    
-    def _is_blocked_ip(self, ip: ipaddress._BaseAddress) -> bool:
-        """IP가 차단된 네트워크 대역에 속하는지 확인"""
-        for network in self.blocked_networks:
-            if ip in network:
-                return True
-        return False
-    
-    def _is_safe_hostname(self, hostname: str) -> bool:
-        """호스트명이 안전한지 확인"""
-        dangerous_patterns = [
-            'localhost',
-            '0.0.0.0',
-            'metadata.google.internal',  # GCP 메타데이터
-            '169.254.169.254',          # AWS 메타데이터
-            'metadata.azure.com',        # Azure 메타데이터
-        ]
-        
-        hostname_lower = hostname.lower()
-        for pattern in dangerous_patterns:
-            if pattern in hostname_lower:
-                logger.warning(f"위험한 호스트명 패턴 감지: {hostname}")
-                return False
-        
-        return True
+# ===== 불변 설정 상수 (Immutable Constants) =====
+PARSERS: tuple[str, ...] = ("lxml", "html.parser", "html5lib")
+ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+ALLOWED_CONTENT_TYPES: frozenset[str] = frozenset({
+    "text/html",
+    "application/xhtml+xml",
+    "text/xml",
+    "application/xml",
+})
+# SSRF 방지를 위해 접속을 차단할 내부 네트워크 대역
+BLOCKED_NETWORKS: tuple = (
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("224.0.0.0/4"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+)
+DEFAULT_HEADERS: MappingProxyType = MappingProxyType({
+    "User-Agent": "AsyncScanner-Bot/1.0",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "ko-KR,ko;q=0.9,en;q=0.8",
+    "Accept-Encoding": "gzip, deflate",
+    "Cache-Control": "no-cache",
+})
+
+DEFAULT_TIMEOUT: int = 10
+DNS_TIMEOUT: int = 3
+MAX_CONTENT_LENGTH: int = 50 * 1024 * 1024  # 50MB
+MAX_CONNECTIONS: int = 100
+MAX_CONNECTIONS_PER_HOST: int = 30
+CHUNK_SIZE: int = 8192
+MAX_REDIRECTS: int = 10
+
+
+class ParseResult(TypedDict, total=False):
+    """파싱 결과를 담는 타입 정의"""
+    success: bool
+    soup: Optional[BeautifulSoup]
+    base_url: Optional[str]
+    error: Optional[str]
+    status_code: Optional[int]
+
 
 class AsyncHTMLParser:
-    """비동기 HTML 파서"""
-    
-    def __init__(self, 
-                 timeout: int = AsyncParserConstants.DEFAULT_TIMEOUT,
-                 verify_ssl: bool = True,
-                 max_content_length: int = AsyncParserConstants.MAX_CONTENT_LENGTH,
-                 max_connections: int = AsyncParserConstants.MAX_CONNECTIONS):
-        """
-        AsyncHTMLParser 초기화
-        
-        Args:
-            timeout (int): HTTP 요청 타임아웃
-            verify_ssl (bool): SSL 인증서 검증 여부
-            max_content_length (int): 최대 콘텐츠 크기
-            max_connections (int): 최대 동시 연결 수
-        """
-        self.timeout = timeout
-        self.verify_ssl = verify_ssl
-        self.max_content_length = max_content_length
-        self.max_connections = max_connections
-        
-        self.ssrf_protection = AsyncSSRFProtection()
-        self.session = None
-        self._closed = False
-        
-    async def __aenter__(self):
-        """비동기 컨텍스트 매니저 진입"""
-        await self._ensure_session()
-        return self
-    
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """비동기 컨텍스트 매니저 종료"""
-        await self.close()
-    
-    async def _ensure_session(self):
-        """세션이 없으면 생성"""
-        if self.session is None or self.session.closed:
-            self.session = await self._create_session()
-    
-    async def _create_session(self) -> ClientSession:
-        """비동기 HTTP 세션 생성"""
-        # SSL 컨텍스트 설정
-        ssl_context = None
-        if not self.verify_ssl:
-            ssl_context = ssl.create_default_context()
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
-        
-        # 커넥터 설정
-        connector = TCPConnector(
-            limit=self.max_connections,
-            limit_per_host=AsyncParserConstants.MAX_CONNECTIONS_PER_HOST,
-            ssl=ssl_context,
-            enable_cleanup_closed=True
+    """SSRF 방어 기능을 갖춘 비동기 HTML 파서 코어 엔진"""
+
+    def __init__(
+            self,
+            timeout: int = DEFAULT_TIMEOUT,
+            headers: Optional[dict] = None
+    ):
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self.headers = dict(DEFAULT_HEADERS) if headers is None else dict(headers)
+        self.session: Optional[aiohttp.ClientSession] = None
+
+    async def __aenter__(self) -> AsyncHTMLParser:
+        """비동기 컨텍스트 매니저 진입: 세션 생성"""
+        connector = aiohttp.TCPConnector(
+            limit=MAX_CONNECTIONS,
+            limit_per_host=MAX_CONNECTIONS_PER_HOST,
         )
-        
-        # 타임아웃 설정
-        timeout = ClientTimeout(
-            total=self.timeout,
-            connect=self.timeout // 3,
-            sock_read=self.timeout // 2
-        )
-        
-        session = ClientSession(
-            headers=AsyncParserConstants.DEFAULT_HEADERS,
+        self.session = aiohttp.ClientSession(
             connector=connector,
-            timeout=timeout,
-            raise_for_status=False  # 수동으로 처리
+            timeout=self.timeout,
+            headers=self.headers,
         )
-        
-        return session
-    
-    async def parse_from_url(self, url: str) -> Dict[str, Any]:
-        """
-        비동기로 URL에서 HTML을 가져와 파싱
-        
-        Args:
-            url (str): 대상 URL
-            
-        Returns:
-            Dict[str, Any]: 파싱 결과
-        """
-        try:
-            logger.info(f"비동기 URL 파싱 시작: {url}")
-            
-            # 1. 세션 확인
-            await self._ensure_session()
-            
-            # 2. 초기 URL 검증
-            if not await self.ssrf_protection.is_safe_url(url):
-                return {
-                    'success': False,
-                    'error': 'SSRF 보안 정책에 의해 차단된 URL',
-                    'base_url': url
-                }
-            
-            # 3. 비동기 HTTP 요청 (리다이렉트 수동 처리)
-            final_response = await self._follow_safe_redirects_async(url)
-            
-            # 4. 응답 검증
-            if not self._validate_response_headers(final_response):
-                return {
-                    'success': False,
-                    'error': '허용되지 않는 응답 형식',
-                    'base_url': str(final_response.url)
-                }
-            
-            # 5. HTTP 상태 코드 검사
-            if final_response.status >= 400:
-                return {
-                    'success': False,
-                    'error': f'HTTP {final_response.status} 오류',
-                    'base_url': str(final_response.url),
-                    'status_code': final_response.status
-                }
-            
-            # 6. 비동기 콘텐츠 읽기
-            content = await self._read_content_safely_async(final_response)
-            
-            # 7. 인코딩 감지 및 텍스트 변환
-            html_text = await self._decode_content_async(final_response, content)
-            
-            # 8. HTML 파싱
-            soup = self._parse_html_with_fallback(html_text)
-            
-            logger.info(f"비동기 파싱 성공: {final_response.url} (상태코드: {final_response.status})")
-            
-            return {
-                'success': True,
-                'soup': soup,
-                'base_url': str(final_response.url),
-                'status_code': final_response.status,
-                'headers': dict(final_response.headers),
-                'content_type': final_response.headers.get('content-type', ''),
-                'error': None
-            }
-            
-        except asyncio.TimeoutError:
-            error_msg = f"비동기 요청 타임아웃: {url}"
-            logger.error(error_msg)
-            return {'success': False, 'error': error_msg, 'base_url': url}
-            
-        except aiohttp.ClientError as e:
-            error_msg = f"비동기 HTTP 클라이언트 오류: {url} - {str(e)}"
-            logger.error(error_msg)
-            return {'success': False, 'error': error_msg, 'base_url': url}
-            
-        except Exception as e:
-            error_msg = f"예상치 못한 비동기 오류: {url} - {str(e)}"
-            logger.error(error_msg)
-            return {'success': False, 'error': error_msg, 'base_url': url}
-    
-    async def _follow_safe_redirects_async(self, url: str, max_redirects: int = 10) -> aiohttp.ClientResponse:
-        """비동기 안전한 리다이렉트 추적"""
-        redirect_count = 0
-        current_url = url
-        visited_urls = set()  # 리다이렉트 루프 방지
-        
-        while redirect_count < max_redirects:
-            # 리다이렉트 루프 감지
-            if current_url in visited_urls:
-                raise Exception(f"리다이렉트 루프 감지: {current_url}")
-            
-            visited_urls.add(current_url)
-            
-            # 비동기 요청
-            response = await self.session.get(current_url, allow_redirects=False)
-            
-            # 리다이렉트가 아니면 종료
-            if not (300 <= response.status < 400):
-                return response
-            
-            # Location 헤더 확인
-            location = response.headers.get('Location')
-            if not location:
-                return response
-            
-            # 절대 URL로 변환
-            next_url = str(response.url.join(aiohttp.URL(location)))
-            
-            # 리다이렉트 대상 URL 안전성 검증
-            if not await self.ssrf_protection.is_safe_url(next_url):
-                raise Exception(f"리다이렉트 대상이 안전하지 않음: {next_url}")
-            
-            logger.debug(f"비동기 안전한 리다이렉트: {current_url} -> {next_url}")
-            
-            current_url = next_url
-            redirect_count += 1
-            response.close()  # 이전 응답 정리
-        
-        raise Exception("리다이렉트 횟수 초과")
-    
-    def _validate_response_headers(self, response: aiohttp.ClientResponse) -> bool:
-        """응답 헤더 검증"""
-        # Content-Length 검증
-        content_length = response.headers.get('content-length')
-        if content_length:
-            try:
-                length = int(content_length)
-                if length > self.max_content_length:
-                    logger.warning(f"콘텐츠 크기가 너무 큼: {length} bytes")
-                    return False
-            except ValueError:
-                pass
-        
-        # Content-Type 검증
-        content_type = response.headers.get('content-type', '').lower()
-        if not content_type:
-            logger.warning("Content-Type 헤더가 없음")
-            return False
-        
-        main_type = content_type.split(';')[0].strip()
-        if main_type not in AsyncParserConstants.ALLOWED_CONTENT_TYPES:
-            logger.warning(f"허용되지 않는 Content-Type: {content_type}")
-            return False
-        
-        return True
-    
-    async def _read_content_safely_async(self, response: aiohttp.ClientResponse) -> bytes:
-        """비동기로 안전하게 콘텐츠 읽기"""
-        chunks = []
-        total_size = 0
-        
-        async for chunk in response.content.iter_chunked(AsyncParserConstants.CHUNK_SIZE):
-            chunks.append(chunk)
-            total_size += len(chunk)
-            
-            if total_size > self.max_content_length:
-                raise Exception(f"콘텐츠 크기 한계 초과: {total_size} bytes")
-        
-        return b''.join(chunks)
-    
-    async def _decode_content_async(self, response: aiohttp.ClientResponse, content: bytes) -> str:
-        """비동기 인코딩 감지 및 디코딩"""
-        # 1. aiohttp 자동 감지 사용
-        try:
-            return await response.text()
-        except Exception:
-            pass
-        
-        # 2. 수동 디코딩
-        encoding = 'utf-8'
-        
-        # HTTP 헤더에서 인코딩 확인
-        content_type = response.headers.get('content-type', '')
-        if 'charset=' in content_type:
-            try:
-                encoding = content_type.split('charset=')[1].split(';')[0].strip()
-            except:
-                pass
-        
-        try:
-            return content.decode(encoding, errors='ignore')
-        except:
-            return content.decode('utf-8', errors='ignore')
-    
-    async def parse_html_string(self, html_string: str, base_url: Optional[str] = None) -> Dict[str, Any]:
-        """
-        HTML 문자열을 직접 파싱 (비동기 버전)
-        
-        Args:
-            html_string (str): HTML 문자열
-            base_url (str, optional): 상대 URL 해석용 기준 URL
-            
-        Returns:
-            Dict[str, Any]: 파싱 결과
-        """
-        try:
-            if not html_string or not html_string.strip():
-                return {
-                    'success': False,
-                    'error': '빈 HTML 문자열',
-                    'base_url': base_url
-                }
-            
-            # 크기 제한 검증
-            if len(html_string.encode('utf-8')) > self.max_content_length:
-                return {
-                    'success': False,
-                    'error': f'HTML 크기가 너무 큼: {len(html_string)} bytes',
-                    'base_url': base_url
-                }
-            
-            # HTML 파싱 (CPU 집약적이므로 executor에서 실행)
-            loop = asyncio.get_event_loop()
-            soup = await loop.run_in_executor(
-                None, 
-                self._parse_html_with_fallback, 
-                html_string
-            )
-            
-            logger.info("비동기 HTML 문자열 파싱 완료")
-            
-            return {
-                'success': True,
-                'soup': soup,
-                'base_url': base_url,
-                'error': None
-            }
-            
-        except Exception as e:
-            error_msg = f"비동기 HTML 파싱 오류: {str(e)}"
-            logger.error(error_msg)
-            return {
-                'success': False,
-                'error': error_msg,
-                'base_url': base_url
-            }
-    
-    async def parse(self, html: str) -> BeautifulSoup:
-        """
-        프로젝트 요구사항에 맞는 비동기 파싱 함수
-        
-        Args:
-            html (str): HTML 문자열
-            
-        Returns:
-            BeautifulSoup: 파싱된 객체
-            
-        Raises:
-            ValueError: 빈 HTML 입력 시
-            Exception: 파싱 실패 시
-        """
-        if not html or not html.strip():
-            raise ValueError("빈 HTML 입력")
-        
-        # CPU 집약적 작업을 executor에서 실행
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, 
-            self._parse_html_with_fallback, 
-            html
-        )
-    
-    def _parse_html_with_fallback(self, html_string: str) -> BeautifulSoup:
-        """여러 파서를 시도하여 HTML 파싱 (동기 버전)"""
-        for parser in AsyncParserConstants.PARSERS:
-            try:
-                soup = BeautifulSoup(html_string, parser)
-                logger.debug(f"파싱 성공 (파서: {parser})")
-                return soup
-            except Exception as e:
-                logger.debug(f"{parser} 파서 실패: {str(e)}")
-                continue
-        
-        # 모든 파서 실패 시 기본 파서로 재시도
-        logger.warning("모든 파서 실패, html.parser로 강제 시도")
-        return BeautifulSoup(html_string, 'html.parser')
-    
-    async def close(self):
-        """비동기 세션 정리"""
-        if not self._closed and self.session and not self.session.closed:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """비동기 컨텍스트 매니저 종료: 세션 자원 해제"""
+        if self.session and not self.session.closed:
             await self.session.close()
-            self._closed = True
-    
-    def __del__(self):
-        """소멸자에서 세션 정리 시도"""
-        if not self._closed and self.session and not self.session.closed:
+
+    @staticmethod
+    async def _is_safe_url(url: str) -> bool:
+        """
+        URL 안전성 검증: 스킴 확인 + DNS 해석 + 내부 IP 대역 차단
+
+        주의: 이 검증은 1차 방어 수준이며, 완전한 DNS Rebinding 방어를 위해서는
+        DNS 조회 후 연결 IP를 고정하고 재조회를 차단하는 추가 조치가 필요함
+        """
+        try:
+            parsed = urlparse(url)
+            if parsed.scheme not in ALLOWED_SCHEMES:
+                return False
+
+            hostname = parsed.hostname
+            if not hostname:
+                return False
+
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+            loop = asyncio.get_running_loop()
+
+            addrinfo = await asyncio.wait_for(
+                loop.getaddrinfo(hostname, port),
+                timeout=DNS_TIMEOUT,
+            )
+
+            # 해석된 모든 IP가 차단 대역에 속하는지 검사
+            for _, _, _, _, sockaddr in addrinfo:
+                ip = ipaddress.ip_address(sockaddr[0])
+                if any(ip in network for network in BLOCKED_NETWORKS):
+                    return False
+
+            return True
+
+        except asyncio.TimeoutError:
+            logger.debug(f"DNS 조회 타임아웃: {url}")
+            return False
+        except OSError as e:
+            logger.debug(f"DNS 조회 실패: {url} - {e}")
+            return False
+        except (ValueError, TypeError) as e:
+            logger.debug(f"URL 파싱 오류: {url} - {e}")
+            return False
+
+    @staticmethod
+    def _is_valid_content_type(content_type: Optional[str]) -> bool:
+        """응답의 Content-Type이 허용된 HTML 형식인지 확인"""
+        if not content_type:
+            return False
+        main_type = content_type.split(";")[0].strip().lower()
+        return main_type in ALLOWED_CONTENT_TYPES
+
+    @staticmethod
+    def _parse_html(html: str) -> BeautifulSoup:
+        """여러 파서를 순차적으로 시도하여 HTML 파싱 (폴백 로직)"""
+        for parser in PARSERS:
             try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    loop.create_task(self.close())
-                else:
-                    loop.run_until_complete(self.close())
-            except:
-                pass
+                return BeautifulSoup(html, parser)
+            except FeatureNotFound:
+                continue
+            except (TypeError, ValueError):
+                continue
+        return BeautifulSoup(html, "html.parser")
 
-# 비동기 편의 함수들
-async def parse_url_async(url: str, 
-                         timeout: int = AsyncParserConstants.DEFAULT_TIMEOUT, 
-                         verify_ssl: bool = True) -> Dict[str, Any]:
-    """비동기 URL 파싱 편의 함수"""
-    async with AsyncHTMLParser(timeout=timeout, verify_ssl=verify_ssl) as parser:
-        return await parser.parse_from_url(url)
+    async def _read_content(self, response: aiohttp.ClientResponse) -> bytes:
+        """스트리밍 방식으로 응답을 읽어 메모리 과부하(OOM) 방지"""
+        # Content-Length 헤더를 통한 사전 검사 (버그 수정됨)
+        content_length_header = response.headers.get("Content-Length")
+        if content_length_header:
+            try:
+                content_length = int(content_length_header)
+            except (ValueError, TypeError):
+                content_length = None
 
-async def parse_html_async(html_string: str, base_url: Optional[str] = None) -> Dict[str, Any]:
-    """비동기 HTML 문자열 파싱 편의 함수"""
-    async with AsyncHTMLParser() as parser:
-        return await parser.parse_html_string(html_string, base_url)
+            if content_length is not None and content_length > MAX_CONTENT_LENGTH:
+                raise ValueError(f"컨텐츠 크기 제한 초과: {content_length} bytes")
 
-async def parse_async(html: str) -> BeautifulSoup:
-    """비동기 프로젝트 요구사항용 파싱 함수"""
-    async with AsyncHTMLParser() as parser:
-        return await parser.parse(html)
+        # 청크 단위로 읽으며 실제 크기 실시간 감시
+        buffer = bytearray()
+        async for chunk in response.content.iter_chunked(CHUNK_SIZE):
+            buffer.extend(chunk)
+            if len(buffer) > MAX_CONTENT_LENGTH:
+                raise ValueError(f"컨텐츠 실제 크기 제한 초과: {len(buffer)} bytes")
 
-# 다중 URL 동시 처리 함수
-async def parse_multiple_urls(urls: List[str], 
-                            max_concurrent: int = 10,
-                            timeout: int = AsyncParserConstants.DEFAULT_TIMEOUT) -> List[Dict[str, Any]]:
-    """
-    여러 URL을 동시에 비동기 처리
-    
-    Args:
-        urls (List[str]): URL 리스트
-        max_concurrent (int): 최대 동시 처리 수
-        timeout (int): 각 요청의 타임아웃
-        
-    Returns:
-        List[Dict[str, Any]]: 각 URL의 파싱 결과
-    """
-    semaphore = asyncio.Semaphore(max_concurrent)
-    
-    async def parse_single_url(url: str) -> Dict[str, Any]:
-        async with semaphore:
-            async with AsyncHTMLParser(timeout=timeout) as parser:
-                return await parser.parse_from_url(url)
-    
-    tasks = [parse_single_url(url) for url in urls]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    
-    # 예외 처리
-    processed_results = []
-    for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            processed_results.append({
-                'success': False,
-                'error': f'비동기 처리 오류: {str(result)}',
-                'base_url': urls[i]
-            })
-        else:
-            processed_results.append(result)
-    
-    return processed_results
+        return bytes(buffer)
 
-# 테스트 코드
-if __name__ == "__main__":
-    async def test_async_parser():
-        print("=== 비동기 HTML Parser 테스트 ===")
-        
-        # 단일 URL 테스트
-        print("\n1. 단일 URL 비동기 파싱:")
-        result = await parse_url_async("https://httpbin.org/html")
-        print(f"결과: {'성공' if result['success'] else '실패'}")
-        if result['success']:
-            print(f"제목: {result['soup'].title.string if result['soup'].title else 'None'}")
-        
-        # 다중 URL 동시 처리 테스트
-        print("\n2. 다중 URL 동시 처리:")
-        test_urls = [
-            "https://httpbin.org/html",
-            "https://httpbin.org/json",  # 차단되어야 함
-            "https://example.com",
-        ]
-        
-        results = await parse_multiple_urls(test_urls, max_concurrent=3)
-        for i, result in enumerate(results):
-            print(f"URL {i+1}: {'성공' if result['success'] else '실패'}")
-            if not result['success']:
-                print(f"  오류: {result['error']}")
-    
-    # 이벤트 루프 실행
-    asyncio.run(test_async_parser())
+    async def parse(self, url: str) -> ParseResult:
+        """
+        URL로부터 HTML을 가져와 파싱
+
+        요청사항 반영: aiohttp 내장 리다이렉트 사용 (allow_redirects=True)
+        보안: 초기 URL + 최종 URL 검증으로 SSRF 방어
+
+        주의: 중간 리다이렉트 경로는 검증하지 않음. 완전한 SSRF 방어가 필요하면
+        allow_redirects=False로 수동 추적 방식을 사용해야 함.
+        """
+        if not self.session:
+            return {
+                "success": False,
+                "error": "세션이 초기화되지 않았습니다. async with 구문을 사용하세요.",
+                "base_url": url,
+            }
+
+        try:
+            # 1. 초기 URL 안전성 검증
+            if not await self._is_safe_url(url):
+                return {
+                    "success": False,
+                    "error": f"SSRF 보안 정책에 의해 차단됨: {url}",
+                    "base_url": url,
+                }
+
+            # 2. aiohttp 내장 리다이렉트 사용 (요청사항 반영)
+            async with self.session.get(
+                    url,
+                    allow_redirects=True,
+                    max_redirects=MAX_REDIRECTS
+            ) as response:
+                final_url = str(response.url)
+
+                # 3. 최종 URL 안전성 검증 (리다이렉트 후)
+                if not await self._is_safe_url(final_url):
+                    return {
+                        "success": False,
+                        "error": f"리다이렉트 대상이 SSRF 정책에 의해 차단됨: {final_url}",
+                        "base_url": final_url,
+                    }
+
+                # 4. HTTP 오류 상태 확인
+                if response.status >= 400:
+                    return {
+                        "success": False,
+                        "error": f"HTTP {response.status} 에러",
+                        "base_url": final_url,
+                        "status_code": response.status,
+                    }
+
+                # 5. Content-Type 검증
+                content_type = response.headers.get("Content-Type", "")
+                if not self._is_valid_content_type(content_type):
+                    return {
+                        "success": False,
+                        "error": f"허용되지 않는 Content-Type: {content_type}",
+                        "base_url": final_url,
+                        "status_code": response.status,
+                    }
+
+                # 6. 데이터 안전하게 읽기 (OOM 방어)
+                raw = await self._read_content(response)
+
+                # 7. 인코딩 처리
+                encoding = response.charset or "utf-8"
+                try:
+                    html = raw.decode(encoding)
+                except (UnicodeDecodeError, LookupError):
+                    html = raw.decode("utf-8", errors="replace")
+
+                # 8. HTML 파싱
+                soup = self._parse_html(html)
+
+                return {
+                    "success": True,
+                    "soup": soup,
+                    "base_url": final_url,
+                    "status_code": response.status,
+                    "error": None,
+                }
+
+        except asyncio.TimeoutError:
+            return {"success": False, "error": "요청 타임아웃", "base_url": url}
+        except aiohttp.TooManyRedirects:
+            return {
+                "success": False,
+                "error": f"리다이렉트 횟수 초과 (최대: {MAX_REDIRECTS}회)",
+                "base_url": url,
+            }
+        except aiohttp.ClientError as exc:
+            return {
+                "success": False,
+                "error": f"HTTP 클라이언트 오류: {type(exc).__name__}",
+                "base_url": url,
+            }
+        except ValueError as exc:
+            return {
+                "success": False,
+                "error": str(exc),
+                "base_url": url,
+            }
+        except Exception as exc:
+            logger.exception("파서 예외 발생")
+            return {
+                "success": False,
+                "error": f"예상치 못한 오류: {type(exc).__name__}",
+                "base_url": url,
+            }
+
+    def parse_html_string(
+            self,
+            html: str,
+            base_url: str = "",
+            max_length: int = MAX_CONTENT_LENGTH
+    ) -> ParseResult:
+        """HTML 문자열을 직접 파싱 (크기 검사 포함)"""
+        # None 또는 비문자열 입력 방어
+        if not isinstance(html, str):
+            return {
+                "success": False,
+                "error": f"잘못된 입력 타입: {type(html).__name__} (str 필요)",
+                "base_url": base_url,
+            }
+
+        try:
+            byte_size = len(html.encode("utf-8"))
+            if byte_size > max_length:
+                return {
+                    "success": False,
+                    "error": f"입력 크기 초과: {byte_size} > {max_length} bytes",
+                    "base_url": base_url,
+                }
+
+            soup = self._parse_html(html)
+            return {
+                "success": True,
+                "soup": soup,
+                "base_url": base_url,
+                "error": None,
+            }
+
+        except (TypeError, ValueError, FeatureNotFound) as exc:
+            return {
+                "success": False,
+                "error": f"파싱 오류: {type(exc).__name__}",
+                "base_url": base_url,
+            }


### PR DESCRIPTION
### 📌 PR 목적 (What)
피드백 반영하여 수동 리다이렉트 추적 및 거대한 방어 클래스를 해체, aiohttp 내장 기능을 활용한 경량화된 파서 엔진으로 리팩토링

IPv4/IPv6 주소 비교 에러(TypeError)를 원천 차단, 객체 지향 컨벤션에 맞게 정적 메서드 전환을 완료

### 🛠 주요 변경 사항 (How)
구조적 클래스 해체 및 모듈화

- 거대한 SSRF 방어 클래스를 삭제하고 AsyncHTMLParser 내 _is_safe_url 정적 메서드로 통합

- 상수 클래스를 제거하고 파일 최상단에 frozenset 및 MappingProxyType을 적용한 불변(Immutable) 객체로 배치하여 설정 오염을 방지

보안 및 안정성 강화

- TypeError 해결: BLOCKED_NETWORKS를 IPv4와 IPv6 버전별로 분리 관리하여 주소 비교 시 발생하는 런타임 에러를 해결함.

- 메서드 최적화: self 상태를 사용하지 않는 parse_html_string을 @staticmethod로 전환하여 메모리 효율을 높임.

안티 패턴 및 유틸리티 정리

- __del__ 소멸자를 삭제하고, 파일 하단의 불필요한 헬퍼 함수(parse_url_async 등)와 테스트 코드 블록을 모두 제거하여 코어 엔진의 단일 책임에 집중함.

### 💡 리뷰어 참고 사항
aiohttp의 allow_redirects=True 설정을 활용하되, 초기 URL과 최종 도달 URL에 대한 이중 검증을 통해 수동 로직 삭제로 인한 보안 공백을 최소화했습니다.

### ✅ 다음 작업 (Next Step)
[ ] form_extractor.py 리뷰 사항 반영 및 최적화