### PR TITLE
[fix] crawler engine.py 크롤러 엔진 로직 수정

### DIFF
--- a/crawler/engine.py
+++ b/crawler/engine.py
@@ -1,24 +1,18 @@
 # crawler/engine.py
 
 import asyncio
-import re
-from urllib.parse import urljoin, urlparse, parse_qs
+from urllib.parse import urljoin, urlparse
 from datetime import datetime
-from bs4 import BeautifulSoup
 from contextlib import asynccontextmanager
-import json
 
 from core.models import (
     PageData,
-    AttackSurface,
-    HttpMethod,
-    ParamLocation,
     TokenDetector
 )
+from parser.html_parser import AsyncHTMLParser  #
+from crawler.session_manager import SessionManager  #
+from crawler.url_filter import URLFilter  #
 from utils.logger import get_logger
-
-from crawler.session_manager import SessionManager
-from crawler.url_filter import URLFilter
 
 logger = get_logger(__name__)
 
@@ -42,8 +36,6 @@ class CrawlStats:
         self.urls_queued = 0
         self.errors = 0
         self.forms_found = 0
-        self.apis_found = 0
-        self.attack_surfaces = 0
         self.dynamic_tokens_found = 0
         self.start_time = datetime.now()
 
@@ -57,22 +49,20 @@ class CrawlStats:
             "urls_queued": self.urls_queued,
             "errors": self.errors,
             "forms_found": self.forms_found,
-            "apis_found": self.apis_found,
-            "attack_surfaces": self.attack_surfaces,
             "dynamic_tokens_found": self.dynamic_tokens_found,
             "duration": self.duration
         }
 
 
 class CrawlerEngine:
-    """웹 크롤러 엔진"""
+    """개선된 웹 크롤러 엔진"""
 
     def __init__(self, queue_manager, config=None):
-        self.queue_manager = queue_manager
+        self.queue_manager = queue_manager  #
         self.config = config or CrawlConfig()
 
-        self.session_manager = SessionManager()
-        self.url_filter = URLFilter()
+        self.session_manager = SessionManager()  #
+        self.url_filter = URLFilter()  #
 
         self._visited = set()
         self._queue = asyncio.Queue()
@@ -80,40 +70,14 @@ class CrawlerEngine:
         self._workers = []
         self._shutdown = asyncio.Event()
         self._external_session = False
-        self._seen_surfaces = set()
-
-        self._api_patterns = {
-            'json': ['/api/', '/v1/', '/v2/', '/graphql'],
-            'rest': ['PUT', 'DELETE', 'PATCH']
-        }
-
-        self._injectable_headers = [
-            "User-Agent", "Referer", "X-Forwarded-For", "X-Real-IP",
-            "X-Originating-IP", "X-Remote-IP", "X-Remote-Addr", "X-Client-IP",
-            "Accept-Language", "Accept-Encoding", "Origin", "Host",
-        ]
 
     @staticmethod
     def _get_safe_attr(element, attr_name: str) -> str:
-        """
-        bs4 요소에서 속성값을 안전하게 문자열로 추출
-        ✨ [수정] PyCharm의 str | bytes 경고를 해결하고 실제 바이트 디코딩 처리
-        """
+        """bs4 요소에서 속성값을 안전하게 추출"""
         raw_val = element.get(attr_name)
-
-        # 1. 리스트인 경우 첫 번째 요소 추출 (class 속성 등)
         if isinstance(raw_val, list):
             raw_val = raw_val[0] if raw_val else ""
-
-        # 2. 파이참 경고 해결: bytes 타입일 경우 디코딩
-        if isinstance(raw_val, bytes):
-            return raw_val.decode('utf-8', errors='ignore')
-
-        # 3. 그 외 (문자열 등)
-        if raw_val is not None:
-            return str(raw_val)
-
-        return ""
+        return str(raw_val) if raw_val is not None else ""
 
     def set_session(self, session_manager):
         self.session_manager = session_manager
@@ -148,7 +112,6 @@ class CrawlerEngine:
 
     def _reset_state(self):
         self._visited.clear()
-        self._seen_surfaces.clear()
         self._stats = CrawlStats()
         self._shutdown.clear()
 
@@ -161,36 +124,24 @@ class CrawlerEngine:
             asyncio.create_task(self._worker(i))
             for i in range(self.config.workers)
         ]
-
         try:
             await asyncio.gather(*self._workers, return_exceptions=True)
