### PR TITLE
[fix] AttackSurface 생성 시 토큰 값 병합 및 파라미터 평탄화 로직 적용

### DIFF
--- a/parser/surface_builder.py
+++ b/parser/surface_builder.py
@@ -100,6 +100,7 @@ class SurfaceBuilder:
                 parameters=parameters,
                 headers=page_data.headers,
                 cookies=page_data.cookies,
+                dynamic_tokens=page_data.dynamic_tokens.copy(),
                 source_url=str(page_data.url),
                 description=f"Form (risk: {form.get('risk_level')}, tokens: {len(page_data.dynamic_tokens)})"
             ))
@@ -134,6 +135,7 @@ class SurfaceBuilder:
                 parameters=parameters,
                 headers=page_data.headers,
                 cookies=page_data.cookies,
+                dynamic_tokens=page_data.dynamic_tokens.copy(),
                 source_url=str(page_data.url),
                 description="Link Query Params"
             ))


### PR DESCRIPTION
## 📌 PR 목적 (What)
크롤러가 수집한 페이지 데이터를 분석하여 퍼저가 즉시 사용할 수 있는 최적의 상태로 공격 표면(Attack Surface)을 가공
## 🛠️ 주요 변경 사항 (How)
parser/surface_builder.py의 process_page 메서드 내 Form 및 Link 추출 로직 수정
토큰 전달: AttackSurface 객체 생성 시 dynamic_tokens=page_data.dynamic_tokens.copy()를 명시하여 식별된 토큰 딕셔너리 전체를 전달
URL 정규화: _strip_query_string을 적용하여 베이스 URL을 분리, 쿼리스트링으로 인한 중복 공격 지점 생성 방지.
파라미터 평탄화: _normalize_parameters를 적용하여 모든 파라미터 값을 단일 문자열(String)로 통일 