### PR TITLE
[feat] SurfaceBuilder 구현 파서-퍼저 간 직접 전송 모델 도입

### DIFF
--- a/parser/surface_builder.py
+++ b/parser/surface_builder.py
@@ -1,3 +1,5 @@
+# core/surface_builder.py
+
 import hashlib
 import logging
 import asyncio
@@ -9,11 +11,17 @@ from parser import form_extractor, link_extractor
 
 logger = logging.getLogger(__name__)
 
-# 퍼저 콜백 타입 정의
 SurfaceCallback = Callable[[AttackSurface], Union[Awaitable[None], None]]
 
 
 class SurfaceBuilder:
+    """
+    공격 표면 빌더
+    - 중복 파싱 방지 (Soup 재사용)
+    - 동적 토큰(CSRF 등) 자동 병합
+    - 퍼저 콜백 직송
+    """
+
     def __init__(self, fuzzer_callback: SurfaceCallback):
         self.fuzzer_callback = fuzzer_callback
         self._seen_signatures: Set[str] = set()
@@ -26,19 +34,19 @@ class SurfaceBuilder:
         return hashlib.md5(raw.encode()).hexdigest()
 
     async def process_page(self, page_data: PageData) -> None:
-        """
-        PageData를 분석하여 AttackSurface를 추출하고 퍼저로 직배송합니다.
-        """
+        """PageData를 분석하여 AttackSurface를 추출하고 퍼저로 직배송"""
         surfaces: List[AttackSurface] = []
 
-        # ✅ 반영 1: BeautifulSoup 객체를 한 번만 생성하여 재사용 (CPU 오버헤드 감소)
-        soup = BeautifulSoup(page_data.html, 'html.parser')
+        # ✅ [최적화] CrawlerEngine에서 만든 soup이 있으면 재사용, 없으면 1회만 파싱
+        if isinstance(page_data.soup, BeautifulSoup):
+            source_soup = page_data.soup
+        else:
+            source_soup = BeautifulSoup(page_data.html, 'html.parser')
 
         # ==========================================
         # 1. HTML Form 기반 AttackSurface 추출
         # ==========================================
-        # 문자열 대신 이미 파싱된 soup 객체를 넘깁니다.
-        forms = form_extractor.extract_forms(soup, base_url=page_data.url)
+        forms = form_extractor.extract_forms(source_soup, base_url=page_data.url)
 
         for form in forms:
             method_str = str(form.get('method', 'GET')).upper()
@@ -47,40 +55,34 @@ class SurfaceBuilder:
             except ValueError:
                 method = HttpMethod.GET
 
-            if method in (HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE):
-                param_location = ParamLocation.BODY_FORM
-            else:
-                param_location = ParamLocation.QUERY
+            loc = ParamLocation.BODY_FORM if method in (HttpMethod.POST, HttpMethod.PUT) \
+                else ParamLocation.QUERY
 
-            action_url = form.get('action')
-            safe_url = str(action_url) if action_url else str(page_data.url)
+            safe_url = str(form.get('action')) if form.get('action') else str(page_data.url)
 
-            # ✅ 반영 2: 크롤러가 수집해온 동적 토큰을 파라미터에 병합
+            # ✨ [데이터 병합] 크롤러가 수집한 동적 토큰을 공격 파라미터에 주입
             parameters = form.get('parameters', {}).copy()
             if page_data.dynamic_tokens:
                 parameters.update(page_data.dynamic_tokens)
 
-            surface = AttackSurface(
+            surfaces.append(AttackSurface(
                 url=safe_url,
                 method=method,
-                param_location=param_location,
+                param_location=loc,
                 parameters=parameters,
                 headers=page_data.headers,
                 cookies=page_data.cookies,
                 source_url=str(page_data.url),
-                description=f"Form Input (risk: {form.get('risk_level', 'low')}, csrf: {form.get('has_csrf_token')})"
-            )
-            surfaces.append(surface)
+                description=f"Form (risk: {form.get('risk_level')}, tokens: {len(page_data.dynamic_tokens)})"
+            ))
 
         # ==========================================
         # 2. URL 파라미터(Link) 기반 AttackSurface 추출
         # ==========================================
-        # 문자열 대신 이미 파싱된 soup 객체를 넘깁니다.
-        links = link_extractor.extract_links(soup, base_url=page_data.url)
+        links = link_extractor.extract_links(source_soup, base_url=page_data.url)
 
         for link in links:
-            if not link.get('params'):
-                continue
+            if not link.get('params'): continue
 
             method_str = str(link.get('method', 'GET')).upper()
             try:
