### PR TITLE
[fix] get_payload 메서드 split 구현 수정

### DIFF
--- a/modules/sqli/payloads.py
+++ b/modules/sqli/payloads.py
@@ -26,7 +26,8 @@ def get_sqli_payloads() -> list[Payload]:
                 continue
             
             # 1. 파싱: 값 || 타입 || 위험도
-            parts = line.split("||")
+            # value 내부에 "||"가 있을 수 있으므로 뒤에서 2번만 분리
+            parts = line.rsplit("||", 2)
             if len(parts) == 3:
                 raw_value = parts[0].strip()
                 attack_type = parts[1].strip()


### PR DESCRIPTION
## 📌 PR 목적 (What)
line.split("||")으로 구분할 경우 sqli.txt의 payload에 || 이 있는 경우 구조가 붕괴될 수 있으므로 구현을 rsplit으로 변경

## 🛠️ 주요 변경 사항 (How)
- parts = line.rsplit("||", 2) 로 변경하여 뒤에서부터 2번 split 수행하도록 변경
