### PR TITLE
[refactor] 내장 모듈 충돌 방지를 위한 패키지명 변경

### DIFF
--- a/crawler/engine.py
+++ b/crawler/engine.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin, urlparse
 from datetime import datetime
 from contextlib import asynccontextmanager
 from core.models import (PageData, TokenDetector)
-from parser.html_parser import AsyncHTMLParser
+from parsers.html_parsers import AsyncHTMLParser
 from crawler.session_manager import SessionManager
 from crawler.url_filter import URLFilter
 from utils.logger import get_logger

--- a/crawler/session_manager.py
+++ b/crawler/session_manager.py
@@ -104,7 +104,7 @@ class SessionManager:
     @staticmethod
     def _extract_csrf_token(html: str, token_name: str) -> Optional[str]:
         try:
-            soup = BeautifulSoup(html, 'html.parser')
+            soup = BeautifulSoup(html, 'html.parsers')
             token_input = soup.find('input', {'name': token_name})
 
             val = SessionManager._get_safe_attr(token_input, 'value')

--- a/parsers/form_extractor.py
+++ b/parsers/form_extractor.py
@@ -1,0 +1,149 @@
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+import logging
+from typing import Dict, List, Optional, Union, Any
+from typing_extensions import TypedDict, NotRequired
+
+logger = logging.getLogger(__name__)
+
+# 성능 최적화를 위한 상수 정의 (frozenset 사용)
+CSRF_PATTERNS = frozenset({'csrf', 'token', 'authenticity', '_token', 'nonce'})
+UPLOAD_ENCTYPES = frozenset({'multipart/form-data'})
+RISK_KEYWORDS = {
+    'high': frozenset({'password', 'passwd', 'pwd', 'admin', 'auth', 'login', 'pay'}),
+    'medium': frozenset({'email', 'user', 'card', 'config'})
+}
+
+
+class CSRFTokenInfo(TypedDict):
+    name: str
+    value: str
+    type: str
+
+
+class FormInfo(TypedDict):
+    type: str
+    index: int
+    action: str
+    method: str
+    enctype: str
+    parameters: Dict[str, Union[str, List[str]]]
+    has_csrf_token: bool
+    raw_html: str
+    csrf_token: NotRequired[Optional[CSRFTokenInfo]]
+    is_file_upload: NotRequired[bool]
+    risk_level: NotRequired[str]
+
+
+def _get_attr_str(tag, attr: str, default: str = "") -> str:
+    """BeautifulSoup의 list/str 속성 불일치 해결"""
+    val = tag.get(attr, default)
+    return " ".join(val) if isinstance(val, list) else str(val)
+
+
+def _get_limited_raw_html(tag, max_bytes: int = 10240) -> str:
+    """바이트 단위 안전 절삭"""
+    raw_html = str(tag)
+    raw_bytes = raw_html.encode('utf-8', errors='ignore')
+    if len(raw_bytes) <= max_bytes:
+        return raw_html
+    return raw_bytes[:max_bytes].decode('utf-8', errors='ignore') + "..."
+
+
+def extract_forms(
+        html: Union[str, BeautifulSoup],
+        base_url: Optional[str] = None,
+        include_all_buttons: bool = True
+) -> List[FormInfo]:
+    """
+    HTML에서 폼 정보를 추출하여 정형화된 데이터로 반환
+    """
+    soup = BeautifulSoup(html, 'html.parsers') if isinstance(html, str) else html
+    extracted_forms: List[FormInfo] = []
+
+    for i, form in enumerate(soup.find_all('form')):
+        try:
+            # 1. 폼 기본 정보
+            action_raw = _get_attr_str(form, 'action').strip()
+            action = urljoin(base_url, action_raw) if base_url else action_raw
+            method = _get_attr_str(form, 'method', 'get').lower()
+            enctype = _get_attr_str(form, 'enctype', 'application/x-www-form-urlencoded').lower()
+
+            # 2. 파라미터 수집
+            params: Dict[str, Any] = {}
+            has_file_input = False
+
+            for el in form.find_all(['input', 'textarea', 'select', 'button']):
+                name = _get_attr_str(el, 'name').strip()
+                if not name: continue
+
+                tag_name = el.name
+                el_type = _get_attr_str(el, 'type').lower()
+                val = ""
+
+                if tag_name == 'select':
+                    opt = el.find('option', selected=True) or el.find('option')
+                    val = _get_attr_str(opt, 'value') if opt else ""
+                elif tag_name == 'textarea':
+                    val = el.get_text()
+                elif tag_name == 'button' or el_type == 'submit':
+                    if not include_all_buttons: continue
+                    val = _get_attr_str(el, 'value')
+                elif el_type == 'file':
+                    has_file_input = True
+                    val = ""
+                elif el_type in ('checkbox', 'radio'):
+                    if el.has_attr('checked'):
+                        val = _get_attr_str(el, 'value', 'on')
+                    else:
+                        continue
+                else:
+                    val = _get_attr_str(el, 'value')
+
+                # Multi-value 처리
+                if name in params:
+                    if isinstance(params[name], list):
+                        params[name].append(val)
+                    else:
+                        params[name] = [params[name], val]
+                else:
+                    params[name] = val
+
+            # 3. 보안 분석 (개선 사항 반영)
+            csrf_info: Optional[CSRFTokenInfo] = None  # 타입 명시 반영
+            param_names_lower = [str(k).lower() for k in params.keys()]
+            param_str = " ".join(param_names_lower)  # Join 미리 수행 (효율화 반영)
+
+            # CSRF 탐지
+            for p_name, p_val in params.items():
+                if any(pat in str(p_name).lower() for pat in CSRF_PATTERNS):
+                    csrf_info = {'name': p_name, 'value': str(p_val), 'type': 'hidden'}
+                    break
+
+            # 위험도 산정
+            risk_level = 'low'
+            for level, keys in RISK_KEYWORDS.items():
+                if any(k in param_str for k in keys):
+                    risk_level = level
+                    break
+
+            # 4. 결과 저장
+            extracted_forms.append({
+                'type': 'form',
+                'index': i,
+                'action': action,
+                'method': method if method in ('get', 'post', 'put', 'delete', 'patch') else 'get',
+                'enctype': enctype,
+                'parameters': params,
+                'has_csrf_token': csrf_info is not None,
+                'raw_html': _get_limited_raw_html(form),
+                'csrf_token': csrf_info,
+                'is_file_upload': has_file_input or (enctype in UPLOAD_ENCTYPES),
+                'risk_level': risk_level
+            })
+
+        except (AttributeError, TypeError) as e:
+            logger.warning("Form #%d parsing skipped: %s", i, e)
+            continue
+
+    return extracted_forms

