### PR TITLE
[refactor] 브루트 포스 상세 로그 제거, 전체 실행 시 브루트 포스 제외

### DIFF
--- a/cli/parser.py
+++ b/cli/parser.py
@@ -41,7 +41,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default="all",
         choices=["sqli", "bruteforce", "lfi", "file_upload", "ssrf", "all"],
-        help="Attack category to run (default: all)",
+        help="Attack category to run (default: all, excludes bruteforce)",
     )
     parser.add_argument(
         "--bf-wordlist",

--- a/fuzzer/setup.py
+++ b/fuzzer/setup.py
@@ -24,7 +24,7 @@ def select_modules(args) -> list:
         )
         selected.append(sqli_module)
 
-    if args.type in ("bruteforce", "all"):
+    if args.type == "bruteforce":
         bruteforce_module = BruteforceModule(
             wordlist_path=args.bf_wordlist,
             enable_mutation=not args.bf_disable_mutation,

--- a/mock_parser.py
+++ b/mock_parser.py
@@ -77,18 +77,18 @@ def get_dvwa_mock_surfaces(
         #     description="DVWA Brute Force (GET, with CSRF token)",
         #     dynamic_tokens=["user_token"],
         # ),
-        # AttackSurface(
-        #     url=f"{root}/vulnerabilities/brute/",
-        #     method=HttpMethod.GET,
-        #     param_location=ParamLocation.QUERY,
-        #     parameters={
-        #         "username": "admin",
-        #         "password": "password",
-        #         "Login": "Login",
-        #     },
-        #     cookies=auth_cookies,
-        #     description="DVWA Brute Force (GET, no CSRF token)",
-        # ),
+        AttackSurface(
+            url=f"{root}/vulnerabilities/brute/",
+            method=HttpMethod.GET,
+            param_location=ParamLocation.QUERY,
+            parameters={
+                "username": "admin",
+                "password": "password",
+                "Login": "Login",
+            },
+            cookies=auth_cookies,
+            description="DVWA Brute Force (GET, no CSRF token)",
+        ),
         # AttackSurface(
         #     url=f"{root}/vulnerabilities/sqli/",
         #     method=HttpMethod.GET,
@@ -134,14 +134,14 @@ def get_dvwa_mock_surfaces(
         #     cookies=auth_cookies,
         #     description="DVWA DOM XSS (GET)",
         # ),
-        AttackSurface(
-            url=f"{root}/test_ssrf.php/",
-            method=HttpMethod.GET,
-            param_location=ParamLocation.QUERY,
-            parameters={"url": "http://example.com"},
-            cookies=auth_cookies,
-            description="DVWA SSRF(GET)",
-        ),
+        # AttackSurface(
+        #     url=f"{root}/test_ssrf.php/",
+        #     method=HttpMethod.GET,
+        #     param_location=ParamLocation.QUERY,
+        #     parameters={"url": "http://example.com"},
+        #     cookies=auth_cookies,
+        #     description="DVWA SSRF(GET)",
+        # ),
     ]
 
 

--- a/modules/bruteforce/module.py
+++ b/modules/bruteforce/module.py
@@ -91,16 +91,11 @@ class BruteforceModule(BaseModule):
         return [p for p in parameters if surface_params.get(p) == _FUZZ]
 
     def analyze(self, response, payload, elapsed_time, original_res=None, requester=None) -> bool:
-        print(f"[*] [{self.name}] Trying payload: {payload.value}")
-        is_success, evidences = detect_login_success(
+        is_success, _ = detect_login_success(
             response=response,
             payload=payload,
             original_res=original_res,
             success_keywords=self.success_keywords,
             fail_keywords=self.fail_keywords,
         )
-        if is_success:
-            print(f"[+] [{self.name}] Valid credential candidate: {payload.value}")
-            for evidence in evidences:
-                print(f"    -> {evidence}")
         return is_success

--- a/modules/registry.py
+++ b/modules/registry.py
@@ -21,6 +21,10 @@ def get_attack_modules(attack_type: str) -> list[BaseModule]:
         "file_upload": FileUploadModule,
     }
     if attack_type == "all":
-        return [factory() for factory in factories.values()]
+        return [
+            factory()
+            for name, factory in factories.items()
+            if name != "bruteforce"
+        ]
     factory = factories.get(attack_type)
     return [factory()] if factory else []


### PR DESCRIPTION
## 📌 PR 목적 (What)
- 브루트 포스 실행 시 테스트를 위해 구현했던 상세 로그 삭제
- `-t all` 옵션에서 브루트 포스 제외
## 🛠️ 주요 변경 사항 (How)
- 브루트 포스 상세 로그 삭제
- `-t all` 옵션에서 브루트 포스 제외하고 '-t bruteforce'로 명시 실행만 가능하도록 변경

## ✅ 다음 작업 (Next Step)
- 퍼저 통합 테스트