@@ -88,46 +90,38 @@ class SurfaceBuilder:
             except ValueError:
                 method = HttpMethod.GET
 
-            link_url = str(link.get('url', ''))
-
-            # 링크 파라미터에도 동적 토큰 정보를 주입합니다.
+            # 링크 파라미터에도 동적 토큰 병합 (정규화된 문자열 타입)
             parameters = link.get('params', {}).copy()
             if page_data.dynamic_tokens:
                 parameters.update(page_data.dynamic_tokens)
 
-            surface = AttackSurface(
-                url=link_url,
+            surfaces.append(AttackSurface(
+                url=str(link.get('url', '')),
                 method=method,
                 param_location=ParamLocation.QUERY,
                 parameters=parameters,
                 headers=page_data.headers,
                 cookies=page_data.cookies,
                 source_url=str(page_data.url),
-                description=f"Link Parameter (source: {link.get('source', 'unknown')})"
-            )
-            surfaces.append(surface)
+                description="Link Query Params"
+            ))
 
         # ==========================================
-        # 3. 중복 검증 및 퍼저 콜백(Callback) 호출
+        # 3. 중복 검증 및 퍼저 콜백 호출
         # ==========================================
         for surface in surfaces:
-            if not surface.url:
-                continue
+            if not surface.url: continue
 
             sig = self._generate_signature(surface)
-            if sig in self._seen_signatures:
-                continue
+            if sig in self._seen_signatures: continue
 
             self._seen_signatures.add(sig)
 
-            logger.debug(f"[SurfaceBuilder] 퍼저로 공격 표면 전달: {surface.url}")
+            logger.debug(f"[SurfaceBuilder] 퍼저로 전송: {surface.url}")
 
-            # 콜백을 통해 퍼저로 즉시 전송
             result = self.fuzzer_callback(surface)
             if asyncio.iscoroutine(result):
                 await result
 
     def get_stats(self) -> dict:
-        return {
-            "unique_surfaces_found": len(self._seen_signatures)
-        }
+        return {"unique_surfaces_sent": len(self._seen_signatures)}

--- a/parser/surface_builder.py
+++ b/parser/surface_builder.py
@@ -1,0 +1,133 @@
+import hashlib
+import logging
+import asyncio
+from typing import Callable, Awaitable, Set, List, Union
+from bs4 import BeautifulSoup
+
+from core.models import PageData, AttackSurface, HttpMethod, ParamLocation
+from parser import form_extractor, link_extractor
+
+logger = logging.getLogger(__name__)
+
+# 퍼저 콜백 타입 정의
+SurfaceCallback = Callable[[AttackSurface], Union[Awaitable[None], None]]
+
+
+class SurfaceBuilder:
+    def __init__(self, fuzzer_callback: SurfaceCallback):
+        self.fuzzer_callback = fuzzer_callback
+        self._seen_signatures: Set[str] = set()
+
+    @staticmethod
+    def _generate_signature(surface: AttackSurface) -> str:
+        """AttackSurface의 고유 해시 생성 (중복 제거용)"""
+        param_keys = str(sorted(surface.parameters.keys()))
+        raw = f"{surface.url}:{surface.method.value}:{surface.param_location.value}:{param_keys}"
+        return hashlib.md5(raw.encode()).hexdigest()
+
+    async def process_page(self, page_data: PageData) -> None:
+        """
+        PageData를 분석하여 AttackSurface를 추출하고 퍼저로 직배송합니다.
+        """
+        surfaces: List[AttackSurface] = []
+
+        # ✅ 반영 1: BeautifulSoup 객체를 한 번만 생성하여 재사용 (CPU 오버헤드 감소)
+        soup = BeautifulSoup(page_data.html, 'html.parser')
+
+        # ==========================================
+        # 1. HTML Form 기반 AttackSurface 추출
+        # ==========================================
+        # 문자열 대신 이미 파싱된 soup 객체를 넘깁니다.
+        forms = form_extractor.extract_forms(soup, base_url=page_data.url)
+
+        for form in forms:
+            method_str = str(form.get('method', 'GET')).upper()
+            try:
+                method = HttpMethod(method_str)
+            except ValueError:
+                method = HttpMethod.GET
+
+            if method in (HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE):
+                param_location = ParamLocation.BODY_FORM
+            else:
+                param_location = ParamLocation.QUERY
+
+            action_url = form.get('action')
+            safe_url = str(action_url) if action_url else str(page_data.url)
+
+            # ✅ 반영 2: 크롤러가 수집해온 동적 토큰을 파라미터에 병합
+            parameters = form.get('parameters', {}).copy()
+            if page_data.dynamic_tokens:
+                parameters.update(page_data.dynamic_tokens)
+
+            surface = AttackSurface(
+                url=safe_url,
+                method=method,
+                param_location=param_location,
+                parameters=parameters,
+                headers=page_data.headers,
+                cookies=page_data.cookies,
+                source_url=str(page_data.url),
+                description=f"Form Input (risk: {form.get('risk_level', 'low')}, csrf: {form.get('has_csrf_token')})"
+            )
+            surfaces.append(surface)
+
+        # ==========================================
+        # 2. URL 파라미터(Link) 기반 AttackSurface 추출
+        # ==========================================
+        # 문자열 대신 이미 파싱된 soup 객체를 넘깁니다.
+        links = link_extractor.extract_links(soup, base_url=page_data.url)
+
+        for link in links:
+            if not link.get('params'):
+                continue
+
+            method_str = str(link.get('method', 'GET')).upper()
+            try:
+                method = HttpMethod(method_str)
+            except ValueError:
+                method = HttpMethod.GET
+
+            link_url = str(link.get('url', ''))
+
+            # 링크 파라미터에도 동적 토큰 정보를 주입합니다.
+            parameters = link.get('params', {}).copy()
+            if page_data.dynamic_tokens:
+                parameters.update(page_data.dynamic_tokens)
+
+            surface = AttackSurface(
+                url=link_url,
+                method=method,
+                param_location=ParamLocation.QUERY,
+                parameters=parameters,
+                headers=page_data.headers,
+                cookies=page_data.cookies,
+                source_url=str(page_data.url),
+                description=f"Link Parameter (source: {link.get('source', 'unknown')})"
+            )
+            surfaces.append(surface)
+
+        # ==========================================
+        # 3. 중복 검증 및 퍼저 콜백(Callback) 호출
+        # ==========================================
+        for surface in surfaces:
+            if not surface.url:
+                continue
+
+            sig = self._generate_signature(surface)
+            if sig in self._seen_signatures:
+                continue
+
+            self._seen_signatures.add(sig)
+
+            logger.debug(f"[SurfaceBuilder] 퍼저로 공격 표면 전달: {surface.url}")
+
+            # 콜백을 통해 퍼저로 즉시 전송
+            result = self.fuzzer_callback(surface)
+            if asyncio.iscoroutine(result):
+                await result
+
+    def get_stats(self) -> dict:
+        return {
+            "unique_surfaces_found": len(self._seen_signatures)
+        }


