### PR TITLE
[feat] 기존 payload 직접 실행 경로에서 모듈-큐 경로로 전환

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from core import AttackSurface, HttpMethod, ParamLocation
 from fuzzer import FuzzerEngine
 from reporter import ReportGenerator
 
-from test_dependencies import get_payloads, is_vulnerable, verbose_request_sender
+from test_dependencies import count_module_payloads, get_attack_modules, verbose_request_sender
 
 
 def _parse_cookies(raw: str) -> dict[str, str]:
@@ -70,11 +70,11 @@ async def main() -> None:
         cookies=cookies,
     )
 
-    # Load payloads via test module (per --type, resolves to the right provider function).
-    payloads = get_payloads(attack_type=args.type)
-    if not payloads:
-        print(f"No payloads registered for attack type {args.type!r}. Exiting.")
+    selected_modules = get_attack_modules(attack_type=args.type)
+    if not selected_modules:
+        print(f"No modules registered for attack type {args.type!r}. Exiting.")
         return
+    payload_count = count_module_payloads(selected_modules)
 
     delay = (1.0 / args.rps) if args.rps > 0 else 0.0
     concurrency = max(1, args.rps)
@@ -83,21 +83,22 @@ async def main() -> None:
     print(f"Target URL:     {base_url}")
     print(f"Parameters:     {list(query_params.keys())}")
     print(f"Attack type:    {args.type}")
-    print(f"Payload count:  {len(payloads)}")
+    print(f"Module count:   {len(selected_modules)}")
+    print(f"Payload count:  {payload_count}")
     print(f"Throttle (rps): {args.rps} (delay {delay:.3f}s)")
     print("=" * 60 + "\n")
 
     engine = FuzzerEngine(
         max_concurrent_requests=concurrency,
-        worker_count=concurrency,
+        worker_count=concurrency,  # kept for legacy mode compatibility
+        modules=selected_modules,
+        concurrency_per_module=concurrency,
         delay=delay,
     )
 
-    stats = await engine.run(
+    stats = await engine.run_with_attack_modules(
         surfaces=[surface],
-        payloads=payloads,
         request_sender=verbose_request_sender,
-        is_vulnerable=is_vulnerable,
     )
 
     reporter = ReportGenerator(stats=stats, findings=engine.findings)

--- a/test_dependencies.py
+++ b/test_dependencies.py
@@ -1,15 +1,19 @@
 """
-Temporary test hooks for payloads, vulnerability checks, and logging.
+Temporary test hooks for module queue mode.
 
-Replace imports in main.py with the real payload/verification module when ready.
+Replace imports in main.py with the real team modules when ready.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
 from core import Payload
 from fuzzer import FuzzerResponse, build_and_send_request
+from modules.sqli.analyzer import SQLiModule
+from modules.xss.analyzer import XSSModule
 
 
 def _payloads_sqli() -> list[Payload]:
@@ -83,6 +87,53 @@ def is_vulnerable(response: FuzzerResponse) -> bool:
         return True
 
     return False
+
+
+@dataclass(slots=True)
+class CsrfModule:
+    """
+    Temporary CSRF module for module-queue integration tests.
+    """
+
+    name: str = "CSRF"
+
+    def get_payloads(self) -> list[Payload]:
+        return _payloads_csrf()
+
+    def analyze(
+        self,
+        response: FuzzerResponse,
+        payload: Payload,
+        elapsed_time: float,
+        original_res: FuzzerResponse | None = None,
+    ) -> bool:
+        del payload, elapsed_time, original_res
+        text = (response.text or "").lower()
+        return "password changed" in text or "csrf" in text
+
+
+def get_attack_modules(attack_type: str) -> list[Any]:
+    """
+    Return module instances used by FuzzerEngine.run_with_attack_modules().
+    """
+    module_factories: dict[str, Callable[[], Any]] = {
+        "sqli": SQLiModule,
+        "xss": XSSModule,
+        "csrf": CsrfModule,
+    }
+
+    if attack_type == "all":
+        return [factory() for factory in module_factories.values()]
+
+    factory = module_factories.get(attack_type)
+    return [factory()] if factory else []
+
+
+def count_module_payloads(modules: list[Any]) -> int:
+    """
+    Sum payload sizes across selected modules for CLI display.
+    """
+    return sum(len(module.get_payloads()) for module in modules)
 
 
 async def verbose_request_sender(session, surface, parameter, payload):


### PR DESCRIPTION
## 📌 PR 목적 (What)
1. 기존에 get_payloads 함수를 직접 받아오던 걸 모듈 선택 후 내부 메서드를 실행하도록 구현 방식을 변경.
2. 테스트 의존성 역할을 모듈-큐 방식으로 정리.
## 🛠️ 주요 변경 사항 (How)
### main.py
- 기존 payload 직접 실행 경로(get_payloads + engine.run)에서 모듈-큐 경로로 전환.
- get_attack_modules(args.type)로 모듈 선택 후 engine.run_with_attack_modules(...) 실행.
- 엔진 생성 시 modules, concurrency_per_module 전달.
- CLI 출력에 Module count, 총 Payload count 표시 추가.

### test_dependencies.py
- SQLiModule, XSSModule를 직접 반환하는 get_attack_modules(attack_type) 추가.
- 임시 CsrfModule 추가(get_payloads, analyze 구현).
- count_module_payloads(modules) 추가(CLI 출력용).