### PR TITLE
[fix] 리팩토링 중 발생한 BeautifulSoup 파서 문자열 오타 원복

### DIFF
--- a/parsers/form_extractor.py
+++ b/parsers/form_extractor.py
@@ -58,7 +58,7 @@ def extract_forms(
     """
     HTML에서 폼 정보를 추출하여 정형화된 데이터로 반환
     """
-    soup = BeautifulSoup(html, 'html.parsers') if isinstance(html, str) else html
+    soup = BeautifulSoup(html, 'html.parser') if isinstance(html, str) else html
     extracted_forms: List[FormInfo] = []
 
     for i, form in enumerate(soup.find_all('form')):


### PR DESCRIPTION
## 📌 PR 목적 (What)
크롤러 엔진 구동 시 발생하는 FeatureNotFound 파싱 오류를 해결하여, 중단되었던 공격 표면(Attack Surface) 추출 파이프라인을 정상 복구

## 🛠️ 주요 변경 사항 (How)
 잘못 변경된 'html.parsers' 문자열을 다시 올바른 내장 파서 명칭인 'html.parser'(단수형)로 롤백
`parsers/form_extractor.py`