### PR TITLE
[fix] parsers 배열형 파라미터 보존 및 추출 프로세스 Executor 위임

### DIFF
--- a/parsers/link_extractor.py
+++ b/parsers/link_extractor.py
@@ -82,12 +82,12 @@ def normalize_url(url: str, base_url: str) -> Optional[str]:
         return None
 
 
-def parse_params(url: str) -> Dict[str, str]: # ✨ [수정] 반환 타입을 Dict[str, str]로 고정
+# 기존 Dict[str, str] 에서 Dict[str, Union[str, List[str]]] 로 타입 변경
+def parse_params(url: str) -> Dict[str, Union[str, List[str]]]:
     try:
-        # parse_qs의 결과: {'id': ['admin']}
         qs = parse_qs(urlparse(url).query, keep_blank_values=True)
-        # ✨ [정규화] 리스트의 첫 번째 값만 취하여 문자열로 변환
-        return {k: v[0] if v else "" for k, v in qs.items()}
+        # ✨ [보안 수정 2] 리스트 값이 여러 개면 리스트를 유지하고, 하나면 문자열로 변환
+        return {k: v if len(v) > 1 else (v[0] if v else "") for k, v in qs.items()}
     except Exception as e:
         logger.debug("파라미터 파싱 실패: %s", e)
         return {}

--- a/parsers/surface_builder.py
+++ b/parsers/surface_builder.py
@@ -44,13 +44,13 @@ class SurfaceBuilder:
         return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', parsed.fragment))
 
     @staticmethod
-    def _normalize_parameters(raw_params: Dict[str, Any]) -> Dict[str, str]:
-        """✅ [수정] Fuzzer에서 TypeError가 발생하지 않도록 모든 값을 단일 문자열로 평탄화"""
+    def _normalize_parameters(raw_params: Dict[str, Any]) -> Dict[str, Union[str, List[str]]]:
+        """✅ [보안 수정 2] 배열 기반 페이로드(SQLi 등) 대응을 위해 리스트 형태 유지"""
         normalized = {}
         for key, value in raw_params.items():
             if isinstance(value, list):
-                # 리스트인 경우 첫 번째 값만 취하거나 빈 문자열 처리
-                normalized[key] = str(value[0]) if value else ""
+                # 리스트 내부 요소만 문자열로 안전하게 치환하며 배열 구조 보존
+                normalized[key] = [str(v) for v in value]
             else:
                 normalized[key] = str(value)
         return normalized
@@ -155,7 +155,7 @@ class SurfaceBuilder:
         )
 
         # ==========================================
-        # 3. 중복 검증 및 퍼저 콜백 호출 (이벤트 루프에서 가볍게 처리)
+        # 4.. 중복 검증 및 퍼저 콜백 호출 (이벤트 루프에서 가볍게 처리)
         # ==========================================
         for surface in surfaces:
             if not surface.url: continue


### PR DESCRIPTION
## 📌 PR 목적 (What)
Parsers: 공격 표면 추출 정밀도 및 성능 향
## 🛠️ 주요 변경 사항 (How)
`link_extractor.py`: 기존에 첫 번째 값만 취하던 로직을 수정하여, 중복 파라미터가 존재할 경우 모든 값을 리스트로 보존하도록 parse_params를 업데이트
`surface_builder.py`: 공격 표면 추출 과정에서의 연산 병목을 해결하기 위해 run_in_executor를 적용
`surface_builder.py`: AttackSurface 생성 시 dynamic_tokens(CSRF 등)를 명시적으로 복사하여 포함시키고, 쿼리스트링 정규화(_strip_query_string)를 통해 중복 타겟 생성을 방지