### PR TITLE
[fix]  SurfaceBuilder URL 중복 방어 및 파라미터 평탄화 로직 통합

### DIFF
--- a/parser/surface_builder.py
+++ b/parser/surface_builder.py
@@ -3,7 +3,8 @@
 import hashlib
 import logging
 import asyncio
-from typing import Callable, Awaitable, Set, List, Union
+from typing import Callable, Awaitable, Set, List, Union, Dict, Any
+from urllib.parse import urlparse, urlunparse
 from bs4 import BeautifulSoup
 
 from core.models import PageData, AttackSurface, HttpMethod, ParamLocation
@@ -19,6 +20,7 @@ class SurfaceBuilder:
     공격 표면 빌더
     - 중복 파싱 방지 (Soup 재사용)
     - 동적 토큰(CSRF 등) 자동 병합
+    - URL 쿼리스트링 중복 제거 및 파라미터 타입 평탄화 (Fuzzer 호환성)
     - 퍼저 콜백 직송
     """
 
@@ -33,11 +35,30 @@ class SurfaceBuilder:
         raw = f"{surface.url}:{surface.method.value}:{surface.param_location.value}:{param_keys}"
         return hashlib.md5(raw.encode()).hexdigest()
 
+    @staticmethod
+    def _strip_query_string(url: str) -> str:
+        """✅ [수정] URL에서 쿼리스트링(?id=1)을 제거하여 중복 결합 방지"""
+        parsed = urlparse(url)
+        # scheme, netloc, path, params, query(제거), fragment
+        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', parsed.fragment))
+
+    @staticmethod
+    def _normalize_parameters(raw_params: Dict[str, Any]) -> Dict[str, str]:
+        """✅ [수정] Fuzzer에서 TypeError가 발생하지 않도록 모든 값을 단일 문자열로 평탄화"""
+        normalized = {}
+        for key, value in raw_params.items():
+            if isinstance(value, list):
+                # 리스트인 경우 첫 번째 값만 취하거나 빈 문자열 처리
+                normalized[key] = str(value[0]) if value else ""
+            else:
+                normalized[key] = str(value)
+        return normalized
+
     async def process_page(self, page_data: PageData) -> None:
         """PageData를 분석하여 AttackSurface를 추출하고 퍼저로 직배송"""
         surfaces: List[AttackSurface] = []
 
-        # ✅ [최적화] CrawlerEngine에서 만든 soup이 있으면 재사용, 없으면 1회만 파싱
+        # CrawlerEngine에서 만든 soup이 있으면 재사용, 없으면 1회만 파싱
         if isinstance(page_data.soup, BeautifulSoup):
             source_soup = page_data.soup
         else:
@@ -58,10 +79,13 @@ class SurfaceBuilder:
             loc = ParamLocation.BODY_FORM if method in (HttpMethod.POST, HttpMethod.PUT) \
                 else ParamLocation.QUERY
 
-            safe_url = str(form.get('action')) if form.get('action') else str(page_data.url)
+            action_url = str(form.get('action')) if form.get('action') else str(page_data.url)
 
-            # ✨ [데이터 병합] 크롤러가 수집한 동적 토큰을 공격 파라미터에 주입
-            parameters = form.get('parameters', {}).copy()
+            # Form의 action URL에도 쿼리스트링이 있을 수 있으므로 정제
+            safe_url = self._strip_query_string(action_url) if loc == ParamLocation.QUERY else action_url
+
+            # 파라미터 평탄화(List 제거) 및 동적 토큰 병합
+            parameters = self._normalize_parameters(form.get('parameters', {}))
             if page_data.dynamic_tokens:
                 parameters.update(page_data.dynamic_tokens)
 
@@ -90,13 +114,17 @@ class SurfaceBuilder:
             except ValueError:
                 method = HttpMethod.GET
 
-            # 링크 파라미터에도 동적 토큰 병합 (정규화된 문자열 타입)
-            parameters = link.get('params', {}).copy()
+            # ✅ URL 쿼리스트링 제거 (파라미터는 parameters 딕셔너리로 분리되어 넘어감)
+            raw_url = str(link.get('url', ''))
+            clean_url = self._strip_query_string(raw_url)
+
+            # 파라미터 평탄화(List 제거) 및 동적 토큰 병합
+            parameters = self._normalize_parameters(link.get('params', {}))
             if page_data.dynamic_tokens:
                 parameters.update(page_data.dynamic_tokens)
 
             surfaces.append(AttackSurface(
-                url=str(link.get('url', '')),
+                url=clean_url,
                 method=method,
                 param_location=ParamLocation.QUERY,
                 parameters=parameters,


### PR DESCRIPTION
## 📌 PR 목적 (What)
퍼징 엔진에 전달되는 데이터의 무결성을 보장하고, 실제 요청 시 발생할 수 있는 논리적 오류를 해결
## 🛠️ 주요 변경 사항 (How)
URL 쿼리스트링 중복 제거: _strip_query_string 메서드를 통해 URL에서 ?id=1 등의 부분을 제거 후 경로만 남겨, 퍼저의 중복 파라미터 결합 문제를 해결
파라미터 타입 강제화: _normalize_parameters를 통해 모든 파라미터 값을 단일 str로 확정 지어 퍼징 로직의 견고함을 향상
타입 가드 적용: isinstance를 사용하여 page_data.soup의 타입을 명확히 검증하고 IDE 경고를 해결
데이터 병합: 크롤러가 발견한 동적 보안 토큰(CSRF 등)을 각 공격 표면에 자동으로 주입
## ✅ 다음 작업 (Next Step)
- crawler + parser 통합 후 테스트