-        except Exception as e:
-            logger.error("워커 실행 중 오류: %s", e)
         finally:
             await self._cleanup_workers()
 
     async def _cleanup_workers(self):
         self._shutdown.set()
-
         for worker in self._workers:
             if not worker.done():
                 worker.cancel()
-
         if self._workers:
             await asyncio.gather(*self._workers, return_exceptions=True)
-
         self._workers.clear()
 
     async def _worker(self, worker_id):
-        logger.debug("워커 %d 시작", worker_id)
-
         while not self._shutdown.is_set():
             try:
                 item = await asyncio.wait_for(self._queue.get(), timeout=1.0)
-
-                if item[0] is None:
-                    break
-
                 url, depth = item
 
                 if not self._should_continue_crawling():
@@ -201,84 +152,33 @@ class CrawlerEngine:
                 await asyncio.sleep(self.config.delay)
 
             except asyncio.TimeoutError:
-                if self._queue.empty() and not self._shutdown.is_set():
-                    break
-            except asyncio.CancelledError:
-                logger.debug("워커 %d 강제 취소됨", worker_id)
-                break
-            # noinspection PyBroadException
+                if self._queue.empty(): break
             except Exception as e:
                 logger.error("워커 %d 오류: %s", worker_id, e)
 
-        logger.debug("워커 %d 종료", worker_id)
-
     def _should_continue_crawling(self):
-        return (
-                not self._shutdown.is_set() and
-                self._stats.urls_visited < self.config.max_urls
-        )
+        return not self._shutdown.is_set() and self._stats.urls_visited < self.config.max_urls
 
     async def _process_url(self, url, depth):
         url = self.url_filter.normalize_url(url)
-
-        if not self._is_valid_url(url):
+        if url in self._visited or not self.url_filter.should_crawl(url):
             return
 
-        self._mark_visited(url)
+        self._visited.add(url)
+        self._stats.urls_visited += 1
         logger.info("[%d] %s (depth=%d)", self._stats.urls_visited, url, depth)
 
         try:
             response = await self._fetch_url(url)
-            if not response:
-                return
-
-            await self._process_response(response, url, depth)
-
-        # noinspection PyBroadException
+            if response:
+                await self._process_response(response, url, depth)
         except Exception as e:
             logger.error("처리 실패 (%s): %s", url, e)
             self._stats.errors += 1
 
-    def _is_valid_url(self, url):
-        return url not in self._visited and self.url_filter.should_crawl(url)
-
-    def _mark_visited(self, url):
-        self._visited.add(url)
-        self._stats.urls_visited += 1
-
-    async def _fetch_url(self, url, max_retries=2):
-        for attempt in range(max_retries):
-            try:
-                response = await self.session_manager.get(url, timeout=self.config.timeout)
-
-                if not response:
-                    if attempt < max_retries - 1:
-                        await asyncio.sleep(1.0)
-                        continue
-                    self._stats.errors += 1
-                    return None
-
-                final_url = str(response.get("url", url))
-                if self._is_login_redirect(str(url), final_url):
-                    logger.warning("로그인 페이지로 리다이렉트됨: %s", final_url)
-                    self._stats.errors += 1
-                    return None
-
-                return response
-
-            # noinspection PyBroadException
-            except Exception as e:
-                logger.debug("요청 실패 (%s) 시도 %d/%d: %s", url, attempt + 1, max_retries, e)
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(1.0)
-                else:
-                    self._stats.errors += 1
-                    return None
-        return None
-
-    @staticmethod
-    def _is_login_redirect(original_url: str, final_url: str) -> bool:
-        return "login" in final_url.lower() and "login" not in original_url.lower()
+    async def _fetch_url(self, url):
+        # session_manager를 통해 안전한 요청 수행
+        return await self.session_manager.get(url, timeout=self.config.timeout)
 
     async def _process_response(self, response, url, depth):
         html = response.get("text", "")
@@ -286,339 +186,75 @@ class CrawlerEngine:
         headers = response.get("headers", {})
         cookies = response.get("cookies", {})
 
-        page = PageData(url=final_url, html=html, depth=depth)
+        # 1. PageData 객체 생성 및 큐 매니저로 전달
+        page = PageData(
+            url=final_url,
+            html=html,
+            depth=depth,
+            headers=headers,
+            cookies=cookies
+        )
         self.queue_manager.add_page(page)
 
