### PR TITLE
[fix] models 내 dynamic_tokens 타입을 dict로 변경

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -123,7 +123,7 @@ class AttackSurface:
     parameters: dict[str, Any] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
     cookies: dict[str, str] = field(default_factory=dict)
-    dynamic_tokens: list[str] = field(default_factory=list)
+    dynamic_tokens: dict[str, str] = field(default_factory=dict)
     source_url: str | None = None
     description: str | None = None
     depth: int = 0
@@ -160,7 +160,7 @@ class AttackSurface:
             parameters=data.get('parameters', {}),
             headers=data.get('headers', {}),
             cookies=data.get('cookies', {}),
-            dynamic_tokens=data.get('dynamic_tokens', []),
+            dynamic_tokens=data.get('dynamic_tokens', {}),
             source_url=data.get('source_url'),
             description=data.get('description'),
             depth=data.get('depth', 0),


### PR DESCRIPTION
## 📌 PR 목적 (What)
AttackSurface DTO를 개선하여, 퍼징 단계에서 보안 토큰(CSRF 등)이 안전하게 식별되고 유지
## 🛠️ 주요 변경 사항 (How)
core/models.py 내부 AttackSurface 클래스 수정
dynamic_tokens 필드의 타입을 list[str]에서 dict[str, str]로 변경 (토큰의 Key와 Value 모두 저장)
to_dict() 및 from_dict() 메서드에서 빈 딕셔너리({})를 안전하게 처리하도록 직렬화/역직렬화 로직 업데이트
## 💡 리뷰어 참고 사항
Fuzzer가 공격 표면을 전달받았을 때, 변조해서는 안 되는 토큰의 키와 값을 직관적으로 파악할 수 있어 더욱 정밀하고 안정적인 퍼징 시나리오 구성이 가능
