### PR TITLE
[feat] Fuzzer Engine에서 Anti-csrf 토큰 처리 로직 구현

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -50,6 +50,7 @@ class AttackSurface:
     parameters: dict[str, Any] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
     cookies: dict[str, str] = field(default_factory=dict)
+    dynamic_tokens: list[str] = field(default_factory=list)
     source_url: str | None = None
     description: str | None = None
     
@@ -73,6 +74,7 @@ class AttackSurface:
             'parameters': self.parameters,
             'headers': self.headers,
             'cookies': self.cookies,
+            'dynamic_tokens': self.dynamic_tokens,
             'source_url': self.source_url,
             'description': self.description,
             'depth': self.depth,
@@ -88,6 +90,7 @@ class AttackSurface:
             parameters=data.get('parameters', {}),
             headers=data.get('headers', {}),
             cookies=data.get('cookies', {}),
+            dynamic_tokens=data.get('dynamic_tokens', []),
             source_url=data.get('source_url'),
             description=data.get('description'),
             depth=data.get('depth', 0),

--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -81,6 +81,7 @@ class FuzzerEngine:
         worker_count: int = 10,
         modules: Iterable[AttackModule] | None = None,
         concurrency_per_module: int | None = None,
+        session_pool_size: int = 1,
         delay: float = 0.0,
         request_timeout: float = 15.0,
         queue_maxsize: int = 0,
@@ -91,6 +92,8 @@ class FuzzerEngine:
             raise ValueError("worker_count must be >= 1")
         if concurrency_per_module is not None and concurrency_per_module < 1:
             raise ValueError("concurrency_per_module must be >= 1")
+        if session_pool_size < 1:
+            raise ValueError("session_pool_size must be >= 1")
         if delay < 0:
             raise ValueError("delay must be >= 0")
 
@@ -98,6 +101,7 @@ class FuzzerEngine:
         self.worker_count = worker_count
         self.modules = tuple(modules or ())
         self.concurrency_per_module = concurrency_per_module or worker_count
+        self.session_pool_size = session_pool_size
         self.delay = delay
         self.request_timeout = request_timeout
 
@@ -131,6 +135,20 @@ class FuzzerEngine:
     def findings(self) -> list[Finding]:
         return list(self._findings)
 