-        await self._extract_attack_surfaces(html, final_url, headers, cookies)
+        # 2. 전용 파서를 이용한 안전한 HTML 분석
+        parse_result = AsyncHTMLParser.parse_html_string(html, base_url=final_url)
+        if not parse_result.get("success"):
+            logger.warning("파싱 건너뜀 (%s): %s", final_url, parse_result.get("error"))
+            return
 
+        soup = parse_result["soup"]
+
+        # ✨ [수정된 부분] 타입 검사기(PyCharm 등) 에러 해결을 위한 명시적 None 체크
+        if soup is None:
+            return
+
+        # 3. 폼 및 동적 토큰 감지 수행 (파싱된 soup 객체 재사용)
+        await self._process_forms_and_tokens(soup, page)
+
+        # 4. 다음 크롤링 대상 URL 추출
         if depth < self.config.max_depth:
-            await self._queue_next_urls(html, final_url, depth)
+            await self._queue_next_urls(soup, final_url, depth)
 
-    def _add_unique_attack_surface(self, surface: AttackSurface) -> bool:
-        param_keys = tuple(sorted(surface.parameters.keys()))
-        surface_hash = hash((str(surface.url), surface.method.value, param_keys))
-
-        if surface_hash not in self._seen_surfaces:
-            self._seen_surfaces.add(surface_hash)
-            self.queue_manager.add_attack_surface(surface)
-            self._stats.attack_surfaces += 1
-            return True
-
-        return False
-
-    async def _extract_attack_surfaces(self, html, base_url, headers, cookies):
-        try:
-            soup = BeautifulSoup(html, "html.parser")
-            base_url_str = str(base_url)
-
-            await self._extract_forms_surfaces(soup, base_url_str)
-            await self._extract_api_surfaces(html, base_url_str, headers)
-            await self._extract_query_surfaces(soup, base_url_str)
-            await self._extract_header_surfaces(base_url_str)
-            await self._extract_cookie_surfaces(base_url_str, cookies)
-        # noinspection PyBroadException
-        except Exception as e:
-            logger.warning("공격 표면 추출 실패: %s", e)
-
-    async def _extract_forms_surfaces(self, soup, base_url: str):
+    async def _process_forms_and_tokens(self, soup, page_data: PageData):
+        """이미 파싱된 soup 객체로부터 폼과 토큰을 감지하여 PageData에 저장"""
         for form in soup.find_all("form"):
             self._stats.forms_found += 1
-
-            action = self._get_safe_attr(form, "action")
-            # ✨ [수정] Any | None 경고 해결 (명시적 str 캐스팅)
-            method = str(self._get_safe_attr(form, "method") or "GET").upper()
-            enctype = str(self._get_safe_attr(form, "enctype") or "application/x-www-form-urlencoded")
-
-            form_url = urljoin(base_url, action) if action else base_url
-
-            parameters = {}
-            dynamic_tokens = []
-
             for input_field in form.find_all(["input", "textarea", "select"]):
                 name = self._get_safe_attr(input_field, "name")
-                if not name:
-                    continue
+                if not name: continue
 
                 value = self._get_safe_attr(input_field, "value")
-                input_type = str(self._get_safe_attr(input_field, "type") or "text")
+                input_type = self._get_safe_attr(input_field, "type") or "text"
 
+                # TokenDetector를 통한 실시간 보안 토큰 감지
                 if TokenDetector.detect(name, value, input_type):
-                    dynamic_tokens.append(name)
                     self._stats.dynamic_tokens_found += 1
                     logger.info("🔑 동적 토큰 감지: name=%s, type=%s", name, input_type)
 
-                if input_type != "hidden":
-                    value = ""
+                    # ✨ 토큰의 이름과 값을 PageData에 딕셔너리 형태로 저장
+                    page_data.dynamic_tokens[name] = value
 
-                parameters[name] = value
+    async def _queue_next_urls(self, soup, base_url: str, depth):
+        """soup 객체로부터 다음 URL들을 추출하여 작업 큐에 추가"""
+        urls = set()
+        # 링크 추출
+        for a in soup.find_all("a", href=True):
+            full_url = urljoin(base_url, a['href'])
+            if self.url_filter.should_crawl(full_url):
+                urls.add(full_url)
 