--- a/parsers/html_parsers.py
+++ b/parsers/html_parsers.py
@@ -1,0 +1,98 @@
+# parsers/html_parsers.py
+
+"""
+html_parsers.py
+순수 HTML 파서 코어 엔진 (리팩토링 완료)
+- 단일 책임 원칙(SRP) 준수: 네트워크 통신 및 SSRF 검증은 SessionManager/URLFilter로 위임
+- 불필요한 aiohttp 의존성 및 네트워크 로직 제거
+- 순수하게 HTML 문자열을 BeautifulSoup 객체로 빠르고 안전하게 변환하는 역할만 수행
+"""
+
+from __future__ import annotations
+import logging
+from typing import Optional, TypedDict
+
+from bs4 import BeautifulSoup, FeatureNotFound
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+# ===== 불변 설정 상수 (Immutable Constants) =====
+PARSERS: tuple[str, ...] = ("lxml", "html.parsers", "html5lib")
+MAX_CONTENT_LENGTH: int = 50 * 1024 * 1024  # 50MB
+
+
+class ParseResult(TypedDict, total=False):
+    """파싱 결과를 담는 타입 정의"""
+    success: bool
+    soup: Optional[BeautifulSoup]
+    base_url: Optional[str]
+    error: Optional[str]
+
+
+class AsyncHTMLParser:
+    """단일 책임 원칙을 준수하는 경량 HTML 파서 엔진"""
+
+    @staticmethod
+    def _parse_html(html: str) -> BeautifulSoup:
+        """여러 파서를 순차적으로 시도하여 HTML 파싱 (폴백 로직)"""
+        for parser in PARSERS:
+            try:
+                return BeautifulSoup(html, parser)
+            except FeatureNotFound:
+                continue
+            except (TypeError, ValueError):
+                continue
+        # 모든 시도 실패 시 파이썬 내장 기본 파서 사용
+        return BeautifulSoup(html, "html.parsers")
+
+    @staticmethod
+    def parse_html_string(
+            html: str,
+            base_url: str = "",
+            max_length: int = MAX_CONTENT_LENGTH
+    ) -> ParseResult:
+        """
+        HTML 문자열을 직접 파싱 (크기 검사 포함)
+        ✨ [핵심 수정] CPU 바운드 작업이므로 호출자(Engine) 측에서
+        loop.run_in_executor()를 통해 비동기 블로킹 없이 실행되도록 설계되었습니다.
+        """
+        if not isinstance(html, str):
+            return {
+                "success": False,
+                "error": f"잘못된 입력 타입: {type(html).__name__} (str 필요)",
+                "base_url": base_url,
+            }
+
+        try:
+            # 1. 크기 제한 검증 (메모리 과부하/OOM 방지)
+            byte_size = len(html.encode("utf-8", errors="ignore"))
+            if byte_size > max_length:
+                return {
+                    "success": False,
+                    "error": f"입력 크기 초과: {byte_size} > {max_length} bytes",
+                    "base_url": base_url,
+                }
+
+            # 2. 파싱 수행
+            soup = AsyncHTMLParser._parse_html(html)
+            return {
+                "success": True,
+                "soup": soup,
+                "base_url": base_url,
+                "error": None,
+            }
+
+        except (TypeError, ValueError, FeatureNotFound) as exc:
+            return {
+                "success": False,
+                "error": f"파싱 오류: {type(exc).__name__}",
+                "base_url": base_url,
+            }
+        except Exception as exc:
+            logger.exception("파서 예외 발생")
+            return {
+                "success": False,
+                "error": f"예상치 못한 오류: {type(exc).__name__}",
+                "base_url": base_url,
+            }

