### PR TITLE
[fix] crawler core 비동기 큐 전환 및 PageData 모델 내 Soup 필드 추가

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -85,22 +85,23 @@ class TokenDetector:
 
 
 class PageData:
-    """파싱을 위해 정제된 페이지 데이터 (헤더/쿠키 포함)"""
     def __init__(
             self,
             url: str,
             html: str,
             depth: int = 0,
-            headers: Dict[str, str] = None,   # ✨ 추가됨
-            cookies: Dict[str, str] = None,   # ✨ 추가됨
-            dynamic_tokens: Dict[str, str] = None  # ✨ 토큰을 담을 딕셔너리 추가
+            headers: Dict[str, str] = None,
+            cookies: Dict[str, str] = None,
+            dynamic_tokens: Dict[str, str] = None,
+            soup: Any = None  # ✨ [추가] 파싱된 BeautifulSoup 객체를 담을 필드
     ):
         self.url = url
         self.html = html
         self.depth = depth
-        self.headers = headers if headers is not None else {}  # ✨ 추가됨
-        self.cookies = cookies if cookies is not None else {}  # ✨ 추가됨
-        self.dynamic_tokens = dynamic_tokens if dynamic_tokens is not None else {}  # ✨ 추가됨
+        self.headers = headers if headers is not None else {}
+        self.cookies = cookies if cookies is not None else {}
+        self.dynamic_tokens = dynamic_tokens if dynamic_tokens is not None else {}
+        self.soup = soup  # ✨ [추가] 파서로부터 전달받은 soup 저장
 
     def __repr__(self) -> str:
         # ✨ 모든 메타데이터의 상태를 한눈에 파악할 수 있도록 구성

--- a/core/queue_manager.py
+++ b/core/queue_manager.py
@@ -1,12 +1,8 @@
 # core/queue_manager.py
-"""
-큐 관리자
-크롤러 → 파서 → 퍼저 간의 데이터 전달을 관리
-"""
+import asyncio
+from typing import Dict, Any
 
-import threading
-from collections import deque
-
+from core.models import PageData
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -14,209 +10,56 @@ logger = get_logger(__name__)
 
 class QueueManager:
     """
-    작업 큐 관리자
+    비동기 전용 작업 큐 관리자 (asyncio.Queue 기반)
 
     역할:
-    1. 크롤러 → 파서: CrawlResult 전달
-    2. 파서 → 퍼저: AttackSurface 전달
+    1. Crawler -> Parser: 수집된 PageData를 이벤트 루프 블로킹 없이 안전하게 전달
     """
 
-    def __init__(self, max_size=10000):
+    def __init__(self, max_size: int = 10000):
         self.max_size = max_size
-        self._crawl_results = deque(maxlen=max_size)
-        self._attack_surfaces = deque(maxlen=max_size)
-        self._seen_surface_ids = set()
-        self._lock = threading.Lock()
+
+        # ✨ 비동기 큐 할당 (deque 아님)
+        self._page_queue: asyncio.Queue[PageData] = asyncio.Queue(maxsize=max_size)
+
+        # PageData 관련 통계만 유지
         self._stats = {
-            'crawl_results_added': 0,
-            'crawl_results_processed': 0,
-            'surfaces_added': 0,
-            'surfaces_processed': 0,
-            'duplicates_skipped': 0,
+            'pages_added': 0,
+            'pages_processed': 0,
         }
 
     # ============================================================
-    # 크롤러 → 파서 (CrawlResult)
+    # PageData 관리 (Crawler -> Parser)
     # ============================================================
 
-    def add_crawl_result(self, result):
-        """크롤러가 수집한 결과를 큐에 추가"""
-        self._lock.acquire()
-        try:
-            self._crawl_results.append(result)
-            self._stats['crawl_results_added'] += 1
-        finally:
-            self._lock.release()
+    async def add_page(self, page: PageData) -> None:
+        """[비동기] 크롤러가 수집한 페이지 데이터를 큐에 추가 (append -> put)"""
+        await self._page_queue.put(page)
+        self._stats['pages_added'] += 1
 
-    def get_crawl_result(self):
-        """파서가 처리할 결과를 큐에서 가져옴"""
-        self._lock.acquire()
-        try:
-            if self._crawl_results:
-                result = self._crawl_results.popleft()
-                self._stats['crawl_results_processed'] += 1
-                return result
-            return None
-        finally:
-            self._lock.release()
+    async def get_page(self) -> PageData:
+        """[비동기] 파서가 처리할 페이지를 큐에서 대기하며 가져옴 (popleft -> get)"""
+        page = await self._page_queue.get()
+        self._stats['pages_processed'] += 1
+        return page
 