+    def _create_session_pool(self) -> list[aiohttp.ClientSession]:
+        timeout = aiohttp.ClientTimeout(total=self.request_timeout)
+        connector_limit = max(
+            2,
+            (self.max_concurrent_requests * 2 + self.session_pool_size - 1) // self.session_pool_size,
+        )
+        return [
+            aiohttp.ClientSession(
+                timeout=timeout,
+                connector=aiohttp.TCPConnector(limit=connector_limit),
+            )
+            for _ in range(self.session_pool_size)
+        ]
+
     async def run(
         self,
         *,
@@ -144,15 +162,13 @@ class FuzzerEngine:
         if not payload_list:
             raise ValueError("payloads must not be empty")
 
-        timeout = aiohttp.ClientTimeout(total=self.request_timeout)
-        connector = aiohttp.TCPConnector(limit=self.max_concurrent_requests * 2)
-
-        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        sessions = self._create_session_pool()
+        try:
             workers = [
                 asyncio.create_task(
                     self._worker(
                         worker_id=index + 1,
-                        session=session,
+                        session=sessions[index % len(sessions)],
                         request_sender=request_sender,
                         is_vulnerable=is_vulnerable,
                         on_finding=on_finding,
@@ -167,6 +183,8 @@ class FuzzerEngine:
             for _ in workers:
                 await self._queue.put(None)
             await asyncio.gather(*workers, return_exceptions=False)
+        finally:
+            await asyncio.gather(*(session.close() for session in sessions))
 
         return self.stats
 
@@ -273,12 +291,10 @@ class FuzzerEngine:
         if not self.modules:
             raise ValueError("modules must be configured to run module queue mode")
 
-        timeout = aiohttp.ClientTimeout(total=self.request_timeout)
-        connector = aiohttp.TCPConnector(limit=self.max_concurrent_requests * 2)
-
-        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        sessions = self._create_session_pool()
+        try:
             await self.start_module_mode(
-                session=session,
+                sessions=sessions,
                 request_sender=request_sender,
                 on_finding=on_finding,
             )
@@ -287,13 +303,15 @@ class FuzzerEngine:
                 await self.submit_surface(surface)
 
             await self.stop_module_mode()
+        finally:
+            await asyncio.gather(*(session.close() for session in sessions))
 
         return self.stats
 
     async def start_module_mode(
         self,
         *,
-        session: aiohttp.ClientSession,
+        sessions: list[aiohttp.ClientSession],
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None = None,
     ) -> None:
@@ -305,6 +323,8 @@ class FuzzerEngine:
             raise RuntimeError("module mode is already running")
         if not self.modules:
             raise ValueError("modules must be configured before starting module mode")
+        if not sessions:
+            raise ValueError("sessions must not be empty")
 
         self._module_queues = {
             module.name: asyncio.Queue()
@@ -323,7 +343,7 @@ class FuzzerEngine:
                 worker = asyncio.create_task(
                     self._module_worker(
                         worker_id=index + 1,
-                        session=session,
+                        session=sessions[index % len(sessions)],
                         module=module,
                         queue=queue,
                         payloads=payloads,

--- a/fuzzer/request_builder.py
+++ b/fuzzer/request_builder.py
@@ -4,12 +4,17 @@ import asyncio
 import copy
 import time
 from dataclasses import dataclass
+from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import quote
 
 import aiohttp
 
 from core.models import AttackSurface, ParamLocation
+
+
+_DYNAMIC_TOKEN_LOCKS: dict[str, asyncio.Lock] = {}
+_DYNAMIC_TOKEN_LOCKS_GUARD = asyncio.Lock()
 
 
 @dataclass(slots=True)
@@ -32,6 +37,187 @@ class FuzzerResponse:
         Older code may still access `response.elapsed`.
         """
         return self.elapsed_time
+
+
+class _TokenExtractor(HTMLParser):
+    def __init__(self, targets: set[str]) -> None:
+        super().__init__()
+        self.targets = targets
+        self.tokens: dict[str, str] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {k.lower(): v for k, v in attrs if v is not None}
+        name = attr_map.get("name")
+        if not name or name not in self.targets:
+            return
+
+        tag_lower = tag.lower()
+        if tag_lower == "input":
+            value = attr_map.get("value")
+            if value is not None:
+                self.tokens[name] = value
+        elif tag_lower == "meta":
+            content = attr_map.get("content")
+            if content is not None:
+                self.tokens[name] = content
+
+
+def _dynamic_lock_key(cookies: dict[str, Any]) -> str:
+    session_id = cookies.get("PHPSESSID")
+    if session_id:
+        return f"phpsessid:{session_id}"
+    if not cookies:
+        return "no-cookie"
+    parts = [f"{k}={cookies[k]}" for k in sorted(cookies.keys())]
+    return "cookie:" + "|".join(parts)
+
+
+async def _get_dynamic_token_lock(lock_key: str) -> asyncio.Lock:
+    async with _DYNAMIC_TOKEN_LOCKS_GUARD:
+        lock = _DYNAMIC_TOKEN_LOCKS.get(lock_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _DYNAMIC_TOKEN_LOCKS[lock_key] = lock
+    return lock
+
+
+async def fetch_dynamic_tokens(
+    session: aiohttp.ClientSession,
+    surface: AttackSurface,
+    *,
+    headers_override: dict[str, Any] | None = None,
+    cookies_override: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    dynamic_tokens = getattr(surface, "dynamic_tokens", None) or []
+    token_targets = {str(token) for token in dynamic_tokens if str(token)}
+    if not token_targets:
+        return {}
+
+    headers = copy.deepcopy(headers_override) if headers_override is not None else (
+        copy.deepcopy(surface.headers) if surface.headers else {}
+    )
+    cookies = copy.deepcopy(cookies_override) if cookies_override is not None else (
+        copy.deepcopy(surface.cookies) if surface.cookies else {}
+    )
+
+    request_kwargs: dict[str, Any] = {}
+    if headers:
+        request_kwargs["headers"] = headers
+    if cookies:
+        request_kwargs["cookies"] = cookies
+
+    try:
+        async with session.get(surface.url, **request_kwargs) as response:
+            html = await response.text(errors="replace")
+    except Exception as exc:
+        print(f"[request-builder] dynamic token refresh failed: {exc}")
+        return {}
+
+    parser = _TokenExtractor(token_targets)
+    parser.feed(html)
+    return parser.tokens
+
+
+def _apply_dynamic_tokens(
+    tokens: dict[str, str],
+    *,
+    attack_parameter: str | None,
+    req_params: dict[str, Any],
+    headers: dict[str, Any],
+    cookies: dict[str, Any],
+) -> None:
+    for token_name, token_value in tokens.items():
+        if attack_parameter is not None and token_name == attack_parameter:
+            continue
+        if token_name in req_params:
+            req_params[token_name] = token_value
+        if token_name in headers:
+            headers[token_name] = token_value
+        if token_name in cookies:
+            cookies[token_name] = token_value
+
+
+def _log_dynamic_tokens(
+    *,
+    surface: AttackSurface,
+    attack_parameter: str | None,
+    tokens: dict[str, str],
+    req_params: dict[str, Any],
+    headers: dict[str, Any],
+    cookies: dict[str, Any],
+) -> None:
+    if not tokens:
+        return
+
+    mode = "baseline" if attack_parameter is None else f"attack:{attack_parameter}"
+    print(f"[*] [DynamicToken] refresh on {surface.url} ({mode})")
+    for token_name, extracted_value in tokens.items():
+        used_value = None
+        used_in = "not-applied"
+        if token_name in req_params:
+            used_value = req_params[token_name]
+            used_in = "params"
+        elif token_name in headers:
+            used_value = headers[token_name]
+            used_in = "headers"
+        elif token_name in cookies:
+            used_value = cookies[token_name]
+            used_in = "cookies"
+        print(
+            f"    - {token_name}: extracted='{extracted_value}' "
+            f"used='{used_value}' location={used_in}"
+        )
+
+
+async def _send_prepared_request(
+    session: aiohttp.ClientSession,
+    *,
+    method: str,
+    url: str,
+    request_kwargs: dict[str, Any],
+) -> FuzzerResponse:
+    start_time = time.monotonic()
+    try:
+        async with session.request(method, url, **request_kwargs) as response:
+            text = await response.text(errors="replace")
+            elapsed = time.monotonic() - start_time
+            return FuzzerResponse(
+                status=response.status,
+                text=text,
+                headers=dict(response.headers),
+                elapsed_time=elapsed,
+                url=str(response.url),
+            )
+    except asyncio.TimeoutError:
+        elapsed = time.monotonic() - start_time
+        return FuzzerResponse(
+            status=0,
+            text="",
+            headers={},
+            elapsed_time=elapsed,
+            url=url,
+            error="TimeoutError",
+        )
+    except aiohttp.ClientError as exc:
+        elapsed = time.monotonic() - start_time
+        return FuzzerResponse(
+            status=0,
+            text="",
+            headers={},
+            elapsed_time=elapsed,
+            url=url,
+            error=f"ClientError: {exc}",
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - start_time
+        return FuzzerResponse(
+            status=0,
+            text="",
+            headers={},
+            elapsed_time=elapsed,
+            url=url,
+            error=f"UnknownError: {exc}",
+        )
 
 
 def _inject_path_payload(url: str, parameter: str, payload: str) -> str:
@@ -100,49 +286,59 @@ async def build_and_send_request(
         request_kwargs["headers"] = headers
     if cookies:
         request_kwargs["cookies"] = cookies
+    dynamic_tokens = getattr(surface, "dynamic_tokens", None) or []
+    if not dynamic_tokens:
+        return await _send_prepared_request(
+            session,
+            method=method,
+            url=url,
+            request_kwargs=request_kwargs,
+        )
 
-    start_time = time.monotonic()
-
-    try:
-        async with session.request(method, url, **request_kwargs) as response:
-            text = await response.text(errors="replace")
-            elapsed = time.monotonic() - start_time
-            return FuzzerResponse(
-                status=response.status,
-                text=text,
-                headers=dict(response.headers),
-                elapsed_time=elapsed,
-                url=str(response.url),
+    lock_key = _dynamic_lock_key(cookies)
+    token_lock = await _get_dynamic_token_lock(lock_key)
+    async with token_lock:
+        new_tokens = await fetch_dynamic_tokens(
+            session,
+            surface,
+            headers_override=headers,
+            cookies_override=cookies,
+        )
+        if new_tokens:
+            _apply_dynamic_tokens(
+                new_tokens,
+                attack_parameter=parameter,
+                req_params=req_params,
+                headers=headers,
+                cookies=cookies,
             )
-    except asyncio.TimeoutError:
-        elapsed = time.monotonic() - start_time
-        return FuzzerResponse(
-            status=0,
-            text="",
-            headers={},
-            elapsed_time=elapsed,
+            _log_dynamic_tokens(
+                surface=surface,
+                attack_parameter=parameter,
+                tokens=new_tokens,
+                req_params=req_params,
+                headers=headers,
+                cookies=cookies,
+            )
+
+        if surface.param_location == ParamLocation.QUERY and req_params:
+            request_kwargs["params"] = req_params
+        elif surface.param_location == ParamLocation.BODY_FORM:
+            request_kwargs["data"] = req_params
+        elif surface.param_location == ParamLocation.BODY_JSON:
+            request_kwargs["json"] = req_params
+        elif req_params:
+            request_kwargs["params"] = req_params
+        if headers:
+            request_kwargs["headers"] = headers
+        if cookies:
+            request_kwargs["cookies"] = cookies
+
+        return await _send_prepared_request(
+            session,
+            method=method,
             url=url,
-            error="TimeoutError",
-        )
-    except aiohttp.ClientError as exc:
-        elapsed = time.monotonic() - start_time
-        return FuzzerResponse(
-            status=0,
-            text="",
-            headers={},
-            elapsed_time=elapsed,
-            url=url,
-            error=f"ClientError: {exc}",
-        )
-    except Exception as exc:
-        elapsed = time.monotonic() - start_time
-        return FuzzerResponse(
-            status=0,
-            text="",
-            headers={},
-            elapsed_time=elapsed,
-            url=url,
-            error=f"UnknownError: {exc}",
+            request_kwargs=request_kwargs,
         )
 
 
@@ -170,47 +366,51 @@ async def send_baseline_request(
         request_kwargs["headers"] = headers
     if cookies:
         request_kwargs["cookies"] = cookies
+    dynamic_tokens = getattr(surface, "dynamic_tokens", None) or []
+    if not dynamic_tokens:
+        return await _send_prepared_request(
+            session,
+            method=method,
+            url=url,
+            request_kwargs=request_kwargs,
+        )
 
-    start_time = time.monotonic()
-
-    try:
-        async with session.request(method, url, **request_kwargs) as response:
-            text = await response.text(errors="replace")
-            elapsed = time.monotonic() - start_time
-            return FuzzerResponse(
-                status=response.status,
-                text=text,
-                headers=dict(response.headers),
-                elapsed_time=elapsed,
-                url=str(response.url),
+    lock_key = _dynamic_lock_key(cookies)
+    token_lock = await _get_dynamic_token_lock(lock_key)
+    async with token_lock:
+        new_tokens = await fetch_dynamic_tokens(
+            session,
+            surface,
+            headers_override=headers,
+            cookies_override=cookies,
+        )
+        if new_tokens:
+            _apply_dynamic_tokens(
+                new_tokens,
+                attack_parameter=None,
+                req_params=req_params,
+                headers=headers,
+                cookies=cookies,
             )
-    except asyncio.TimeoutError:
-        elapsed = time.monotonic() - start_time
-        return FuzzerResponse(
-            status=0,
-            text="",
-            headers={},
-            elapsed_time=elapsed,
+            _log_dynamic_tokens(
+                surface=surface,
+                attack_parameter=None,
+                tokens=new_tokens,
+                req_params=req_params,
+                headers=headers,
+                cookies=cookies,
+            )
+
+        if req_params:
+            request_kwargs["params"] = req_params
+        if headers:
+            request_kwargs["headers"] = headers
+        if cookies:
+            request_kwargs["cookies"] = cookies
+
+        return await _send_prepared_request(
+            session,
+            method=method,
             url=url,
-            error="TimeoutError",
-        )
-    except aiohttp.ClientError as exc:
-        elapsed = time.monotonic() - start_time
-        return FuzzerResponse(
-            status=0,
-            text="",
-            headers={},
-            elapsed_time=elapsed,
-            url=url,
-            error=f"ClientError: {exc}",
-        )
-    except Exception as exc:
-        elapsed = time.monotonic() - start_time
-        return FuzzerResponse(
-            status=0,
-            text="",
-            headers={},
-            elapsed_time=elapsed,
-            url=url,
-            error=f"UnknownError: {exc}",
+            request_kwargs=request_kwargs,
         )

--- a/main.py
+++ b/main.py
@@ -434,6 +434,12 @@ async def main() -> None:
         default=0,
         help="Limit number of time/stacked payloads when enabled (0=all)",
     )
+    parser.add_argument(
+        "--session-pool-size",
+        type=int,
+        default=3,
+        help="Number of HTTP sessions to use in parallel (default: 3)",
+    )
 
     args = parser.parse_args()
     try:
@@ -518,6 +524,7 @@ async def main() -> None:
     print("Evasions:       off (mutator disabled)")
     print(f"Throttle (rps): {args.rps} (delay {delay:.3f}s)")
     print(f"Queue workers:  {queue_workers}")
+    print(f"Session pool:   {args.session_pool_size}")
     print("=" * 60 + "\n")
 
     engine = FuzzerEngine(
@@ -525,6 +532,7 @@ async def main() -> None:
         worker_count=queue_workers,  # queue consumption workers
         modules=selected_modules,
         concurrency_per_module=queue_workers,
+        session_pool_size=max(1, args.session_pool_size),
         delay=delay,
     )
 

--- a/mock_parser.py
+++ b/mock_parser.py
@@ -67,9 +67,15 @@ def get_dvwa_mock_surfaces(
             url=f"{root}/vulnerabilities/brute/",
             method=HttpMethod.GET,
             param_location=ParamLocation.QUERY,
-            parameters={"username": "admin", "password": "password", "Login": "Login"},
+            parameters={
+                "username": "admin",
+                "password": "password",
+                "Login": "Login",
+                "user_token": "",
+            },
             cookies=auth_cookies,
             description="DVWA Brute Force (GET)",
+            dynamic_tokens=["user_token"],
         ),
         # AttackSurface(
         #     url=f"{root}/vulnerabilities/upload/",


### PR DESCRIPTION
## 📌 PR 목적 (What)
csrf 토큰을 우회하기 위해 Anti-csrf 토큰 처리 로직을 fuzzer engine에 구현.

## 🛠️ 주요 변경 사항 (How)
### 1. 파서/모델 계층
- `AttackSurface`에 `dynamic_tokens: list[str]` 필드 추가
    - 파일: `core/models.py`
- `mock_parser.py`의 brute surface에 user_token 포함

### 2. 요청 빌더 계층(`fuzzer/request_builder.py`)
- 전송 순서는 Pre-request(GET) -> 토큰 추출 -> 요청값 덮어쓰기 -> 공격 전송
- `fetch_dynamic_tokens(...)`
    - 대상 URL로 GET 요청 수행
    - HTML에서 dynamic_tokens 목록에 해당하는 토큰 값을 추출
- `_apply_dynamic_tokens(...)`
    - 추출된 토큰을 실제 전송 데이터에 반영
    - 현재 공격 타겟 파라미터와 토큰 이름이 같으면 돞어쓰기 스킵
- `_log_dynamic_tokens(...)`
    - 토큰 이름/추출값/실사용값/적용 위치 로그 출력
    
### 3. 동시성 제어
같은 세션을 사용할 경우 병렬로 처리하게 되면 토큰 무효화 경쟁이 발생. 이를 해결하기 위해 요청 빌더에 세션 키 기반 Lock 도입.
- PHPSESSID 기반으로 lock key 생성
- 동일 세션 내에서는 직렬화
- 서로 다른 세션은 병렬 가능

### 4. 세션 폴링(`fuzzer/engine.py`, `main.py`)
성능 보완을 위해 단일 세션 공유에서 세션 풀로 확장.
- CLI 옵션 추가: `--session-pool-size` (기본 3)
    - 파일: `main.py`
- 엔진이 `aiohttp.ClientSession` 여러 개 생성 후 워커에 라운드로빈 할당
    - 파일: `fuzzer/engine.py`
- 효과: 동적 토큰 로직은 유지하면서, 멀티세션 환경에서 병렬 처리량 확보 가능

## 💡 리뷰어 참고 사항
**@팀B(허윤):**
세션 폴링을 통해 병렬 처리를 하여도 페이로드가 7\~8000개 가량 되는 brute force 공격 시 1~2시간으 시간 소요가 있습니다. 너무 느리다 싶으면 웹 애플리케이션에 따라 `--session-pool-size` 값을 올려서 사용하시면 됩니다.

## ✅ 다음 작업 (Next Step)
- `main.py`에 구현되어 있는 기능 세부 파일들로 분리