--- a/parsers/link_extractor.py
+++ b/parsers/link_extractor.py
@@ -1,0 +1,343 @@
+import re
+import logging
+from urllib.parse import urljoin, urlparse, parse_qs
+from typing import Dict, List, Optional, Set, Union
+from bs4 import BeautifulSoup, Tag
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# 상수 (공통 관리)
+# ============================================================================
+
+IGNORED_SCHEMES = frozenset(['javascript', 'mailto', 'tel', 'data', 'blob', 'file'])
+
+CRITICAL_PARAMS = frozenset([
+    'id', 'user', 'uid', 'file', 'path', 'dir', 'url', 'redirect', 'next',
+    'cmd', 'exec', 'query', 'sql', 'token', 'key', 'admin', 'debug',
+    'page', 'template', 'include', 'callback', 'download', 'load'
+])
+
+API_INDICATORS = frozenset(['/api/', '/v1/', '/v2/', '/v3/', '/rest/', '/ajax/', '/graphql'])
+
+TARGET_RELS = frozenset(['canonical', 'next', 'prev', 'alternate'])
+
+JS_URL_PATTERNS = [
+    re.compile(r'''location\.href\s*=\s*["']([^"']{1,500})["']''', re.I),
+    re.compile(r'''window\.open\s*\(\s*["']([^"']{1,500})["']''', re.I),
+    re.compile(r'''\.href\s*=\s*["']([^"']{1,500})["']''', re.I),
+]
+
+META_REFRESH_PATTERN = re.compile(r'url\s*=\s*["\']?([^"\';\s>]{1,500})', re.I)
+
+
+# ============================================================================
+# 유틸리티
+# ============================================================================
+
+def get_attr(tag: Tag, attr: str, default: str = '') -> str:
+    if not isinstance(tag, Tag):
+        return default
+    value = tag.get(attr)
+    if value is None:
+        return default
+    if isinstance(value, list):
+        return value[0] if value else default
+    return str(value).strip()
+
+
+def get_rel(tag: Tag) -> Set[str]:
+    if not isinstance(tag, Tag):
+        return set()
+    value = tag.get('rel')
+    if not value:
+        return set()
+    if isinstance(value, list):
+        return {v.lower() for v in value}
+    return {str(value).lower()}
+
+
+def normalize_url(url: str, base_url: str) -> Optional[str]:
+    if not url or not isinstance(url, str):
+        return None
+
+    url = url.strip()
+    if not url or url == '#' or url.lower().startswith('javascript:'):
+        return None
+
+    try:
+        absolute = urljoin(base_url, url)
+        parsed = urlparse(absolute)
+
+        original_parsed = urlparse(url)
+        if original_parsed.scheme and original_parsed.scheme.lower() in IGNORED_SCHEMES:
+            return None
+
+        if parsed.scheme not in ('http', 'https'):
+            return None
+
+        return absolute
+    except Exception as e:
+        logger.debug("URL 정규화 실패: url=%s err=%s", url[:100], e)
+        return None
+
+
+def parse_params(url: str) -> Dict[str, str]: # ✨ [수정] 반환 타입을 Dict[str, str]로 고정
+    try:
+        # parse_qs의 결과: {'id': ['admin']}
+        qs = parse_qs(urlparse(url).query, keep_blank_values=True)
+        # ✨ [정규화] 리스트의 첫 번째 값만 취하여 문자열로 변환
+        return {k: v[0] if v else "" for k, v in qs.items()}
+    except Exception as e:
+        logger.debug("파라미터 파싱 실패: %s", e)
+        return {}
+
+
+def is_same_domain(url: str, base_domain: str) -> bool:
+    try:
+        domain = urlparse(url).netloc.lower()
+        base = base_domain.lower()
+        return domain == base or domain.endswith('.' + base)
+    except Exception as e:
+        logger.debug("도메인 검사 실패: url=%s err=%s", url[:100], e)
+        return False
+
+
+def make_seen_key(url: str, method: str = 'GET') -> str:
+    return f"{method.upper()}:{url.lower().rstrip('/')}"
+
+
+# ============================================================================
+# 추출 세부 로직
+# ============================================================================
+
+def extract_anchor_links(soup: BeautifulSoup, base_url: str, seen: Set[str]) -> List[dict]:
+    links = []
+    for tag in soup.find_all('a'):
+        href = get_attr(tag, 'href')
+        url = normalize_url(href, base_url)
+        if not url: continue
+
+        key = make_seen_key(url, 'GET')
+        if key in seen: continue
+        seen.add(key)
+
+        text = ''
+        try:
+            text = tag.get_text(strip=True)[:100]
+        except Exception:
+            pass
+
+        links.append({
+            'url': url, 'method': 'GET', 'params': parse_params(url),
+            'source': 'anchor', 'text': text
+        })
+    return links
+
+
+def extract_link_tags(soup: BeautifulSoup, base_url: str, seen: Set[str]) -> List[dict]:
+    links = []
+    for tag in soup.find_all('link'):
+        href = get_attr(tag, 'href')
+        url = normalize_url(href, base_url)
+        if not url: continue
+
+        rel_set = get_rel(tag)
+        if not rel_set & TARGET_RELS: continue
+
+        key = make_seen_key(url, 'GET')
+        if key in seen: continue
+        seen.add(key)
+
+        links.append({
+            'url': url, 'method': 'GET', 'params': parse_params(url),
+            'source': 'link_tag', 'rel': list(rel_set)
+        })
+    return links
+
+
+def extract_js_links(soup: BeautifulSoup, base_url: str, seen: Set[str]) -> List[dict]:
+    links = []
+    for script in soup.find_all('script'):
+        if get_attr(script, 'src'): continue
+        content = script.string or ''
+        if content:
+            links.extend(_extract_urls_from_js(content, base_url, seen, 'script'))
+
+    for attr in ('onclick', 'onmouseover', 'onload'):
+        for tag in soup.find_all(attrs={attr: True}):
+            handler = get_attr(tag, attr)
+            if handler:
+                links.extend(_extract_urls_from_js(handler, base_url, seen, f'event_{attr}'))
+
+    for attr in ('data-url', 'data-href', 'data-src', 'data-link'):
+        for tag in soup.find_all(attrs={attr: True}):
+            val = get_attr(tag, attr)
+            url = normalize_url(val, base_url)
+            if not url: continue
+
+            key = make_seen_key(url, 'GET')
+            if key in seen: continue
+            seen.add(key)
+
+            links.append({
+                'url': url, 'method': 'GET', 'params': parse_params(url), 'source': attr
+            })
+    return links
+
+
+def _extract_urls_from_js(content: str, base_url: str, seen: Set[str], source: str) -> List[dict]:
+    links = []
+    content = content[:50000]
+    for pattern in JS_URL_PATTERNS:
+        try:
+            for match in pattern.findall(content):
+                url = normalize_url(match, base_url)
+                if not url: continue
+
+                key = make_seen_key(url, 'GET')
+                if key in seen: continue
+                seen.add(key)
+
+                links.append({
+                    'url': url, 'method': 'GET', 'params': parse_params(url), 'source': source
+                })
+        except re.error as e:
+            logger.debug("정규식 오류: %s", e)
+    return links
+
+
+def extract_meta_refresh(soup: BeautifulSoup, base_url: str, seen: Set[str]) -> List[dict]:
+    links = []
+    for meta in soup.find_all('meta', attrs={'http-equiv': True}):
+        if get_attr(meta, 'http-equiv').lower() != 'refresh': continue
+
+        content = get_attr(meta, 'content')
+        if not content: continue
+
+        match = META_REFRESH_PATTERN.search(content)
+        if not match: continue
+
+        url = normalize_url(match.group(1), base_url)
+        if not url: continue
+
+        key = make_seen_key(url, 'GET')
+        if key in seen: continue
+        seen.add(key)
+
+        links.append({
+            'url': url, 'method': 'GET', 'params': parse_params(url), 'source': 'meta_refresh'
+        })
+    return links
+
+
+def extract_media_links(soup: BeautifulSoup, base_url: str, seen: Set[str]) -> List[dict]:
+    links = []
+    media_tags = [('iframe', 'src'), ('img', 'src'), ('video', 'src'), ('embed', 'src')]
+    for tag_name, attr_name in media_tags:
+        for tag in soup.find_all(tag_name):
+            src = get_attr(tag, attr_name)
+            url = normalize_url(src, base_url)
+            if not url: continue
+
+            params = parse_params(url)
+            if not params: continue
+
+            key = make_seen_key(url, 'GET')
+            if key in seen: continue
+            seen.add(key)
+
+            links.append({
+                'url': url, 'method': 'GET', 'params': params, 'source': f'media_{tag_name}'
+            })
+    return links
+
+
+# ============================================================================
+# 분석 및 인터페이스
+# ============================================================================
+
+def analyze_link(link: dict) -> None:
+    """공격 지점(Attack Surface) 우선순위 분석"""
+    params = link.get('params', {})
+    param_names = {k.lower() for k in params.keys()}
+
+    critical = list(param_names & CRITICAL_PARAMS)
+    link['critical_params'] = critical
+
+    url_path = urlparse(link.get('url', '')).path.lower()
+    link['is_api'] = any(indicator in url_path for indicator in API_INDICATORS)
+
+    score = len(critical) * 2
+    if link['is_api']: score += 2
+    if link.get('method') == 'POST': score += 1
+    if len(params) > 5: score += 1
+    link['risk_score'] = min(score, 10)
+
+
+def extract_links(
+        html_or_soup: Union[str, BeautifulSoup],
+        base_url: str,
+        include_external: bool = False,
+        include_js: bool = True,
+        include_media: bool = True,
+        include_meta: bool = True,
+) -> List[dict]:
+    """
+    HTML 소스 또는 파싱된 객체로부터 링크 추출
+    (폼 추출은 form_extractor 모듈에서 전담)
+    """
+    if not html_or_soup or not base_url: return []
+
+    if isinstance(html_or_soup, str):
+        try:
+            soup = BeautifulSoup(html_or_soup, 'html.parsers')
+        except Exception as e:
+            logger.error("HTML 파싱 실패: %s", e)
+            return []
+    elif isinstance(html_or_soup, BeautifulSoup):
+        soup = html_or_soup
+    else:
+        logger.error("지원하지 않는 타입: %s", type(html_or_soup).__name__)
+        return []
+
+    base_domain = urlparse(base_url).netloc.lower()
+    seen: Set[str] = set()
+    links: List[dict] = []
+
+    links.extend(extract_anchor_links(soup, base_url, seen))
+
+    if include_meta:
+        links.extend(extract_link_tags(soup, base_url, seen))
+        links.extend(extract_meta_refresh(soup, base_url, seen))
+
+    if include_js:
+        links.extend(extract_js_links(soup, base_url, seen))
+
+    if include_media:
+        links.extend(extract_media_links(soup, base_url, seen))
+
+    if not include_external:
+        links = [l for l in links if is_same_domain(l['url'], base_domain)]
+
+    for link in links:
+        analyze_link(link)
+
+    return links
+
+
+def get_summary(links: List[dict]) -> dict:
+    if not links: return {'total': 0}
+    methods, sources = {}, {}
+    for link in links:
+        m = link.get('method', 'GET')
+        methods[m] = methods.get(m, 0) + 1
+        s = link.get('source', 'unknown')
+        sources[s] = sources.get(s, 0) + 1
+
+    return {
+        'total': len(links), 'methods': methods, 'sources': sources,
+        'with_params': sum(1 for l in links if l.get('params')),
+        'with_critical': sum(1 for l in links if l.get('critical_params')),
+        'high_risk': sum(1 for l in links if l.get('risk_score', 0) >= 7),
+    }