-            if parameters:
-                if method == "GET":
-                    param_location = ParamLocation.QUERY
-                elif "json" in enctype.lower():  # ✨ Any|None 경고 해결됨
-                    param_location = ParamLocation.BODY_JSON
-                else:
-                    param_location = ParamLocation.BODY_FORM
+        # 폼 액션 추출
+        for form in soup.find_all("form", action=True):
+            full_url = urljoin(base_url, form['action'])
+            if self.url_filter.should_crawl(full_url):
+                urls.add(full_url)
 
-                try:
-                    http_method = HttpMethod[method]
-                except KeyError:
-                    http_method = HttpMethod.POST
-
-                surface = AttackSurface(
-                    url=form_url,
-                    method=http_method,
-                    param_location=param_location,
-                    parameters=parameters,
-                    dynamic_tokens=dynamic_tokens,
-                    source_url=base_url,
-                    description=f"Form [{method}] from {base_url}"
-                )
-
-                if self._add_unique_attack_surface(surface):
-                    if dynamic_tokens:
-                        logger.info("폼 공격 표면 추가: %s (동적 토큰: %s)", form_url, dynamic_tokens)
-                    else:
-                        logger.debug("폼 공격 표면 추가: %s (%s)", form_url, param_location.value)
-
-    async def _extract_api_surfaces(self, html, base_url: str, headers):
-        raw_ct = headers.get("content-type")
-        content_type = str(raw_ct).lower() if raw_ct else ""
-
-        if "application/json" in content_type:
-            self._stats.apis_found += 1
-
-            try:
-                json_data = json.loads(html)
-                parameters = self._extract_json_parameters(json_data)
-
-                if parameters:
-                    surface = AttackSurface(
-                        url=base_url,
-                        method=HttpMethod.POST,
-                        param_location=ParamLocation.BODY_JSON,
-                        parameters=parameters,
-                        dynamic_tokens=[],
-                        source_url=base_url,
-                        description="JSON API endpoint"
-                    )
-
-                    if self._add_unique_attack_surface(surface):
-                        logger.debug("JSON API 공격 표면 추가: %s", base_url)
-
-            except json.JSONDecodeError:
-                pass
-
-        api_patterns = [
-            r'fetch\s*\(\s*["\']([^"\']+)["\']',
-            r'axios\.(get|post|put|delete)\s*\(\s*["\']([^"\']+)["\']',
-            r'\.ajax\s*\(\s*\{[^}]*url\s*:\s*["\']([^"\']+)["\']',
-            r'\$\.(get|post)\s*\(\s*["\']([^"\']+)["\']',
-        ]
-
-        for pattern in api_patterns:
-            matches = re.findall(pattern, html, re.IGNORECASE)
-            for match in matches:
-                if isinstance(match, tuple):
-                    api_path = str(match[-1])
-                    method_hint = str(match[0]) if len(match) > 1 else "GET"
-                else:
-                    api_path = str(match)
-                    method_hint = "GET"
-
-                api_url = urljoin(base_url, api_path)
-
-                if not self.url_filter.should_crawl(api_url):
-                    continue
-
-                method_map = {
-                    "get": HttpMethod.GET,
-                    "post": HttpMethod.POST,
-                    "put": HttpMethod.PUT,
-                    "delete": HttpMethod.DELETE,
-                }
-                http_method = method_map.get(method_hint.lower(), HttpMethod.GET)
-
-                self._stats.apis_found += 1
-
-                surface = AttackSurface(
-                    url=api_url,
-                    method=http_method,
-                    param_location=ParamLocation.BODY_JSON,
-                    parameters={},
-                    dynamic_tokens=[],
-                    source_url=base_url,
-                    description=f"API endpoint found in JavaScript [{http_method.value}]"
-                )
-
-                if self._add_unique_attack_surface(surface):
-                    logger.debug("JS API 공격 표면 추가: %s", api_url)
-
-    async def _extract_query_surfaces(self, soup, base_url: str):
-        parsed = urlparse(base_url)
-        if parsed.query:
-            params = parse_qs(parsed.query)
-            if params:
-                parameters = {str(k): str(v[0]) if v else "" for k, v in params.items()}
-                surface = AttackSurface(
-                    url=base_url.split('?')[0],
-                    method=HttpMethod.GET,
-                    param_location=ParamLocation.QUERY,
-                    parameters=parameters,
-                    dynamic_tokens=[],
-                    source_url=base_url,
-                    description="Current URL query parameters"
-                )
-                self._add_unique_attack_surface(surface)
-
-        processed_urls = set()
-        for link in soup.find_all("a", href=True):
-            href = self._get_safe_attr(link, "href")
-
-            if not href or "?" not in href:
-                continue
-
-            # ✨ [수정] bytes 경고 해결 및 안전한 결합
-            full_url = urljoin(base_url, href)
-            url_without_query = full_url.split('?')[0]
-
-            if url_without_query in processed_urls:
-                continue
-
-            processed_urls.add(url_without_query)
-
-            if not self.url_filter.should_crawl(full_url):
-                continue
-
-            parsed = urlparse(full_url)
-            params = parse_qs(parsed.query)
-
-            if params:
-                parameters = {str(k): str(v[0]) if v else "" for k, v in params.items()}
-                surface = AttackSurface(
-                    url=url_without_query,
-                    method=HttpMethod.GET,
-                    param_location=ParamLocation.QUERY,
-                    parameters=parameters,
-                    dynamic_tokens=[],
-                    source_url=base_url,
-                    description="Link with query parameters"
-                )
-
-                if self._add_unique_attack_surface(surface):
-                    logger.debug("쿼리 공격 표면 추가: %s", url_without_query)
-
-    async def _extract_header_surfaces(self, base_url: str):
-        header_parameters = {name: "" for name in self._injectable_headers}
-        surface = AttackSurface(
-            url=base_url,
-            method=HttpMethod.GET,
-            param_location=ParamLocation.HEADER,
-            parameters=header_parameters,
-            dynamic_tokens=[],
-            source_url=base_url,
-            description="HTTP Header injection points"
-        )
-        if self._add_unique_attack_surface(surface):
-            logger.debug("헤더 공격 표면 추가: %s (%d개 헤더)", base_url, len(header_parameters))
-
-    async def _extract_cookie_surfaces(self, base_url: str, cookies):
-        cookie_dict = cookies if cookies else {}
-
-        if not cookie_dict:
-            # noinspection PyBroadException
-            try:
-                cookie_dict = self.session_manager.get_cookies()
-            except Exception:
-                cookie_dict = {}
-
-        if not cookie_dict:
-            return
-
-        cookie_parameters = {str(name): str(value) for name, value in cookie_dict.items()}
-
-        surface = AttackSurface(
-            url=base_url,
-            method=HttpMethod.GET,
-            param_location=ParamLocation.COOKIE,
-            parameters=cookie_parameters,
-            cookies=cookie_parameters,
-            dynamic_tokens=[],
-            source_url=base_url,
-            description=f"Cookie injection points ({len(cookie_parameters)} cookies)"
-        )
-
-        if self._add_unique_attack_surface(surface):
-            logger.debug("쿠키 공격 표면 추가: %s (%d개 쿠키)", base_url, len(cookie_parameters))
-
-    def _extract_json_parameters(self, json_data, prefix=""):
-        parameters = {}
-
-        if isinstance(json_data, dict):
-            for key, value in json_data.items():
-                full_key = f"{prefix}.{key}" if prefix else str(key)
-                if isinstance(value, (dict, list)):
-                    nested = self._extract_json_parameters(value, full_key)
-                    parameters.update(nested)
-                else:
-                    parameters[full_key] = ""
-
-        elif isinstance(json_data, list) and json_data:
-            if isinstance(json_data[0], dict):
-                nested = self._extract_json_parameters(json_data[0], f"{prefix}[0]")
-                parameters.update(nested)
-
-        return parameters
-
-    async def _queue_next_urls(self, html, base_url: str, depth):
-        extracted_data = self._extract_urls(html, base_url)
-        for url in extracted_data["urls"]:
+        for url in urls:
             if url not in self._visited:
                 await self._queue.put((url, depth + 1))
                 self._stats.urls_queued += 1
 
