### PR TITLE
[fix] 통합을 위한 핵심 데이터 모델 확장 및 파이프라인 연동 완료

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Awaitable, Dict
+from typing import Any, Callable, Awaitable
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class CrawlStatus(str, Enum):
 
 
 # ============================================================
-# 핵심 서비스 DTO (AttackSurface & TokenDetector & PageData)
+# 핵심 서비스 DTO (추가된 TokenDetector & PageData)
 # ============================================================
 
 class TokenDetector:
@@ -90,21 +90,20 @@ class PageData:
             url: str,
             html: str,
             depth: int = 0,
-            headers: Dict[str, str] = None,
-            cookies: Dict[str, str] = None,
-            dynamic_tokens: Dict[str, str] = None,
-            soup: Any = None  # ✨ [추가] 파싱된 BeautifulSoup 객체를 담을 필드
+            headers: dict[str, str] | None = None,
+            cookies: dict[str, str] | None = None,
+            dynamic_tokens: list[str] | None = None,
+            soup: Any = None
     ):
         self.url = url
         self.html = html
         self.depth = depth
         self.headers = headers if headers is not None else {}
         self.cookies = cookies if cookies is not None else {}
-        self.dynamic_tokens = dynamic_tokens if dynamic_tokens is not None else {}
-        self.soup = soup  # ✨ [추가] 파서로부터 전달받은 soup 저장
+        self.dynamic_tokens = dynamic_tokens if dynamic_tokens is not None else []
+        self.soup = soup  # 파서로부터 전달받은 soup 저장
 
     def __repr__(self) -> str:
-        # ✨ 모든 메타데이터의 상태를 한눈에 파악할 수 있도록 구성
         return (f"PageData(url='{self.url}', "
                 f"depth={self.depth}, "
                 f"headers={len(self.headers)}, "
@@ -120,10 +119,10 @@ class AttackSurface:
     url: str
     method: HttpMethod = HttpMethod.GET
     param_location: ParamLocation = ParamLocation.QUERY
-    parameters: dict[str, str] = field(default_factory=dict)
+    parameters: dict[str, Any] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
     cookies: dict[str, str] = field(default_factory=dict)
-    dynamic_tokens: dict[str, str] = field(default_factory=dict)
+    dynamic_tokens: list[str] = field(default_factory=list)
     source_url: str | None = None
     description: str | None = None
     depth: int = 0
@@ -160,7 +159,7 @@ class AttackSurface:
             parameters=data.get('parameters', {}),
             headers=data.get('headers', {}),
             cookies=data.get('cookies', {}),
-            dynamic_tokens=data.get('dynamic_tokens', {}),
+            dynamic_tokens=data.get('dynamic_tokens', []),
             source_url=data.get('source_url'),
             description=data.get('description'),
             depth=data.get('depth', 0),

--- a/crawler/engine.py
+++ b/crawler/engine.py
@@ -194,7 +194,7 @@ class CrawlerEngine:
 
         # ✨ [수정/참고사항 반영] 무거운 DOM 순회 로직(find_all)을 스레드 풀로 위임
         def _extract_data_sync(soup_obj, base_url):
-            tokens = {}
+            tokens = []
             next_urls = set()
             forms_found = 0
             links_found = 0
@@ -208,7 +208,7 @@ class CrawlerEngine:
                     value = input_field.get("value", "")
                     input_type = input_field.get("type", "text")
                     if TokenDetector.detect(name, value, input_type):
-                        tokens[name] = value
+                        tokens.append(f"{name}={value}")
 
             # 다음 크롤링 대상 URL 추출
             for a in soup_obj.find_all("a", href=True):
@@ -227,7 +227,7 @@ class CrawlerEngine:
         # 3. 추출된 통계 업데이트 및 토큰 병합
         self._stats.total_forms_found += forms_cnt
         self._stats.total_links_found += links_cnt
-        page.dynamic_tokens.update(tokens)
+        page.dynamic_tokens.extend(tokens)
 
         # 4. 비동기 큐 매니저로 전달
         await self.queue_manager.add_page(page)

--- a/parsers/surface_builder.py
+++ b/parsers/surface_builder.py
@@ -106,10 +106,15 @@ class SurfaceBuilder:
             # Form의 action URL에도 쿼리스트링이 있을 수 있으므로 정제
             safe_url = self._strip_query_string(action_url) if loc == ParamLocation.QUERY else action_url
 
-            # 파라미터 평탄화(List 제거) 및 동적 토큰 병합
-            parameters = self._normalize_parameters(form.get('parameters', {}))
+            normalized_params = self._normalize_parameters(form.get('parameters', {}))
+            parameters: dict[str, Any] = dict(normalized_params)
+
             if page_data.dynamic_tokens:
-                parameters.update(page_data.dynamic_tokens)
+                for token_str in page_data.dynamic_tokens:
+                    if "=" in token_str:
+                        parts = token_str.split("=", 1)
+                        if len(parts) == 2:
+                            parameters[parts[0]] = parts[1]
 
             surfaces.append(AttackSurface(
                 url=safe_url,
@@ -141,10 +146,16 @@ class SurfaceBuilder:
             raw_url = str(link.get('url', ''))
             clean_url = self._strip_query_string(raw_url)
 
-            # 파라미터 평탄화(List 제거) 및 동적 토큰 병합
-            parameters = self._normalize_parameters(link.get('params', {}))
+            normalized_params = self._normalize_parameters(link.get('params', {}))
+            # ✨ 타입 충돌 방지용 새 딕셔너리
+            parameters: dict[str, Any] = dict(normalized_params)
             if page_data.dynamic_tokens:
-                parameters.update(page_data.dynamic_tokens)
+                # ✨ 리스트 안의 "이름=값" 문자열을 쪼개서 parameters 딕셔너리에 삽입
+                for token_str in page_data.dynamic_tokens:
+                    if "=" in token_str:
+                        parts = token_str.split("=", 1)
+                        if len(parts) == 2:
+                            parameters[parts[0]] = parts[1]
 
             surfaces.append(AttackSurface(
                 url=clean_url,


### PR DESCRIPTION
## 📌 PR 목적 (What)
통합 전 핵심 데이터 모델 확장 및 수정
수정에 따른 코드 수
## 🛠️ 주요 변경 사항 (How)
1.핵심 데이터 모델 확장 및 호환성 유지
TokenDetector 클래스 추가: 정규식 및 키워드 기반으로 폼/파라미터 내의 CSRF 토큰, Nonce 등을 자동 감지하는 유틸리티 구현.
PageData DTO 도입: 파싱 효율을 높이기 위해 크롤러 엔진에서 파싱한 BeautifulSoup 객체(soup)를 PageData에 담아 파서로 전달하도록 구조 변경.
AttackSurface DTO 호환성 유지: 기존 Fuzzer 엔진의 구조를 깨지 않기 위해 parameters는 dict[str, Any]로, dynamic_tokens는 list[str] 형태로 타입을 유지
2. 크롤러 엔진파싱 최적화
무거운 DOM 순회 및 파싱 로직을 run_in_executor를 통해 스레드 풀로 위임하여 메인 이벤트 루프의 블로킹 방지
탐지된 동적 토큰을 PageData.dynamic_tokens 리스트에 "키=값" 형태의 문자열로 가공하여 삽입
3. 공격 표면 빌더 통합 및 타입 안정성 확보
파서가 추출한 파라미터(dict)와 수집된 동적 토큰 리스트(list[str])를 병합할 때 발생하던 타입 충돌 및 EllipsisType 에러 수정.
split("=", 1)을 활용한 안전한 파라미터 병합 로직 추가로 Fuzzer 전달 과정의 런타임 에러 원천 차단.
비동기 큐에서 Sentinel(None) 신호를 받으면 컨슈머 루프를 안전하게 종료하는 Lifecycle 로직 통합.