--- a/parsers/surface_builder.py
+++ b/parsers/surface_builder.py
@@ -1,0 +1,176 @@
+# core/surface_builder.py
+
+import hashlib
+import logging
+import asyncio
+from typing import Callable, Awaitable, Set, List, Union, Dict, Any
+from urllib.parse import urlparse, urlunparse
+from bs4 import BeautifulSoup
+
+from core.models import PageData, AttackSurface, HttpMethod, ParamLocation
+from parsers import form_extractor, link_extractor
+
+logger = logging.getLogger(__name__)
+
+SurfaceCallback = Callable[[AttackSurface], Union[Awaitable[None], None]]
+
+
+class SurfaceBuilder:
+    """
+    공격 표면 빌더
+    - 중복 파싱 방지 (Soup 재사용)
+    - 동적 토큰(CSRF 등) 자동 병합
+    - URL 쿼리스트링 중복 제거 및 파라미터 타입 평탄화 (Fuzzer 호환성)
+    - 퍼저 콜백 직송
+    ✨ [핵심 수정] CPU 집약적 추출 작업을 스레드 풀(Executor)로 위임하여 루프 블로킹 방지
+    """
+
+    def __init__(self, fuzzer_callback: SurfaceCallback):
+        self.fuzzer_callback = fuzzer_callback
+        self._seen_signatures: Set[str] = set()
+
+    @staticmethod
+    def _generate_signature(surface: AttackSurface) -> str:
+        """AttackSurface의 고유 해시 생성 (중복 제거용)"""
+        param_keys = str(sorted(surface.parameters.keys()))
+        raw = f"{surface.url}:{surface.method.value}:{surface.param_location.value}:{param_keys}"
+        return hashlib.md5(raw.encode()).hexdigest()
+
+    @staticmethod
+    def _strip_query_string(url: str) -> str:
+        """✅ [수정] URL에서 쿼리스트링(?id=1)을 제거하여 중복 결합 방지"""
+        parsed = urlparse(url)
+        # scheme, netloc, path, params, query(제거), fragment
+        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', parsed.fragment))
+
+    @staticmethod
+    def _normalize_parameters(raw_params: Dict[str, Any]) -> Dict[str, str]:
+        """✅ [수정] Fuzzer에서 TypeError가 발생하지 않도록 모든 값을 단일 문자열로 평탄화"""
+        normalized = {}
+        for key, value in raw_params.items():
+            if isinstance(value, list):
+                # 리스트인 경우 첫 번째 값만 취하거나 빈 문자열 처리
+                normalized[key] = str(value[0]) if value else ""
+            else:
+                normalized[key] = str(value)
+        return normalized
+
+    def _extract_surfaces_sync(self, page_data: PageData) -> List[AttackSurface]:
+        """
+        ✨ [핵심 수정] CPU를 집중적으로 사용하는 동기식 데이터 추출 및 정제 로직
+        이 메서드는 메인 이벤트 루프를 막지 않기 위해 별도의 스레드에서 실행됩니다.
+        """
+        surfaces: List[AttackSurface] = []
+
+        # CrawlerEngine에서 만든 soup이 있으면 재사용, 없으면 1회만 파싱
+        if isinstance(page_data.soup, BeautifulSoup):
+            source_soup = page_data.soup
+        else:
+            source_soup = BeautifulSoup(page_data.html, 'html.parsers')
+
+        # ==========================================
+        # 1. HTML Form 기반 AttackSurface 추출
+        # ==========================================
+        forms = form_extractor.extract_forms(source_soup, base_url=page_data.url)
+
+        for form in forms:
+            method_str = str(form.get('method', 'GET')).upper()
+            try:
+                method = HttpMethod(method_str)
+            except ValueError:
+                method = HttpMethod.GET
+
+            loc = ParamLocation.BODY_FORM if method in (HttpMethod.POST, HttpMethod.PUT) \
+                else ParamLocation.QUERY
+
+            action_url = str(form.get('action')) if form.get('action') else str(page_data.url)
+
+            # Form의 action URL에도 쿼리스트링이 있을 수 있으므로 정제
+            safe_url = self._strip_query_string(action_url) if loc == ParamLocation.QUERY else action_url
+
+            # 파라미터 평탄화(List 제거) 및 동적 토큰 병합
+            parameters = self._normalize_parameters(form.get('parameters', {}))
+            if page_data.dynamic_tokens:
+                parameters.update(page_data.dynamic_tokens)
+
+            surfaces.append(AttackSurface(
+                url=safe_url,
+                method=method,
+                param_location=loc,
+                parameters=parameters,
+                headers=page_data.headers,
+                cookies=page_data.cookies,
+                dynamic_tokens=page_data.dynamic_tokens.copy(),
+                source_url=str(page_data.url),
+                description=f"Form (risk: {form.get('risk_level')}, tokens: {len(page_data.dynamic_tokens)})"
+            ))
+
+        # ==========================================
+        # 2. URL 파라미터(Link) 기반 AttackSurface 추출
+        # ==========================================
+        links = link_extractor.extract_links(source_soup, base_url=page_data.url)
+
+        for link in links:
+            if not link.get('params'): continue
+
+            method_str = str(link.get('method', 'GET')).upper()
+            try:
+                method = HttpMethod(method_str)
+            except ValueError:
+                method = HttpMethod.GET
+
+            # ✅ URL 쿼리스트링 제거 (파라미터는 parameters 딕셔너리로 분리되어 넘어감)
+            raw_url = str(link.get('url', ''))
+            clean_url = self._strip_query_string(raw_url)
+
+            # 파라미터 평탄화(List 제거) 및 동적 토큰 병합
+            parameters = self._normalize_parameters(link.get('params', {}))
+            if page_data.dynamic_tokens:
+                parameters.update(page_data.dynamic_tokens)
+
+            surfaces.append(AttackSurface(
+                url=clean_url,
+                method=method,
+                param_location=ParamLocation.QUERY,
+                parameters=parameters,
+                headers=page_data.headers,
+                cookies=page_data.cookies,
+                dynamic_tokens=page_data.dynamic_tokens.copy(),
+                source_url=str(page_data.url),
+                description="Link Query Params"
+            ))
+
+        return surfaces
+
+    async def process_page(self, page_data: PageData) -> None:
+        """
+        PageData를 분석하여 AttackSurface를 추출하고 퍼저로 직배송
+        ✨ [핵심 수정] run_in_executor를 통한 비동기 논블로킹(Non-blocking) 호출 적용
+        """
+        loop = asyncio.get_running_loop()
+
+        # CPU 연산이 많은 DOM 순회 및 파싱 로직을 스레드 풀로 넘겨 크롤러 통신 지연 방지
+        surfaces = await loop.run_in_executor(
+            None, self._extract_surfaces_sync, page_data
+        )
+
+        # ==========================================
+        # 3. 중복 검증 및 퍼저 콜백 호출 (이벤트 루프에서 가볍게 처리)
+        # ==========================================
+        for surface in surfaces:
+            if not surface.url: continue
+
+            sig = self._generate_signature(surface)
+            if sig in self._seen_signatures: continue
+
+            self._seen_signatures.add(sig)
+
+            logger.debug(f"[SurfaceBuilder] 퍼저로 전송: {surface.url}")
+
+            # 콜백 실행 (퍼저로 전달)
+            result = self.fuzzer_callback(surface)
+            if asyncio.iscoroutine(result):
+                await result
+
+    def get_stats(self) -> dict:
+        return {"unique_surfaces_sent": len(self._seen_signatures)}


### PR DESCRIPTION
## 📌 PR 목적 (What)
기존의 parser 폴더명이 파이썬 내장 표준 라이브러리인 parser 모듈과 이름이 중복되어 발생하는 모듈 섀도잉(Module Shadowing) 문제를 해결하기 위한 리팩토링, 이 변경을 통해 시스템의 안정성을 확보하고 의도치 않은 ImportError를 방지
## 🛠️ 주요 변경 사항 (How)
1. 디렉토리 명칭 변경
parser/ ➡️ parsers/
파이썬 환경에서 내장 모듈보다 프로젝트 로컬 폴더가 우선적으로 로드되는 특성상, 내장 기능을 호출해야 하는 외부 라이브러리와의 충돌 가능성을 완전히 제거
2. 임포트 경로 일괄 업데이트
폴더 이름 변경에 따라 해당 패키지를 참조하는 모든 코드의 경로를 수정