-    def _extract_urls(self, html, base_url: str):
-        urls = set()
-        try:
-            soup = BeautifulSoup(html, "html.parser")
-            urls.update(self._extract_links(soup, base_url))
-            urls.update(self._extract_form_actions(soup, base_url))
-        # noinspection PyBroadException
-        except Exception as e:
-            logger.warning("URL 추출 실패: %s", e)
-        return {"urls": list(urls)}
-
-    def _extract_links(self, soup, base_url: str):
-        links = set()
-        for element in soup.find_all("a", href=True):
-            href = self._get_safe_attr(element, "href")
-            url = self._process_extracted_url(href, base_url)
-            if url:
-                links.add(url)
-        return links
-
-    def _extract_form_actions(self, soup, base_url: str):
-        actions = set()
-        for form in soup.find_all("form"):
-            action = self._get_safe_attr(form, "action")
-            if action:
-                url = self._process_extracted_url(action, base_url)
-                if url:
-                    actions.add(url)
-        return actions
-
-    def _process_extracted_url(self, url: str, base_url: str) -> str | None:
-        if not url or url.startswith(("#", "javascript:", "mailto:")):
-            return None
-
-        # ✨ [수정] url, base_url이 명확히 문자열로 타입 체킹됨
-        full_url = urljoin(base_url, url)
-        if self.url_filter.should_crawl(full_url):
-            return full_url
-        return None
-
     def stop(self):
