### PR TITLE
[fix] 리팩토링 중 발생한 BeautifulSoup 파서 문자열 오타 원복

### DIFF
--- a/crawler/session_manager.py
+++ b/crawler/session_manager.py
@@ -104,7 +104,7 @@ class SessionManager:
     @staticmethod
     def _extract_csrf_token(html: str, token_name: str) -> Optional[str]:
         try:
-            soup = BeautifulSoup(html, 'html.parsers')
+            soup = BeautifulSoup(html, 'html.parser')
             token_input = soup.find('input', {'name': token_name})
 
             val = SessionManager._get_safe_attr(token_input, 'value')

--- a/parsers/html_parser.py
+++ b/parsers/html_parser.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # ===== 불변 설정 상수 (Immutable Constants) =====
-PARSERS: tuple[str, ...] = ("lxml", "html.parsers", "html5lib")
+PARSERS: tuple[str, ...] = ("lxml", "html.parser", "html5lib")
 MAX_CONTENT_LENGTH: int = 50 * 1024 * 1024  # 50MB
 
 
@@ -44,7 +44,7 @@ class AsyncHTMLParser:
             except (TypeError, ValueError):
                 continue
         # 모든 시도 실패 시 파이썬 내장 기본 파서 사용
-        return BeautifulSoup(html, "html.parsers")
+        return BeautifulSoup(html, "html.parser")
 
     @staticmethod
     def parse_html_string(

--- a/parsers/link_extractor.py
+++ b/parsers/link_extractor.py
@@ -291,7 +291,7 @@ def extract_links(
 
     if isinstance(html_or_soup, str):
         try:
-            soup = BeautifulSoup(html_or_soup, 'html.parsers')
+            soup = BeautifulSoup(html_or_soup, 'html.parser')
         except Exception as e:
             logger.error("HTML 파싱 실패: %s", e)
             return []

--- a/parsers/surface_builder.py
+++ b/parsers/surface_builder.py
@@ -66,7 +66,7 @@ class SurfaceBuilder:
         if isinstance(page_data.soup, BeautifulSoup):
             source_soup = page_data.soup
         else:
-            source_soup = BeautifulSoup(page_data.html, 'html.parsers')
+            source_soup = BeautifulSoup(page_data.html, 'html.parser')
 
         # ==========================================
         # 1. HTML Form 기반 AttackSurface 추출


### PR DESCRIPTION
## 📌 PR 목적 (What)
크롤러 엔진 구동 시 발생하는 FeatureNotFound 파싱 오류를 해결하여, 중단되었던 공격 표면(Attack Surface) 추출 파이프라인을 정상 복구
## 🛠️ 주요 변경 사항 (How)
아래 파일들에서 잘못 변경된 'html.parsers' 문자열을 다시 올바른 내장 파서 명칭인 'html.parser'(단수형)로 롤백
`crawler/session_manager.py`
`parsers/html_parser.py`
`parsers/form_extractor.py`
`parsers/link_extractor.py`
`parsers/surface_builder.py`
