### PR TITLE
[feat] dynamic_token에 포함된 파라미터를 퍼저의 공격 대상에서 제외

### DIFF
--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -577,10 +577,29 @@ class FuzzerEngine:
             print(f"[*] [{module.name}] stop-on-first-hit triggered; skipping remaining payloads.")
 
     @staticmethod
-    def _iter_parameters(surface: AttackSurface) -> Iterable[str]:
+    def _dynamic_token_names(surface: AttackSurface) -> set[str]:
+        raw_tokens = getattr(surface, "dynamic_tokens", None)
+        if not raw_tokens:
+            return set()
+        if isinstance(raw_tokens, dict):
+            return {str(name) for name in raw_tokens.keys() if str(name)}
+        if isinstance(raw_tokens, (list, tuple, set)):
+            return {str(name) for name in raw_tokens if str(name)}
+        token_name = str(raw_tokens).strip()
+        return {token_name} if token_name else set()
+
+    @classmethod
+    def _iter_parameters(cls, surface: AttackSurface) -> Iterable[str]:
         params = getattr(surface, "parameters", None)
+        dynamic_token_names = cls._dynamic_token_names(surface)
         if params is None:
             return ()
         if isinstance(params, dict):
-            return params.keys()
-        return tuple(str(p) for p in params)
+            return tuple(
+                key for key in params.keys()
+                if str(key) not in dynamic_token_names
+            )
+        return tuple(
+            str(p) for p in params
+            if str(p) not in dynamic_token_names
+        )


### PR DESCRIPTION
## 📌 PR 목적 (What)
파서와의 동기화를 위해 dynamic_token에 포함된 파라미터를 퍼저의 공격 대상에서 제외.
## 🛠️ 주요 변경 사항 (How)
- `fuzzer/engine.py`에서 파라미터 순회 로직을 수정.
- `_iter_parameters()`에서 해당 이름들을 필터링하도록 변경.
## 💡 리뷰어 참고 사항
**@팀A:**
동적 토큰(CSRF 등) 원본 유지 (Payload 덮어쓰기 주의)를 위해 퍼저 자체에서 처리하였습니다.