-        logger.info("크롤링 중지 요청")
         self._shutdown.set()
 
     def get_stats(self):
@@ -627,12 +263,7 @@ class CrawlerEngine:
     def _log_summary(self):
         logger.info("========== 크롤링 종료 ==========")
         logger.info(
-            "방문: %d, 에러: %d, 폼: %d, API: %d, 공격표면: %d, 동적토큰: %d, 시간: %.2f초",
-            self._stats.urls_visited,
-            self._stats.errors,
-            self._stats.forms_found,
-            self._stats.apis_found,
-            self._stats.attack_surfaces,
-            self._stats.dynamic_tokens_found,
-            self._stats.duration
+            "방문: %d, 폼: %d, 동적토큰: %d, 시간: %.2f초",
+            self._stats.urls_visited, self._stats.forms_found,
+            self._stats.dynamic_tokens_found, self._stats.duration
         )


### PR DESCRIPTION
## 📌 PR 목적 (What)
안전한 파서(AsyncHTMLParser)를 통합하여 크롤러 엔진(CrawlerEngine)의 SSRF 보안성 및 안정성을 강화하고, 퍼저(Fuzzer)로 이어지는 데이터 파이프라인의 핵심인 PageData의 무결성(헤더/쿠키 보존)을 확보.
크롤러(Crawler)에서 감지한 세션 정보 및 동적 토큰이 파서(Parser)를 거쳐 최종적으로 퍼저(Fuzzer)의 AttackSurface 객체까지 안전하게 도달할 수 있도록 데이터 전달 흐름을 개선
크롤러가 파서의 역활 중 일부를 추가로 하는 것이 아닌 크롤링에 집중할 수 있게 코드 수정
## 🛠️ 주요 변경 사항 (How)
안전한 전용 파서 연동 (AsyncHTMLParser): 기존 BeautifulSoup 직접 호출 방식을 제거하고, 내부망 접근 차단(SSRF 방어) 등 보안 로직이 적용된 parse_html_string을 사용하도록 엔진 구조를 개선.
데이터 무결성 및 컨텍스트 보존: HTTP 응답에서 추출한 headers와 cookies가 누락되지 않고 PageData 객체에 온전히 담겨 큐(QueueManager)로 전달되도록 수정 (퍼저가 정확한 세션/권한 컨텍스트에서 공격을 수행하는 데 필수적).
리소스 최적화 (파싱 1회 제한): HTML 파싱을 단 1회만 수행하고, 생성된 soup 객체를 URL 추출, 폼 수집, 동적 토큰(TokenDetector) 감지 모듈에서 재사용하도록 로직을 변경하여 불필요한 CPU 리소스 낭비 제거.
타입 안정성 (Type Safety) 확보: 정적 타입 검사기(PyCharm 등)에서 발생하던 BeautifulSoup | None 경고를 해결하기 위해 방어 코드(Type Guard, if soup is None: return)를 추가하여 런타임 에러 가능성 원천 차단.
데이터 전달 순서 보장: _process_response 메서드에서 PageData를 생성하자마자 큐에 넣던 방식을 수정하여, 폼/토큰 분석이 완전히 끝난 후 큐에 적재하도록 순서를 변경했습니다.
토큰 저장 로직 추가: _process_forms_and_tokens 메서드가 page_data 인자를 전달받도록 서명을 수정하고, 감지된 토큰의 name과 value를 page_data.dynamic_tokens 딕셔너리에 저장하도록 구현했습니다.
AttackSurface 관련 코드 제거: AttackSurface 관련 코드를 모두 제거하고, 폼에서 동적 토큰을 감지하고 통계를 수집하는 로직만 남기도록 수정