### PR TITLE
[fix] 크롤러-파서 종료 동기화 및 큐 데이터 유실 문제 해결

### DIFF
--- a/crawler/engine.py
+++ b/crawler/engine.py
@@ -4,8 +4,6 @@ import asyncio
 from urllib.parse import urljoin, urlparse
 from datetime import datetime
 from contextlib import asynccontextmanager
-
-# ✨ [수정] 통합된 models.py에서 PageData, TokenDetector, CrawlStats를 가져옴
 from core.models import PageData, TokenDetector, CrawlStats
 from parsers.html_parser import AsyncHTMLParser
 from crawler.session_manager import SessionManager
@@ -71,6 +69,11 @@ class CrawlerEngine:
 
         async with self._session_context():
             await self._run_workers()
+
+        # ✨ [핵심 수정] 모든 워커가 종료된 후, 파서 컨슈머에게 종료 신호 전송
+        # QueueManager를 통해 큐에 None을 전달하여 파서(SurfaceBuilder)가 남은 데이터를 처리하고 종료되게 합니다.
+        await self.queue_manager.add_page(None)
+        logger.info("[Engine] 파서 종료 신호(Sentinel) 전송 완료")
 
         self._stats.end_time = datetime.now()
         self._log_summary()
@@ -196,7 +199,7 @@ class CrawlerEngine:
             forms_found = 0
             links_found = 0
 
-            # 폼 & 동적 토  큰 추출
+            # 폼 & 동적 토큰 추출
             for form in soup_obj.find_all("form"):
                 forms_found += 1
                 for input_field in form.find_all(["input", "textarea", "select"]):

--- a/parsers/surface_builder.py
+++ b/parsers/surface_builder.py
@@ -22,12 +22,30 @@ class SurfaceBuilder:
     - 동적 토큰(CSRF 등) 자동 병합
     - URL 쿼리스트링 중복 제거 및 파라미터 타입 평탄화 (Fuzzer 호환성)
     - 퍼저 콜백 직송
-    ✨ [핵심 수정] CPU 집약적 추출 작업을 스레드 풀(Executor)로 위임하여 루프 블로킹 방지
+    - [추가] 큐 소비(Consumer) 로직 통합
     """
 
     def __init__(self, fuzzer_callback: SurfaceCallback):
         self.fuzzer_callback = fuzzer_callback
         self._seen_signatures: Set[str] = set()
+
+    async def consume_from_queue(self, queue_manager):
+        """
+        ✨ [신규] 큐에서 데이터를 직접 꺼내서 처리하는 Consumer 역할 수행
+        Sentinel(None) 신호를 받으면 큐에 남은 데이터를 모두 처리하고 안전하게 종료됩니다.
+        """
+        logger.info("[SurfaceBuilder] 큐 데이터 소비 루프를 시작합니다.")
+        while True:
+            # 큐에서 데이터를 가져옴 (데이터가 올 때까지 비동기 대기)
+            page_data = await queue_manager.get_page()
+
+            # 엔진이 보낸 종료 신호(None) 확인
+            if page_data is None:
+                logger.info("[SurfaceBuilder] 모든 데이터 처리가 완료되어 컨슈머를 종료합니다.")
+                break
+
+            # 페이지 분석 및 AttackSurface 추출 실행
+            await self.process_page(page_data)
 
     @staticmethod
     def _generate_signature(surface: AttackSurface) -> str:


### PR DESCRIPTION
## 📌 PR 목적 (What)
데이터 유실(Data Loss) 방지 및 종료 동기화: 크롤러가 목표치를 채우고 먼저 종료될 때, 큐에 남아 대기 중이던 PageData가 파서에 의해 처리되지 못하고 증발하는 크리티컬한 문제 해결
## 🛠️ 주요 변경 사항 (How)
`crawler/engine.py`: 크롤링 워커들이 모든 작업을 완료한 직후(start 메서드 종료 전), 비동기 큐에 Sentinel(종료 신호인 None)을 삽입하는 로직 추가
`core/surface_builder.py` 큐에서 데이터를 직접 꺼내어 처리하는 consume_from_queue(self, queue_manager) 비동기 메서드를 신규 추가하여 Consumer 역할을 내재화
## 💡 리뷰어 참고 사항
실행 시cli에서 await asyncio.gather(engine.start(), builder.consume_from_queue()) 형태로 즉시 동시 실행이 가능