### PR DESCRIPTION
## 📌 PR 목적 (What)
파싱된 AttackSurface을 큐에 적재하지 않고, Fuzzer의 진입점으로 즉시 전달하는 SurfaceBuilder 모듈을 구현
시스템 복잡도를 낮추고 데이터 처리 지연을 최소화하기 위한 아키텍처 개선 작업
## 🛠️ 주요 변경 사항 (How)
신규 모듈 추가: PageData를 입력받아 내부적으로 form_extractor 및 link_extractor를 호출하여 공격 표면을 추출
추출된 데이터를 프로젝트 표준 DTO인 AttackSurface 규격으로 변환
콜백 기반 전송 방식 도입: 생성자에서 fuzzer_callback을 주입받아, 추출된 AttackSurface를 별도의 큐 저장 단계 없이 퍼저로 직배송
중복 제거(Deduplication) 로직 통합: _generate_signature 정적 메서드를 통해 URL + Method + Parameters 구조 기반의 해시를 생성
동일한 공격 지점이 퍼저로 반복 전송되지 않도록 필터링을 수행
데이터 무결성 강화: page_data.dynamic_tokens에 담긴 크롤러 수집 토큰 정보를 AttackSurface의 parameters에 병합하여, 퍼저가 CSRF 토큰이나 세션 검증을 올바르게 통과할 수 있게 추가
중복 파싱 제거: page_data.soup이 존재할 경우 이를 우선 활용하고, 없을 때만 파싱을 수행하는 로직을 적용했습니다.
동적 토큰 병합: page_data.dynamic_tokens에 담긴 정보를 각 AttackSurface의 파라미터에 자동으로 업데이트하도록 개선했습니다.
## 💡 리뷰어 참고 사항
구현 세부 사항 (Technical Details)
데이터 흐름: PageData -> SurfaceBuilder -> AttackSurface 생성 -> 중복 체크 -> Fuzzer Callback 호출.
비동기 지원: 퍼저의 처리가 지연될 경우를 대비하여 process_page 메서드를 비동기(async)로 구현
-중복 파싱 제거, 동적 토큰 병합은 시은님이 오류라고 알려주신것 수정한것
