### PR TITLE
[fix] 크롤링 응답 처리 시 누적 세션 쿠키가 전달되도록 개선

### DIFF
--- a/crawler/engine.py
+++ b/crawler/engine.py
@@ -182,7 +182,7 @@ class CrawlerEngine:
         html = response.get("text", "")
         final_url = str(response.get("url", url))
         headers = response.get("headers", {})
-        cookies = response.get("cookies", {})
+        cookies = self.session_manager.get_cookies()
 
         # ✨ [핵심 수정] CPU를 무겁게 쓰는 HTML 파싱 작업을 이벤트 루프에서 분리 (스레드 풀 실행)
         # 이를 통해 크롤러 워커들이 네트워크 요청을 주고받는 흐름이 멈추지 않도록 보장합니다.


### PR DESCRIPTION
## 📌 PR 목적 (What)
보호된 타겟(Authenticated Pages)을 탐색할 때 획득한 세션 권한이 파서와 퍼저까지 온전히 전달되도록 크롤러의 쿠키 처리 방식을 수정
## 🛠️ 주요 변경 사항 (How)
crawler/engine.py의 _process_response 메서드 수정
단일 응답 객체의 쿠키가 아닌, 전체 세션을 관리하는 self.session_manager.get_cookies()를 호출하여 유지 중인 누적 세션 쿠키를 획득하여 전달하도록 변경
## 💡 리뷰어 참고 사항
로그인을 통해 획득한 세션 상태(PHPSESSID 등)가 모든 공격 표면 객체에 정상적으로 부여되므로, 인가된 사용자 권한 내에서의 취약점 스캔이 안정적으로 수행