-    def has_crawl_results(self):
-        """처리할 CrawlResult가 있는지 확인"""
-        self._lock.acquire()
-        try:
-            return len(self._crawl_results) > 0
-        finally:
-            self._lock.release()
-
-    def crawl_result_count(self):
-        """대기 중인 CrawlResult 수"""
-        self._lock.acquire()
-        try:
-            return len(self._crawl_results)
-        finally:
-            self._lock.release()
-
-    # ============================================================
-    # 파서 → 퍼저 (AttackSurface)
-    # ============================================================
-
-    def add_attack_surface(self, surface):
-        """
-        파서가 생성한 공격 표면을 큐에 추가
-
-        Args:
-            surface: AttackSurface 인스턴스
-
-        Returns:
-            bool: 추가 성공 여부 (중복이면 False)
-        """
-        surface_id = surface.get_id()
-
-        self._lock.acquire()
-        try:
-            if surface_id in self._seen_surface_ids:
-                self._stats['duplicates_skipped'] += 1
-                return False
-
-            self._attack_surfaces.append(surface)
-            self._seen_surface_ids.add(surface_id)
-            self._stats['surfaces_added'] += 1
-            return True
-        finally:
-            self._lock.release()
-
-    def get_attack_surface(self):
-        """퍼저가 처리할 공격 표면을 큐에서 가져옴"""
-        self._lock.acquire()
-        try:
-            if self._attack_surfaces:
-                surface = self._attack_surfaces.popleft()
-                self._stats['surfaces_processed'] += 1
-                return surface
-            return None
-        finally:
-            self._lock.release()
-
-    def get_attack_surfaces(self, count=10):
-        """여러 개의 공격 표면을 한번에 가져옴"""
-        self._lock.acquire()
-        try:
-            surfaces = []
-            fetch_count = min(count, len(self._attack_surfaces))
-            for _ in range(fetch_count):
-                surface = self._attack_surfaces.popleft()
-                surfaces.append(surface)
-                self._stats['surfaces_processed'] += 1
-            return surfaces
-        finally:
-            self._lock.release()
-
-    def has_attack_surfaces(self):
-        """처리할 AttackSurface가 있는지 확인"""
-        self._lock.acquire()
-        try:
-            return len(self._attack_surfaces) > 0
-        finally:
-            self._lock.release()
-
-    def attack_surface_count(self):
-        """대기 중인 AttackSurface 수"""
-        self._lock.acquire()
-        try:
-            return len(self._attack_surfaces)
-        finally:
-            self._lock.release()
+    def has_pages(self) -> bool:
+        """처리해야 할 페이지가 남아있는지 확인 (len() -> qsize())"""
+        return self._page_queue.qsize() > 0
 
     # ============================================================
     # 통계 및 관리
     # ============================================================
 
-    def get_stats(self):
-        """통계 반환"""
-        self._lock.acquire()
-        try:
-            stats = self._stats.copy()
-            stats['crawl_results_pending'] = len(self._crawl_results)
-            stats['surfaces_pending'] = len(self._attack_surfaces)
-            stats['unique_surfaces'] = len(self._seen_surface_ids)
-            return stats
-        finally:
-            self._lock.release()
+    def get_stats(self) -> Dict[str, Any]:
+        """현재 큐 상태 및 누적 통계 반환 (len() -> qsize())"""
+        stats = self._stats.copy()
+        stats['pages_pending'] = self._page_queue.qsize()
+        return stats
 
-    def clear(self):
-        """모든 큐 초기화"""
-        self._lock.acquire()
-        try:
-            self._crawl_results.clear()
-            self._attack_surfaces.clear()
-            self._seen_surface_ids.clear()
-            self._stats = {
-                'crawl_results_added': 0,
-                'crawl_results_processed': 0,
-                'surfaces_added': 0,
-                'surfaces_processed': 0,
-                'duplicates_skipped': 0,
-            }
-        finally:
-            self._lock.release()
-
-    def is_empty(self):
-        """모든 큐가 비었는지 확인"""
-        self._lock.acquire()
-        try:
-            return not self._crawl_results and not self._attack_surfaces
-        finally:
-            self._lock.release()
-
-    # ============================================================
-    # 편의 메서드 (크롤러용 단순화)
-    # ============================================================
-
-    def add_page(self, page):
-        """크롤러에서 간단하게 페이지 추가"""
-        self._lock.acquire()
-        try:
-            self._crawl_results.append(page)
-            self._stats['crawl_results_added'] += 1
-        finally:
-            self._lock.release()
-
-    def get_page(self):
-        """파서에서 간단하게 페이지 가져오기"""
-        self._lock.acquire()
-        try:
-            if self._crawl_results:
-                page = self._crawl_results.popleft()
-                self._stats['crawl_results_processed'] += 1
-                return page
-            return None
-        finally:
-            self._lock.release()
-
-    def has_pages(self):
-        """처리할 페이지가 있는지"""
-        self._lock.acquire()
-        try:
-            return len(self._crawl_results) > 0
-        finally:
-            self._lock.release()
+    def clear(self) -> None:
+        """큐 초기화 및 통계 리셋 (비동기 큐는 clear가 없으므로 새로 할당)"""
+        self._page_queue = asyncio.Queue(maxsize=self.max_size)
+        self._stats['pages_added'] = 0
+        self._stats['pages_processed'] = 0
+        logger.info("QueueManager가 초기화되었습니다.")


### PR DESCRIPTION
## 📌 PR 목적 (What)
비동기 환경에서의 동시성 성능을 극대화하고 중복 파싱을 방지하기 위해 코어 인프라 로직을 개선
## 🛠️ 주요 변경 사항 (How)
core/models.py:
PageData 클래스에 soup 필드를 추가하여 파싱된 BeautifulSoup 객체를 직접 들고 있을 수 있도록 수정
core/queue_manager.py
기존 threading.Lock과 deque 기반의 동기 큐를 asyncio.Queue 기반의 비동기 큐로 전면 교체
큐 관련 메서드(add_page, get_page)를 async 함수로 전환하여 이벤트 루프 블로킹 위험을 제거