### PR TITLE
[feat] 시간 페이로드 직렬 처리 구현, 탐지 로직 전면 수정

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -105,7 +105,6 @@ class Payload:
     value: str
     attack_type: str
     risk_level: str
-    last_evidences: list[str] | None = None
 
 
 @dataclass(slots=True, frozen=True)

--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -73,7 +73,7 @@ class AttackModule(Protocol):
         elapsed_time: float,
         original_res: Any | None = None,
         requester: Callable[[str], Awaitable[Any]] | None = None,
-    ) -> bool | Awaitable[bool]: ...
+    ) -> tuple[bool, list[str]] | Awaitable[tuple[bool, list[str]]]: ...
 
 
 class FuzzerEngine:
@@ -112,7 +112,6 @@ class FuzzerEngine:
         self._queue: asyncio.Queue[AttackJob | None] = asyncio.Queue(maxsize=queue_maxsize)
         self._module_queues: dict[str, asyncio.Queue[AttackSurface | None]] = {}
         self._module_payloads: dict[str, list[Any]] = {}
-        self._module_stop_events: dict[str, asyncio.Event] = {}
         self._module_workers: list[asyncio.Task[None]] = []
         self._module_runtime_active = False
         self._stats = EngineStats()
@@ -341,10 +340,6 @@ class FuzzerEngine:
             module.name: list(module.get_payloads())
             for module in self.modules
         }
-        self._module_stop_events = {
-            module.name: asyncio.Event()
-            for module in self.modules
-        }
         self._module_workers = []
 
         for module in self.modules:
@@ -374,9 +369,6 @@ class FuzzerEngine:
             raise RuntimeError("module mode is not running")
 
         for module in self.modules:
-            stop_event = self._module_stop_events[module.name]
-            if stop_event.is_set():
-                continue
             payloads = self._module_payloads.get(module.name, [])
             queue = self._module_queues[module.name]
             params = tuple(self._iter_parameters(surface))
@@ -408,7 +400,6 @@ class FuzzerEngine:
         self._module_workers.clear()
         self._module_queues.clear()
         self._module_payloads.clear()
-        self._module_stop_events.clear()
         self._module_runtime_active = False
 
     async def _module_worker(
@@ -429,9 +420,6 @@ class FuzzerEngine:
                 return
 
             try:
-                stop_event = self._module_stop_events.get(module.name)
-                if stop_event is not None and stop_event.is_set():
-                    continue
                 params = tuple(self._iter_parameters(surface))
                 selector = getattr(module, "get_target_parameters", None)
                 if callable(selector):
@@ -448,8 +436,6 @@ class FuzzerEngine:
                 ]
                 batch_size = max(1, self.max_concurrent_requests)
                 for batch in self._chunked(attack_units, batch_size):
-                    if stop_event is not None and stop_event.is_set():
-                        break
                     tasks = [
                         asyncio.create_task(
                             self._process_module_attack(
@@ -483,10 +469,6 @@ class FuzzerEngine:
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None,
     ) -> None:
-        stop_event = self._module_stop_events.get(module.name)
-        if stop_event is not None and stop_event.is_set():
-            return
-
         response: Any
         try:
             async with self._semaphore:
@@ -504,7 +486,6 @@ class FuzzerEngine:
             return
 
         if self.delay > 0:
-            # Sleep outside semaphore so slots are not blocked by throttle waits.
             await asyncio.sleep(self.delay)
 
         elapsed_time = float(
@@ -521,14 +502,24 @@ class FuzzerEngine:
                     payload=mutated_payload,
                 )
 
-        verdict = module.analyze(
+        # [수정] 분석 결과를 tuple로 받아 처리
+        result = module.analyze(
             response=response,
             payload=payload,
             elapsed_time=elapsed_time,
             original_res=baseline_response,
             requester=module_requester
         )
-        is_hit = await verdict if isawaitable(verdict) else verdict
+        
+        if isawaitable(result):
+            result = await result
+
+        # [수정] tuple 언패킹 및 검증 (단순 bool 반환 모듈에 대한 하위 호환성 유지)
+        if isinstance(result, tuple):
+            is_hit, evidences = result
+        else:
+            is_hit = bool(result)
+            evidences = []
 
         async with self._stats_lock:
             self._stats.completed += 1
@@ -536,24 +527,7 @@ class FuzzerEngine:
         if not is_hit:
             return
 
-        verify_hook = getattr(module, "verify", None)
-        if callable(verify_hook):
-            verify_result = verify_hook(
-                session=session,
-                surface=surface,
-                parameter=parameter,
-                payload=payload,
-                response=response,
-                baseline_response=baseline_response,
-            )
-            is_verified = (
-                await verify_result if isawaitable(verify_result) else bool(verify_result)
-            )
-            if not is_verified:
-                return
-
-        evidences = getattr(payload, "last_evidences", [])
-
+        # [수정] Finding 생성 시 언패킹된 evidences를 직접 할당
         finding = Finding(
             surface=surface,
             parameter=parameter,
@@ -562,6 +536,7 @@ class FuzzerEngine:
             module_name=module.name,
             evidences=evidences
         )
+        
         self._findings.append(finding)
         async with self._stats_lock:
             self._stats.findings += 1
@@ -571,35 +546,11 @@ class FuzzerEngine:
             if isawaitable(callback_result):
                 await callback_result
 
-        stop_on_first_hit = bool(getattr(module, "stop_on_first_hit", False))
-        if stop_on_first_hit and stop_event is not None and not stop_event.is_set():
-            stop_event.set()
-            print(f"[*] [{module.name}] stop-on-first-hit triggered; skipping remaining payloads.")
-
     @staticmethod
-    def _dynamic_token_names(surface: AttackSurface) -> set[str]:
-        raw_tokens = getattr(surface, "dynamic_tokens", None)
-        if not raw_tokens:
-            return set()
-        if isinstance(raw_tokens, dict):
-            return {str(name) for name in raw_tokens.keys() if str(name)}
-        if isinstance(raw_tokens, (list, tuple, set)):
-            return {str(name) for name in raw_tokens if str(name)}
-        token_name = str(raw_tokens).strip()
-        return {token_name} if token_name else set()
-
-    @classmethod
-    def _iter_parameters(cls, surface: AttackSurface) -> Iterable[str]:
+    def _iter_parameters(surface: AttackSurface) -> Iterable[str]:
         params = getattr(surface, "parameters", None)
-        dynamic_token_names = cls._dynamic_token_names(surface)
         if params is None:
             return ()
         if isinstance(params, dict):
-            return tuple(
-                key for key in params.keys()
-                if str(key) not in dynamic_token_names
-            )
-        return tuple(
-            str(p) for p in params
-            if str(p) not in dynamic_token_names
-        )
+            return params.keys()
+        return tuple(str(p) for p in params)

--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -12,7 +12,6 @@ from fuzzer.request_builder import send_baseline_request
 try:
     from core.models import AttackSurface  # type: ignore
 except (ImportError, AttributeError):
-    # Temporary fallback for bootstrap phase where models are incomplete.
     @dataclass(slots=True)
     class AttackSurface:  # type: ignore[no-redef]
         url: str
@@ -73,7 +72,7 @@ class AttackModule(Protocol):
         elapsed_time: float,
         original_res: Any | None = None,
         requester: Callable[[str], Awaitable[Any]] | None = None,
-    ) -> tuple[bool, list[str]] | Awaitable[tuple[bool, list[str]]]: ...
+    ) -> tuple[bool, list[str], Any] | Awaitable[tuple[bool, list[str], Any]]: ...
 
 
 class FuzzerEngine:
@@ -288,12 +287,6 @@ class FuzzerEngine:
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None = None,
     ) -> EngineStats:
-        """
-        Module-oriented execution mode.
-        - Creates one queue per attack module.
-        - Dispatches each incoming surface into every module queue.
-        - Loads module payloads once per worker at startup.
-        """
         if not self.modules:
             raise ValueError("modules must be configured to run module queue mode")
 
@@ -321,10 +314,6 @@ class FuzzerEngine:
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None = None,
     ) -> None:
-        """
-        Start module workers.
-        Useful when parser/crawler streams surfaces over time.
-        """
         if self._module_runtime_active:
             raise RuntimeError("module mode is already running")
         if not self.modules:
@@ -362,9 +351,6 @@ class FuzzerEngine:
         self._module_runtime_active = True
 
     async def submit_surface(self, surface: AttackSurface) -> None:
-        """
-        Dispatch one parser-provided surface into every module queue.
-        """
         if not self._module_runtime_active:
             raise RuntimeError("module mode is not running")
 
@@ -382,9 +368,6 @@ class FuzzerEngine:
                 self._stats.queued += len(params) * len(payloads)
 
     async def stop_module_mode(self) -> None:
-        """
-        Wait until all module queues drain, then stop workers.
-        """
         if not self._module_runtime_active:
             return
 
@@ -502,8 +485,7 @@ class FuzzerEngine:
                     payload=mutated_payload,
                 )
 
-        # [수정] 분석 결과를 tuple로 받아 처리
-        result = module.analyze(
+        verdict = module.analyze(
             response=response,
             payload=payload,
             elapsed_time=elapsed_time,
@@ -511,14 +493,20 @@ class FuzzerEngine:
             requester=module_requester
         )
         
-        if isawaitable(result):
-            result = await result
+        if isawaitable(verdict):
+            verdict = await verdict
 
-        # [수정] tuple 언패킹 및 검증 (단순 bool 반환 모듈에 대한 하위 호환성 유지)
-        if isinstance(result, tuple):
-            is_hit, evidences = result
+        actual_payload = payload
+        if isinstance(verdict, tuple):
+            if len(verdict) == 3:
+                is_hit, evidences, actual_payload = verdict
+            elif len(verdict) == 2:
+                is_hit, evidences = verdict
+            else:
+                is_hit = verdict[0]
+                evidences = []
         else:
-            is_hit = bool(result)
+            is_hit = bool(verdict)
             evidences = []
 
         async with self._stats_lock:
@@ -527,11 +515,10 @@ class FuzzerEngine:
         if not is_hit:
             return
 
-        # [수정] Finding 생성 시 언패킹된 evidences를 직접 할당
         finding = Finding(
             surface=surface,
             parameter=parameter,
-            payload=payload,
+            payload=actual_payload,
             response=response,
             module_name=module.name,
             evidences=evidences

--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -12,6 +12,7 @@ from fuzzer.request_builder import send_baseline_request
 try:
     from core.models import AttackSurface  # type: ignore
 except (ImportError, AttributeError):
+    # Temporary fallback for bootstrap phase where models are incomplete.
     @dataclass(slots=True)
     class AttackSurface:  # type: ignore[no-redef]
         url: str
@@ -72,7 +73,7 @@ class AttackModule(Protocol):
         elapsed_time: float,
         original_res: Any | None = None,
         requester: Callable[[str], Awaitable[Any]] | None = None,
-    ) -> tuple[bool, list[str], Any] | Awaitable[tuple[bool, list[str], Any]]: ...
+    ) -> bool | Awaitable[bool]: ...
 
 
 class FuzzerEngine:
@@ -111,6 +112,7 @@ class FuzzerEngine:
         self._queue: asyncio.Queue[AttackJob | None] = asyncio.Queue(maxsize=queue_maxsize)
         self._module_queues: dict[str, asyncio.Queue[AttackSurface | None]] = {}
         self._module_payloads: dict[str, list[Any]] = {}
+        self._module_stop_events: dict[str, asyncio.Event] = {}
         self._module_workers: list[asyncio.Task[None]] = []
         self._module_runtime_active = False
         self._stats = EngineStats()
@@ -287,6 +289,12 @@ class FuzzerEngine:
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None = None,
     ) -> EngineStats:
+        """
+        Module-oriented execution mode.
+        - Creates one queue per attack module.
+        - Dispatches each incoming surface into every module queue.
+        - Loads module payloads once per worker at startup.
+        """
         if not self.modules:
             raise ValueError("modules must be configured to run module queue mode")
 
@@ -314,6 +322,10 @@ class FuzzerEngine:
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None = None,
     ) -> None:
+        """
+        Start module workers.
+        Useful when parser/crawler streams surfaces over time.
+        """
         if self._module_runtime_active:
             raise RuntimeError("module mode is already running")
         if not self.modules:
@@ -327,6 +339,10 @@ class FuzzerEngine:
         }
         self._module_payloads = {
             module.name: list(module.get_payloads())
+            for module in self.modules
+        }
+        self._module_stop_events = {
+            module.name: asyncio.Event()
             for module in self.modules
         }
         self._module_workers = []
@@ -351,10 +367,16 @@ class FuzzerEngine:
         self._module_runtime_active = True
 
     async def submit_surface(self, surface: AttackSurface) -> None:
+        """
+        Dispatch one parser-provided surface into every module queue.
+        """
         if not self._module_runtime_active:
             raise RuntimeError("module mode is not running")
 
         for module in self.modules:
+            stop_event = self._module_stop_events[module.name]
+            if stop_event.is_set():
+                continue
             payloads = self._module_payloads.get(module.name, [])
             queue = self._module_queues[module.name]
             params = tuple(self._iter_parameters(surface))
@@ -368,6 +390,9 @@ class FuzzerEngine:
                 self._stats.queued += len(params) * len(payloads)
 
     async def stop_module_mode(self) -> None:
+        """
+        Wait until all module queues drain, then stop workers.
+        """
         if not self._module_runtime_active:
             return
 
@@ -383,6 +408,7 @@ class FuzzerEngine:
         self._module_workers.clear()
         self._module_queues.clear()
         self._module_payloads.clear()
+        self._module_stop_events.clear()
         self._module_runtime_active = False
 
     async def _module_worker(
@@ -403,6 +429,9 @@ class FuzzerEngine:
                 return
 
             try:
+                stop_event = self._module_stop_events.get(module.name)
+                if stop_event is not None and stop_event.is_set():
+                    continue
                 params = tuple(self._iter_parameters(surface))
                 selector = getattr(module, "get_target_parameters", None)
                 if callable(selector):
@@ -419,6 +448,8 @@ class FuzzerEngine:
                 ]
                 batch_size = max(1, self.max_concurrent_requests)
                 for batch in self._chunked(attack_units, batch_size):
+                    if stop_event is not None and stop_event.is_set():
+                        break
                     tasks = [
                         asyncio.create_task(
                             self._process_module_attack(
@@ -452,6 +483,10 @@ class FuzzerEngine:
         request_sender: AsyncRequestSender,
         on_finding: ResultCallback | None,
     ) -> None:
+        stop_event = self._module_stop_events.get(module.name)
+        if stop_event is not None and stop_event.is_set():
+            return
+
         response: Any
         try:
             async with self._semaphore:
@@ -469,6 +504,7 @@ class FuzzerEngine:
             return
 
         if self.delay > 0:
+            # Sleep outside semaphore so slots are not blocked by throttle waits.
             await asyncio.sleep(self.delay)
 
         elapsed_time = float(
@@ -492,22 +528,7 @@ class FuzzerEngine:
             original_res=baseline_response,
             requester=module_requester
         )
-        
-        if isawaitable(verdict):
-            verdict = await verdict
-
-        actual_payload = payload
-        if isinstance(verdict, tuple):
-            if len(verdict) == 3:
-                is_hit, evidences, actual_payload = verdict
-            elif len(verdict) == 2:
-                is_hit, evidences = verdict
-            else:
-                is_hit = verdict[0]
-                evidences = []
-        else:
-            is_hit = bool(verdict)
-            evidences = []
+        is_hit = await verdict if isawaitable(verdict) else verdict
 
         async with self._stats_lock:
             self._stats.completed += 1
@@ -515,15 +536,32 @@ class FuzzerEngine:
         if not is_hit:
             return
 
+        verify_hook = getattr(module, "verify", None)
+        if callable(verify_hook):
+            verify_result = verify_hook(
+                session=session,
+                surface=surface,
+                parameter=parameter,
+                payload=payload,
+                response=response,
+                baseline_response=baseline_response,
+            )
+            is_verified = (
+                await verify_result if isawaitable(verify_result) else bool(verify_result)
+            )
+            if not is_verified:
+                return
+
+        evidences = getattr(payload, "last_evidences", [])
+
         finding = Finding(
             surface=surface,
             parameter=parameter,
-            payload=actual_payload,
+            payload=payload,
             response=response,
             module_name=module.name,
             evidences=evidences
         )
-        
         self._findings.append(finding)
         async with self._stats_lock:
             self._stats.findings += 1
@@ -533,11 +571,35 @@ class FuzzerEngine:
             if isawaitable(callback_result):
                 await callback_result
 
+        stop_on_first_hit = bool(getattr(module, "stop_on_first_hit", False))
+        if stop_on_first_hit and stop_event is not None and not stop_event.is_set():
+            stop_event.set()
+            print(f"[*] [{module.name}] stop-on-first-hit triggered; skipping remaining payloads.")
+
     @staticmethod
-    def _iter_parameters(surface: AttackSurface) -> Iterable[str]:
+    def _dynamic_token_names(surface: AttackSurface) -> set[str]:
+        raw_tokens = getattr(surface, "dynamic_tokens", None)
+        if not raw_tokens:
+            return set()
+        if isinstance(raw_tokens, dict):
+            return {str(name) for name in raw_tokens.keys() if str(name)}
+        if isinstance(raw_tokens, (list, tuple, set)):
+            return {str(name) for name in raw_tokens if str(name)}
+        token_name = str(raw_tokens).strip()
+        return {token_name} if token_name else set()
+
+    @classmethod
+    def _iter_parameters(cls, surface: AttackSurface) -> Iterable[str]:
         params = getattr(surface, "parameters", None)
+        dynamic_token_names = cls._dynamic_token_names(surface)
         if params is None:
             return ()
         if isinstance(params, dict):
-            return params.keys()
-        return tuple(str(p) for p in params)
+            return tuple(
+                key for key in params.keys()
+                if str(key) not in dynamic_token_names
+            )
+        return tuple(
+            str(p) for p in params
+            if str(p) not in dynamic_token_names
+        )

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -136,7 +136,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
     
     logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
     is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
-    is_blind_candidate = (true_ratio >= 0.985) and (not is_true_expanded)
+    is_blind_candidate = (true_ratio >= 0.95) and (not is_true_expanded)
 
     # [A] 1차 탐지에서 변화 감지
     if is_vuln_1st: 
@@ -148,7 +148,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             if val.strip().endswith("'") or val.strip().endswith('"'):
                 fix_res = await requester(val + " -- ")
                 ratio = get_text_ratio(fix_res.text, orig_text)
-                if ratio >= 0.995:
+                if ratio >= 0.99:
                     return True, evidences + [f"[Verified] Syntax Fix Test(broken) Ratio: {ratio:.4f}"]
 
         # Path 2: 논리 반전 테스트
@@ -160,7 +160,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             if val.strip().endswith("'") or val.strip().endswith('"'):
                 fix_res = await requester(val + " -- ")
                 fix_ratio = get_text_ratio(fix_res.text, orig_text)
-                if fix_ratio >= 0.995:
+                if fix_ratio >= 0.99:
                     return True, evidences + [f"[Verified] Syntax Fix Test Ratio: {fix_ratio:.4f}"]
 
             # 논리 반전 테스트
@@ -182,22 +182,22 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
                 # [검증 1] 참 조건 응답에 데이터가 추가되었고 참 조건 응답과 거짓 조건 응답이 다른가
                 if is_true_expanded:
                     f_to_t_ratio = get_text_ratio(false_res.text, res_text)
-                    if f_to_t_ratio < 0.99:
+                    if f_to_t_ratio < 0.98:
                         tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}"
                         return True, evidences + [tag]
                 
                 # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 같은가
                 elif is_blind_candidate:
                     f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
-                    if false_status == orig_status and f_to_orig_ratio >= 0.99:
+                    if false_status == orig_status and f_to_orig_ratio >= 0.98:
                         return True, evidences + [f"[Verified] Inverted Logic Swapping (False==Baseline) Ratio: {f_to_orig_ratio:.4f}"]
 
                 # [검증 3] 거짓 조건 응답에 데이터가 추가되었고, 참 조건 응답과 거짓조건 응답이 다른가
                 is_false_expanded = (len(false_pure_res) >= len(pure_orig) * 1.1) and (len(false_pure_res) - len(pure_orig) >= 20)
                 if not false_has_syntax_error and is_false_expanded:
-                    f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
-                    if f_to_orig_ratio < 0.99:
-                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False Expansion) Ratio: {f_to_orig_ratio:.4f}"]
+                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+                    if f_to_t_ratio < 0.98:
+                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False Expansion) Ratio: {f_to_t_ratio:.4f}"]
 
     # [B]: 1차 탐지에서 변화 미감지
     elif not has_syntax_error:
@@ -205,7 +205,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
             false_res = await requester(false_payload)
             f_to_t_ratio = get_text_ratio(false_res.text, res_text)
-            if f_to_t_ratio < 0.995:
+            if f_to_t_ratio < 0.99:
                 return True, [f"[Verified] Blind SQLi (Baseline==True and True!=False) Ratio: {f_to_t_ratio:.4f}"]
 
     return False, []

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -1,6 +1,30 @@
 import re
 import html
 from urllib.parse import unquote
+from difflib import SequenceMatcher
+
+def _get_pure_text(html_content: str) -> str:
+    if not html_content:
+        return ""
+    # 1. Script 및 Style 내용 제거
+    text = re.sub(r'<(script|style).*?>.*?</\1>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
+    # 2. HTML 태그 제거
+    text = re.sub(r'<[^>]+?>', ' ', text)
+    # 3. HTML 엔티티 변환 (&nbsp; 등)
+    text = html.unescape(text)
+    # 4. 연속된 공백 및 줄바꿈 정리
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+def get_text_ratio(text1: str, text2: str) -> float:
+    pure1 = _get_pure_text(text1)
+    pure2 = _get_pure_text(text2)
+    
+    if not pure1 and not pure2: return 1.0
+    if not pure1 or not pure2: return 0.0
+    
+    # SequenceMatcher를 사용해 텍스트 유사도 계산
+    return SequenceMatcher(None, pure1, pure2).ratio()
 
 def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None):
     evidences = []
@@ -18,7 +42,7 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
     has_execution_error = False
     has_potential_mismatch = False
 
-    # [1] 문법 오류 식별 및 영역 제거
+    # [1] 문법 오류 식별
     scrubbed_text = res_text
     for pattern in syntax_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
@@ -30,8 +54,6 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
     for var in filter(None, set(payload_variants)):
         scrubbed_text = scrubbed_text.replace(var, "[DIRECT_REFLECTION_REMOVED]")
 
-    # --- 탐지 로직 시작 ---
-
     # 1. 시간 기반 탐지
     timing_keywords = ["sleep(", "waitfor delay", "pg_sleep", "benchmark(", "dbms_pipe.receive_message"]
     has_timing_intent = any(k in payload_value.lower() for k in timing_keywords)
@@ -39,7 +61,7 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
     if is_time_related and elapsed_time >= (4.5 + orig_elapsed):
         evidences.append(f"[Time] Response delayed: {elapsed_time:.2f}s")
 
-    # 2. 실행 에러 및 DBMS 불일치 판별
+    # 2. 에러 기반 탐지
     for pattern in exploit_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
             evidences.append(f"[Error] SQL Execution Error: {pattern}")
@@ -66,17 +88,17 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
         if current_status != orig_status:
             evidences.append(f"[Boolean] Status Code changed: {orig_status} -> {current_status}")
 
-        orig_text_lower = original_res.text.lower()
-        curr_text_lower = scrubbed_text.lower()
-
-        if len(orig_text_lower) > 0:
-            diff_bytes = abs(len(original_res.text) - len(res_text))
-            if diff_bytes > 0:
-                evidences.append(f"[Boolean] Content length changed by {diff_bytes} bytes")
+        ratio = get_text_ratio(original_res.text, res_text)
+        # 변화 감지
+        if ratio < 1.0:
+            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f}")
             
+            # 키워드 상태 반전 체크
+            orig_pure = _get_pure_text(original_res.text).lower()
+            curr_pure = _get_pure_text(res_text).lower()
             blind_keywords = ["exists", "missing", "found", "success", "failed", "invalid", "true", "false"]
             for kw in blind_keywords:
-                if (kw in orig_text_lower) != (kw in curr_text_lower):
+                if (kw in orig_pure) != (kw in curr_pure):
                     evidences.append(f"[Boolean] Blind keyword '{kw}' state inverted")
                     break
 
@@ -89,19 +111,24 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
     val = payload.value
     res_text = response.text
     orig_text = original_res.text
-    is_true_legit = is_similar_pure(res_text, orig_text)
+    
+    pure_res = _get_pure_text(res_text)
+    pure_orig = _get_pure_text(orig_text)
+    
+    true_ratio = get_text_ratio(orig_text, res_text)
+    is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
+    is_true_legit = (true_ratio >= 0.985) or is_true_expanded
 
-    # [A] 1차 탐지에서 변화가 감지된 경우
-    if is_vuln_1st:
+    if is_vuln_1st: # 변화 감지
         if any(tag in str(evidences) for tag in ["[Error]", "[Time]", "[Reflection]"]):
             return True, evidences
 
-        # 참 조건이 원본과 비슷할 때만 수행
         if is_true_legit:
-            # 전략 1: 구문 복구 테스트 (Quote 복구)
+            # 전략 1: 구문 복구 테스트
             if val.strip().endswith("'") or val.strip().endswith('"'):
                 fix_res = await requester(val + " -- ")
-                if is_similar_pure(fix_res.text, orig_text):
+                # 복구된 응답이 원본과 유사한지 확인
+                if get_text_ratio(fix_res.text, orig_text) >= 0.985:
                     return True, evidences + ["[Verified] Syntax Fix Test"]
 
             # 전략 2: 논리 패턴 반전
@@ -109,46 +136,18 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             if re.search(logic_pattern, val) or "1=1" in val:
                 false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
                 false_res = await requester(false_payload)
-                if not is_similar(false_res.text, res_text):
-                    return True, evidences + ["[Verified] Logic Swapping (True!=False)"]
+                
+                if get_text_ratio(false_res.text, res_text) < 0.995:
+                    tag = "[Verified] Logic Swapping (Expansion)" if is_true_expanded else "[Verified] Logic Swapping (True!=False)"
+                    return True, evidences + [tag]
 
-    # [B] 변화 미감지 시
-    elif not has_syntax_error:
+    elif not has_syntax_error and (true_ratio >= 0.985): # 변화 미감지(Blind)
         logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
         if re.search(logic_pattern, val) or "1=1" in val:
             false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
             if false_payload != val:
                 false_res = await requester(false_payload)
-                if is_true_legit and not is_similar(false_res.text, res_text):
+                if get_text_ratio(false_res.text, res_text) < 0.995:
                     return True, ["[Verified] Blind SQLi (Baseline==True and True!=False)"]
 
     return False, []
-
-def is_similar(text1: str, text2: str) -> bool:
-    if not text1 or not text2: return False
-    l1, l2 = len(text1), len(text2)
-    diff = abs(l1 - l2)
-    return (diff / max(l1, l2)) < 0.015
-
-def _get_pure_text(html_content: str) -> str:
-    if not html_content:
-        return ""
-    # 1. Script 및 Style 내용 제거
-    text = re.sub(r'<(script|style).*?>.*?</\1>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
-    # 2. HTML 태그 제거
-    text = re.sub(r'<[^>]+?>', ' ', text)
-    # 3. HTML 엔티티 변환 (&nbsp; 등)
-    text = html.unescape(text)
-    # 4. 연속된 공백 및 줄바꿈 정리
-    text = re.sub(r'\s+', ' ', text).strip()
-    return text
-
-def is_similar_pure(text1: str, text2: str) -> bool:
-    pure1 = _get_pure_text(text1)
-    pure2 = _get_pure_text(text2)
-    
-    if not pure1 and not pure2: return True
-    if not pure1 or not pure2: return False
-    
-    diff = abs(len(pure1) - len(pure2))
-    return (diff / max(len(pure1), len(pure2))) < 0.015

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -136,8 +136,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
     
     logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
     is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
-    is_true_legit = (true_ratio >= 0.995) or is_true_expanded
-    is_blind_candidate = (true_ratio >= 0.985) and (not is_true_legit)
+    is_blind_candidate = (true_ratio >= 0.985) and (not is_true_expanded)
 
     # [A] 1차 탐지에서 변화 감지
     if is_vuln_1st: 
@@ -145,7 +144,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             return True, evidences
 
         # Path 1: 구조적 파손 검증 (주석 처리)
-        if not is_true_legit and not is_blind_candidate:
+        if not is_true_expanded and not is_blind_candidate:
             if val.strip().endswith("'") or val.strip().endswith('"'):
                 fix_res = await requester(val + " -- ")
                 ratio = get_text_ratio(fix_res.text, orig_text)
@@ -155,7 +154,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
         # Path 2: 논리 반전 테스트
         has_logic = re.search(logic_pattern, val) or "1=1" in val
         
-        if is_true_legit or is_blind_candidate or has_logic or any(tag in str(evidences) for tag in ["[ExecutionErr]"]):
+        if is_true_expanded or is_blind_candidate or has_logic or any(tag in str(evidences) for tag in ["[ExecutionErr]"]):
             
             # 주석 복구 시도
             if val.strip().endswith("'") or val.strip().endswith('"'):
@@ -180,11 +179,11 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
                             false_has_syntax_error = True
                             break
 
-                # [검증 1] 참 조건 응답에 데이터가 추가되었거나 baseline과 충분히 유사하고, 참 조건 응답과 거짓 조건 응답이 다른가
-                if is_true_legit:
+                # [검증 1] 참 조건 응답에 데이터가 추가되었고 참 조건 응답과 거짓 조건 응답이 다른가
+                if is_true_expanded:
                     f_to_t_ratio = get_text_ratio(false_res.text, res_text)
                     if f_to_t_ratio < 0.99:
-                        tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}" if is_true_expanded else f"[Verified] Logic Swapping (True!=False) Ratio: {f_to_t_ratio:.4f}"
+                        tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}"
                         return True, evidences + [tag]
                 
                 # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 같은가
@@ -201,7 +200,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
                         return True, evidences + [f"[Verified] Inverted Logic Swapping (False Expansion) Ratio: {f_to_orig_ratio:.4f}"]
 
     # [B]: 1차 탐지에서 변화 미감지
-    elif not has_syntax_error and is_true_legit:
+    elif not has_syntax_error:
         if re.search(logic_pattern, val) or "1=1" in val:
             false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
             false_res = await requester(false_payload)

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -109,7 +109,7 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
 
         ratio = get_text_ratio(original_res.text, res_text)
         if ratio < 0.995:
-            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f}")
+            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f} (Baseline Status: {orig_status})")
             
             orig_pure = _get_pure_text(original_res.text).lower()
             curr_pure = _get_pure_text(res_text).lower()
@@ -136,7 +136,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
     
     logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
     is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
-    is_blind_candidate = (true_ratio >= 0.95) and (not is_true_expanded)
+    is_blind_candidate = (99 > true_ratio >= 0.95) and (not is_true_expanded)
 
     # [A] 1차 탐지에서 변화 감지
     if is_vuln_1st: 
@@ -186,10 +186,11 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
                         tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}"
                         return True, evidences + [tag]
                 
-                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 같은가
+                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 baseline과 같으면서 참 조건 응답과 다른가
                 elif is_blind_candidate:
                     f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
-                    if false_status == orig_status and f_to_orig_ratio >= 0.98:
+                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+                    if f_to_t_ratio < 0.99 and false_status == orig_status and f_to_orig_ratio >= 0.98:
                         return True, evidences + [f"[Verified] Inverted Logic Swapping (False==Baseline) Ratio: {f_to_orig_ratio:.4f}"]
 
                 # [검증 3] 거짓 조건 응답에 데이터가 추가되었고, 참 조건 응답과 거짓조건 응답이 다른가
@@ -206,6 +207,6 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             false_res = await requester(false_payload)
             f_to_t_ratio = get_text_ratio(false_res.text, res_text)
             if f_to_t_ratio < 0.99:
-                return True, [f"[Verified] Blind SQLi (Baseline==True and True!=False) Ratio: {f_to_t_ratio:.4f}"]
+                return True, [f"[Verified] Blind SQLi (Baseline==True(Status: {orig_status}) and True!=False) Ratio: {f_to_t_ratio:.4f}"]
 
     return False, []

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -1,32 +1,29 @@
 import re
 import html
+import asyncio
 from urllib.parse import unquote
 from difflib import SequenceMatcher
 
 def _get_pure_text(html_content: str) -> str:
+    """HTML 태그, 스크립트 등을 제거하여 순수 텍스트만 추출 (노이즈 제거)"""
     if not html_content:
         return ""
-    # 1. Script 및 Style 내용 제거
     text = re.sub(r'<(script|style).*?>.*?</\1>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
-    # 2. HTML 태그 제거
     text = re.sub(r'<[^>]+?>', ' ', text)
-    # 3. HTML 엔티티 변환 (&nbsp; 등)
     text = html.unescape(text)
-    # 4. 연속된 공백 및 줄바꿈 정리
     text = re.sub(r'\s+', ' ', text).strip()
     return text
 
 def get_text_ratio(text1: str, text2: str) -> float:
+    """순수 텍스트 유사도 비율 계산"""
     pure1 = _get_pure_text(text1)
     pure2 = _get_pure_text(text2)
-    
     if not pure1 and not pure2: return 1.0
     if not pure1 or not pure2: return 0.0
-    
-    # SequenceMatcher를 사용해 텍스트 유사도 계산
     return SequenceMatcher(None, pure1, pure2).ratio()
 
 def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None):
+
     evidences = []
     res_text = response.text
     
@@ -36,11 +33,22 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
 
     attack_type = payload.attack_type.lower()
     payload_value = payload.value
-    marker = "SVSDAAAAvunVASDAAAA"
+    marker_start = "SVSDAAAA"
+    marker_stop = "VASDAAAA"
+    dynamic_marker_pattern = re.compile(f"{marker_start}(.*?){marker_stop}", re.I | re.DOTALL)
 
     has_syntax_error = False
     has_execution_error = False
     has_potential_mismatch = False
+
+    timing_keywords = ["sleep(", "waitfor delay", "pg_sleep", "benchmark(", "dbms_pipe.receive_message", "regexp_substring", "repeat("]
+    has_timing_intent = any(k in payload_value.lower() for k in timing_keywords)
+    is_time_related = "time" in attack_type or "stacked" in attack_type or has_timing_intent
+    # 시간 페이로드 타임아웃 탐지
+    if is_time_related and response is None:
+        if elapsed_time >= 4.0:
+            evidences.append(f"[Time] Request Timed Out: {elapsed_time:.2f}s")
+        return len(evidences) > 0, evidences, False
 
     # [1] 문법 오류 식별
     scrubbed_text = res_text
@@ -55,45 +63,54 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
         scrubbed_text = scrubbed_text.replace(var, "[DIRECT_REFLECTION_REMOVED]")
 
     # 1. 시간 기반 탐지
-    timing_keywords = ["sleep(", "waitfor delay", "pg_sleep", "benchmark(", "dbms_pipe.receive_message"]
-    has_timing_intent = any(k in payload_value.lower() for k in timing_keywords)
-    is_time_related = "time" in attack_type or "stacked" in attack_type or has_timing_intent
-    if is_time_related and elapsed_time >= (4.5 + orig_elapsed):
+    if is_time_related and elapsed_time >= (4.0 + orig_elapsed):
         evidences.append(f"[Time] Response delayed: {elapsed_time:.2f}s")
 
     # 2. 에러 기반 탐지
     for pattern in exploit_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
-            evidences.append(f"[Error] SQL Execution Error: {pattern}")
-            has_execution_error = True
+            marker_match = dynamic_marker_pattern.search(res_text)
+            
+            if marker_match:
+                extracted_data = marker_match.group(1)
+                evidences.append(f"[Error] SQL Execution Error (Marker Found: '{extracted_data}'): {pattern}")
+                has_execution_error = True
+            else:
+                evidences.append(f"[ExecutionErr] SQL Execution Error (No Marker): {pattern}")
             break
 
-    if not has_execution_error:
+    if not has_execution_error and not any("[ExecutionErr]" in e for e in evidences):
         for pattern in mismatch_signatures:
             if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
-                evidences.append(f"[Potential] DBMS Mismatch Error: {pattern}")
+                evidences.append(f"[Mismatch] DBMS Mismatch Error: {pattern}")
                 has_potential_mismatch = True
                 break
 
     # 3. 마커 검증
-    marker_lower = marker.lower()
-    if marker_lower in res_text.lower() and marker_lower in scrubbed_text.lower():
-        if has_syntax_error or has_execution_error:
-            evidences.append(f"[Error] SQLi execution marker confirmed in DB output")
-        else:
-            evidences.append(f"[Reflection] SQLi marker confirmed in legitimate content")
+    if not has_execution_error:
+        # 동적 마커 패턴 검색
+        marker_match_res = dynamic_marker_pattern.search(res_text)
+        marker_match_scrubbed = dynamic_marker_pattern.search(scrubbed_text)
+
+        if marker_match_res and marker_match_scrubbed:
+            extracted_data = marker_match_res.group(1)
+            
+            if has_syntax_error or any("executionerr" in e.lower() for e in evidences):
+                evidences.append(f"[Error] SQLi execution marker ('{extracted_data}') confirmed in DB output context")
+                has_execution_error = True
+            else:
+                # 에러가 확인되지 않았는데 마커만 발견된 경우 단순 반사 또는 exploit_signatures에 없는 에러 메시지에서 데이터 추출
+                evidences.append(f"[Reflection] SQLi marker ('{extracted_data}') confirmed in legitimate content")
 
     # 4. 불리언 기반 탐지
-    if (not evidences or has_potential_mismatch) and not has_syntax_error and original_res:
+    if (not evidences or has_potential_mismatch or any("[ExecutionErr]" in e for e in evidences)) and not has_syntax_error and original_res:
         if current_status != orig_status:
             evidences.append(f"[Boolean] Status Code changed: {orig_status} -> {current_status}")
 
         ratio = get_text_ratio(original_res.text, res_text)
-        # 변화 감지
-        if ratio < 1.0:
+        if ratio < 0.995:
             evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f}")
             
-            # 키워드 상태 반전 체크
             orig_pure = _get_pure_text(original_res.text).lower()
             curr_pure = _get_pure_text(res_text).lower()
             blind_keywords = ["exists", "missing", "found", "success", "failed", "invalid", "true", "false"]
@@ -104,50 +121,92 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
 
     return len(evidences) > 0, evidences, has_syntax_error
 
-async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_1st, evidences, has_syntax_error):
+async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_1st, evidences, has_syntax_error, syntax_signatures=None):
     if not requester or not original_res:
         return is_vuln_1st, evidences
 
     val = payload.value
     res_text = response.text
     orig_text = original_res.text
+    orig_status = getattr(original_res, "status", getattr(original_res, "status_code", None))
     
+    true_ratio = get_text_ratio(orig_text, res_text)
     pure_res = _get_pure_text(res_text)
     pure_orig = _get_pure_text(orig_text)
     
-    true_ratio = get_text_ratio(orig_text, res_text)
+    logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
     is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
-    is_true_legit = (true_ratio >= 0.985) or is_true_expanded
+    is_true_legit = (true_ratio >= 0.995) or is_true_expanded
+    is_blind_candidate = (true_ratio >= 0.985) and (not is_true_legit)
 
-    if is_vuln_1st: # 변화 감지
-        if any(tag in str(evidences) for tag in ["[Error]", "[Time]", "[Reflection]"]):
+    # [A] 1차 탐지에서 변화 감지
+    if is_vuln_1st: 
+        if any(tag in str(evidences) for tag in ["[Error]", "[Reflection]", "[Time]"]):
             return True, evidences
 
-        if is_true_legit:
-            # 전략 1: 구문 복구 테스트
+        # Path 1: 구조적 파손 검증 (주석 처리)
+        if not is_true_legit and not is_blind_candidate:
             if val.strip().endswith("'") or val.strip().endswith('"'):
                 fix_res = await requester(val + " -- ")
-                # 복구된 응답이 원본과 유사한지 확인
-                if get_text_ratio(fix_res.text, orig_text) >= 0.985:
-                    return True, evidences + ["[Verified] Syntax Fix Test"]
+                ratio = get_text_ratio(fix_res.text, orig_text)
+                if ratio >= 0.995:
+                    return True, evidences + [f"[Verified] Syntax Fix Test(broken) Ratio: {ratio:.4f}"]
 
-            # 전략 2: 논리 패턴 반전
-            logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
-            if re.search(logic_pattern, val) or "1=1" in val:
+        # Path 2: 논리 반전 테스트
+        has_logic = re.search(logic_pattern, val) or "1=1" in val
+        
+        if is_true_legit or is_blind_candidate or has_logic or any(tag in str(evidences) for tag in ["[ExecutionErr]"]):
+            
+            # 주석 복구 시도
+            if val.strip().endswith("'") or val.strip().endswith('"'):
+                fix_res = await requester(val + " -- ")
+                fix_ratio = get_text_ratio(fix_res.text, orig_text)
+                if fix_ratio >= 0.995:
+                    return True, evidences + [f"[Verified] Syntax Fix Test Ratio: {fix_ratio:.4f}"]
+
+            # 논리 반전 테스트
+            if has_logic:
                 false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
                 false_res = await requester(false_payload)
+                false_res_text = false_res.text
+                false_pure_res = _get_pure_text(false_res_text)
+                false_status = getattr(false_res, "status", getattr(false_res, "status_code", None))
                 
-                if get_text_ratio(false_res.text, res_text) < 0.995:
-                    tag = "[Verified] Logic Swapping (Expansion)" if is_true_expanded else "[Verified] Logic Swapping (True!=False)"
-                    return True, evidences + [tag]
+                # 거짓 응답 문법 에러 확인
+                false_has_syntax_error = False
+                if syntax_signatures:
+                    for pattern in syntax_signatures:
+                        if re.search(pattern, false_res_text, re.I | re.DOTALL):
+                            false_has_syntax_error = True
+                            break
 
-    elif not has_syntax_error and (true_ratio >= 0.985): # 변화 미감지(Blind)
-        logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
+                # [검증 1] 참 조건 응답에 데이터가 추가되었거나 baseline과 충분히 유사하고, 참 조건 응답과 거짓 조건 응답이 다른가
+                if is_true_legit:
+                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+                    if f_to_t_ratio < 0.99:
+                        tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}" if is_true_expanded else f"[Verified] Logic Swapping (True!=False) Ratio: {f_to_t_ratio:.4f}"
+                        return True, evidences + [tag]
+                
+                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 같은가
+                elif is_blind_candidate:
+                    f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
+                    if false_status == orig_status and f_to_orig_ratio >= 0.99:
+                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False==Baseline) Ratio: {f_to_orig_ratio:.4f}"]
+
+                # [검증 3] 거짓 조건 응답에 데이터가 추가되었고, 참 조건 응답과 거짓조건 응답이 다른가
+                is_false_expanded = (len(false_pure_res) >= len(pure_orig) * 1.1) and (len(false_pure_res) - len(pure_orig) >= 20)
+                if not false_has_syntax_error and is_false_expanded:
+                    f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
+                    if f_to_orig_ratio < 0.99:
+                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False Expansion) Ratio: {f_to_orig_ratio:.4f}"]
+
+    # [B]: 1차 탐지에서 변화 미감지
+    elif not has_syntax_error and is_true_legit:
         if re.search(logic_pattern, val) or "1=1" in val:
             false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
-            if false_payload != val:
-                false_res = await requester(false_payload)
-                if get_text_ratio(false_res.text, res_text) < 0.995:
-                    return True, ["[Verified] Blind SQLi (Baseline==True and True!=False)"]
+            false_res = await requester(false_payload)
+            f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+            if f_to_t_ratio < 0.995:
+                return True, [f"[Verified] Blind SQLi (Baseline==True and True!=False) Ratio: {f_to_t_ratio:.4f}"]
 
     return False, []

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -4,10 +4,20 @@ import urllib.parse
 import re
 import dataclasses
 import random
-from typing import Iterator, Any, Tuple, List
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Iterator, Any, Tuple, List, Optional, Iterable
+
 from modules.base_module import BaseModule
 from modules.sqli.payloads import get_sqli_payloads
-from modules.sqli.analyzer import detect_sqli, verify_sqli_logic 
+from modules.sqli.analyzer import detect_sqli, verify_sqli_logic
+from core.models import Payload
+
+@dataclass(frozen=True, slots=True)
+class SQLiInternalPayload(Payload):
+    _is_serial: bool = False
+    _real_time_value: Optional[str] = None
 
 class SQLiModule(BaseModule):
     def __init__(self, **kwargs):
@@ -20,107 +30,189 @@ class SQLiModule(BaseModule):
         self.include_time_based = kwargs.get('include_time_based', False)
         self.max_time_payloads = kwargs.get('max_time_payloads', 0)
         self.random_seed = kwargs.get('random_seed', 37)
+        
+        self._global_time_lock = asyncio.Lock()
+        self._fast_per_param = 0
+        self._known_targets = set()
+        self._total_fast_expected = 0
+        self._global_fast_completed = 0
+        self._counter_lock = asyncio.Lock()
+        
+        # 이벤트 기반 장벽을 통해 시간 페이로드 직렬 처리
+        self._barrier_event = asyncio.Event()
+        self._time_attack_in_flight = 0
+        self._time_phase_active = False
 
-    def _load_json(self, filename):
+    def _load_json(self, filename: str) -> list:
         file_path = os.path.join("config", "payloads", filename)
         if os.path.exists(file_path):
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     return json.load(f)
-            except Exception as e:
-                print(f"[-] [{self.name}] {filename} load failed: {e}")
+            except Exception:
+                return []
         return []
 
-    def _is_time_payload(self, payload) -> bool:
+    def _is_time_payload(self, payload: Payload) -> bool:
         attack_type = str(getattr(payload, "attack_type", "")).lower()
         return "time" in attack_type or "stacked" in attack_type
 
-    def get_payloads(self) -> Iterator[Any]:
-        
-        # 1. 원본 소스 로드
-        all_raw = get_sqli_payloads()
-                
-        # 2. 인덱스 기반 분류
-        fast_indices = []
-        time_indices = []
-
-        for i, p in enumerate(all_raw):
-            if self._is_time_payload(p):
-                time_indices.append(i)
-            else:
-                fast_indices.append(i)
-
-        # 3. 랜덤 부여된 인덱스로 시간 기반 페이로드 샘플링
-        selected_time_indices = []
-        if self.include_time_based and time_indices:
-            random.seed(self.random_seed)
-            limit = self.max_time_payloads if self.max_time_payloads > 0 else len(time_indices)
-            limit = min(limit, len(time_indices))
-            selected_time_indices = random.sample(time_indices, limit)
-
-        for idx in (fast_indices + selected_time_indices):
-            p = all_raw[idx]
-            # 우회 기법 필요할 때만 적용
-            evasion_value = self._apply_evasion_by_level(p.value)
-            yield dataclasses.replace(p, value=evasion_value)
-
-        del all_raw
-        del fast_indices
-        del time_indices
+    def get_target_parameters(self, surface: Any, all_params: Iterable[str]) -> Iterable[str]:
+        params = list(all_params)
+        url = getattr(surface, "url", "")
+        method = getattr(surface, "method", "GET")
+        for p in params:
+            tid = (method, url, p)
+            if tid not in self._known_targets:
+                self._known_targets.add(tid)
+                self._total_fast_expected += self._fast_per_param
+        return params
 
     def get_payload_count(self) -> int:
         all_raw = get_sqli_payloads()
-        fast_count = 0
-        time_total_count = 0
-
-        for p in all_raw:
-            if self._is_time_payload(p):
-                time_total_count += 1
-            else:
-                fast_count += 1
+        fast_c = sum(1 for p in all_raw if not self._is_time_payload(p))
+        time_c = sum(1 for p in all_raw if self._is_time_payload(p))
         
         selected_time_count = 0
-        if self.include_time_based and time_total_count > 0:
-            limit = self.max_time_payloads if self.max_time_payloads > 0 else time_total_count
-            selected_time_count = min(limit, time_total_count)
-            
-        return fast_count + selected_time_count
+        if self.include_time_based:
+            limit = self.max_time_payloads if self.max_time_payloads > 0 else time_c
+            selected_time_count = min(limit, time_c)
+        
+        multiplier = self.evasion_level + 1
+        self._fast_per_param = fast_c * multiplier
+        return self._fast_per_param + (selected_time_count * multiplier)
 
-    def _apply_evasion_by_level(self, value: str) -> str:
-        if self.evasion_level <= 0: return value
-        if self.evasion_level >= 1:
-            value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")
-            value = value.replace("AND", "aNd").replace("OR", "oR")
-            value = value.replace("CASE", "cAsE").replace("WHEN", "wHeN")
-        if self.evasion_level >= 2:
+    def get_payloads(self) -> Iterator[Payload]:
+        if self._fast_per_param == 0: 
+            self.get_payload_count()
+
+        all_raw = get_sqli_payloads()
+        fast_indices = [i for i, p in enumerate(all_raw) if not self._is_time_payload(p)]
+        time_indices = [i for i, p in enumerate(all_raw) if self._is_time_payload(p)]
+
+        for level in range(self.evasion_level + 1):
+            for idx in fast_indices:
+                p = all_raw[idx]
+                yield SQLiInternalPayload(
+                    value=self._apply_evasion_by_level(p.value, level),
+                    attack_type=p.attack_type, risk_level=p.risk_level, _is_serial=False
+                )
+
+        if self.include_time_based and time_indices:
+            random.seed(self.random_seed)
+            limit = self.max_time_payloads if self.max_time_payloads > 0 else len(time_indices)
+            selected_indices = random.sample(time_indices, min(limit, len(time_indices)))
+            for level in range(self.evasion_level + 1):
+                for idx in selected_indices:
+                    p = all_raw[idx]
+                    yield SQLiInternalPayload(
+                        value="1", attack_type=p.attack_type, risk_level=p.risk_level,
+                        _is_serial=True, _real_time_value=self._apply_evasion_by_level(p.value, level)
+                    )
+
+    def _apply_evasion_by_level(self, value: str, level: int) -> str:
+        if level <= 0: return value
+        if level >= 1:
+            value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")\
+                         .replace("AND", "aNd").replace("OR", "oR")\
+                         .replace("CASE", "cAsE").replace("WHEN", "wHeN")
+        if level >= 2:
             value = value.replace(" ", "/**/")
-        if self.evasion_level >= 3:
-            value = urllib.parse.quote(urllib.parse.quote(value))
-            value += "%00"
+        if level >= 3:
+            value = urllib.parse.quote(urllib.parse.quote(value)) + "%00"
         return value
 
-    async def analyze(self, response, payload, elapsed_time, original_res=None, requester=None) -> Tuple[bool, List[str]]:
-        is_vuln_1st, evidences, has_syntax_error = detect_sqli(
-            response=response,
-            payload=payload,
-            elapsed_time=elapsed_time,
-            exploit_signatures=self.exploit_signatures,
-            syntax_signatures=self.syntax_signatures,
-            mismatch_signatures=self.mismatch_signatures,
-            original_res=original_res
-        )
+    async def analyze(self, response: Any, payload: Any, elapsed_time: float, 
+                      original_res: Any = None, requester: Any = None) -> Tuple[bool, List[str], Any]:
+        is_serial = getattr(payload, "_is_serial", False)
 
-        final_hit, final_evidences = await verify_sqli_logic(
-            response=response,
-            payload=payload,
-            original_res=original_res,
-            requester=requester,
-            is_vuln_1st=is_vuln_1st,
-            evidences=evidences,
-            has_syntax_error=has_syntax_error
-        )
+        # [A] 일반 페이로드 분석 (병렬)
+        if not is_serial:
+            # 시간 페이즈 종료까지 대기
+            while self._time_phase_active:
+                await asyncio.sleep(2.0)
 
-        if final_hit:
-            return True, final_evidences
-        
-        return False, []
+            try:
+                is_hit, evidences, has_syntax_error = detect_sqli(
+                    response=response, payload=payload, elapsed_time=elapsed_time,
+                    exploit_signatures=self.exploit_signatures,
+                    syntax_signatures=self.syntax_signatures,
+                    mismatch_signatures=self.mismatch_signatures,
+                    original_res=original_res
+                )
+                final_hit, final_evidences = await verify_sqli_logic(
+                    response, payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
+                )
+                return final_hit, final_evidences, payload
+            finally:
+                async with self._counter_lock:
+                    self._global_fast_completed += 1
+                    if self._global_fast_completed >= self._total_fast_expected and self._total_fast_expected > 0:
+                        if not self._barrier_event.is_set():
+                            self._barrier_event.set()
+
+        # [B] 시간 기반 페이로드 분석 (직렬)
+        if is_serial and requester:
+            async with self._counter_lock:
+                self._time_attack_in_flight += 1
+
+            try:
+                # 1. 장벽 대기
+                if not self._barrier_event.is_set():
+                    try:
+                        # 25초 후 데드락 해제
+                        await asyncio.wait_for(self._barrier_event.wait(), timeout=25.0)
+                    except asyncio.TimeoutError:
+                        if not self._time_phase_active:
+                            print(f"\n[!] Deadlock Breaker: Time-based phase forced.")
+                    
+                if not self._time_phase_active:
+                    print(f"\n[★TRANSITION] Barrier cleared. Starting REAL time-based attacks!")
+                    self._time_phase_active = True
+
+                # 2. 전역 직렬 실행 락
+                async with self._global_time_lock:
+                    real_val = getattr(payload, "_real_time_value", "1")
+                    actual_payload = dataclasses.replace(payload, value=real_val)
+                    
+                    try:
+                        start_ts = asyncio.get_event_loop().time()
+                        real_res = await requester(real_val)
+                        real_elapsed = asyncio.get_event_loop().time() - start_ts
+                        
+                        # 서버 회복 대기
+                        await asyncio.sleep(4.5)
+
+                        is_hit, evidences, has_syntax_error = detect_sqli(
+                            response=real_res, payload=actual_payload, elapsed_time=real_elapsed,
+                            exploit_signatures=self.exploit_signatures,
+                            syntax_signatures=self.syntax_signatures,
+                            mismatch_signatures=self.mismatch_signatures,
+                            original_res=original_res
+                        )
+
+                        if is_hit and not any(tag in str(evidences) for tag in ["[Time]", "[Error]", "[Reflection]"]):
+                            is_hit, evidences = await verify_sqli_logic(
+                                real_res, actual_payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
+                            )
+                        return is_hit, evidences, actual_payload
+
+                    except asyncio.TimeoutError:
+                        is_hit, evidences, _ = detect_sqli(
+                            response=None, payload=actual_payload, elapsed_time=15.0,
+                            exploit_signatures=self.exploit_signatures,
+                            syntax_signatures=self.syntax_signatures,
+                            mismatch_signatures=self.mismatch_signatures,
+                            original_res=original_res
+                        )
+                        return True, evidences, actual_payload
+            finally:
+                async with self._counter_lock:
+                    self._time_attack_in_flight -= 1
+                    if self._time_attack_in_flight == 0:
+                        if self._time_phase_active:
+                            print(f"[★TRANSITION] Going back to normal payloads")
+                            self._barrier_event.clear()
+                            self._time_phase_active = False
+
+        return False, [], payload

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -164,6 +164,7 @@ class SQLiModule(BaseModule):
                         await asyncio.wait_for(self._barrier_event.wait(), timeout=25.0)
                     except asyncio.TimeoutError:
                         if not self._time_phase_active:
+                            pass
                     
                 if not self._time_phase_active:
                     self._time_phase_active = True

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -164,10 +164,8 @@ class SQLiModule(BaseModule):
                         await asyncio.wait_for(self._barrier_event.wait(), timeout=25.0)
                     except asyncio.TimeoutError:
                         if not self._time_phase_active:
-                            print(f"\n[!] Deadlock Breaker: Time-based phase forced.")
                     
                 if not self._time_phase_active:
-                    print(f"\n[★TRANSITION] Barrier cleared. Starting REAL time-based attacks!")
                     self._time_phase_active = True
 
                 # 2. 전역 직렬 실행 락
@@ -211,7 +209,6 @@ class SQLiModule(BaseModule):
                     self._time_attack_in_flight -= 1
                     if self._time_attack_in_flight == 0:
                         if self._time_phase_active:
-                            print(f"[★TRANSITION] Going back to normal payloads")
                             self._barrier_event.clear()
                             self._time_phase_active = False
 

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -4,7 +4,7 @@ import urllib.parse
 import re
 import dataclasses
 import random
-from typing import Iterator
+from typing import Iterator, Any, Tuple, List
 from modules.base_module import BaseModule
 from modules.sqli.payloads import get_sqli_payloads
 from modules.sqli.analyzer import detect_sqli, verify_sqli_logic 
@@ -36,10 +36,10 @@ class SQLiModule(BaseModule):
         return "time" in attack_type or "stacked" in attack_type
 
     def get_payloads(self) -> Iterator[Any]:
-
+        
         # 1. 원본 소스 로드
         all_raw = get_sqli_payloads()
-        
+                
         # 2. 인덱스 기반 분류
         fast_indices = []
         time_indices = []
@@ -58,10 +58,8 @@ class SQLiModule(BaseModule):
             limit = min(limit, len(time_indices))
             selected_time_indices = random.sample(time_indices, limit)
 
-        # 추가 리스트 없이 순회하며 생성
         for idx in (fast_indices + selected_time_indices):
             p = all_raw[idx]
-            
             # 우회 기법 필요할 때만 적용
             evasion_value = self._apply_evasion_by_level(p.value)
             yield dataclasses.replace(p, value=evasion_value)
@@ -71,13 +69,10 @@ class SQLiModule(BaseModule):
         del time_indices
 
     def get_payload_count(self) -> int:
-
         all_raw = get_sqli_payloads()
-        
         fast_count = 0
         time_total_count = 0
 
-        # 페이로드 추가 시 한 번만 개수 카운트
         for p in all_raw:
             if self._is_time_payload(p):
                 time_total_count += 1
@@ -104,7 +99,7 @@ class SQLiModule(BaseModule):
             value += "%00"
         return value
 
-    async def analyze(self, response, payload, elapsed_time, original_res=None, requester=None):
+    async def analyze(self, response, payload, elapsed_time, original_res=None, requester=None) -> Tuple[bool, List[str]]:
         is_vuln_1st, evidences, has_syntax_error = detect_sqli(
             response=response,
             payload=payload,
@@ -126,6 +121,6 @@ class SQLiModule(BaseModule):
         )
 
         if final_hit:
-            object.__setattr__(payload, 'last_evidences', final_evidences)
-            return True
-        return False
+            return True, final_evidences
+        
+        return False, []

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -111,14 +111,14 @@ class SQLiModule(BaseModule):
                     )
 
     def _apply_evasion_by_level(self, value: str, level: int) -> str:
-        if level <= 0: return value
-        if level >= 1:
+        if level == 0: return value
+        if level == 1:
             value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")\
                          .replace("AND", "aNd").replace("OR", "oR")\
                          .replace("CASE", "cAsE").replace("WHEN", "wHeN")
-        if level >= 2:
+        if level == 2:
             value = value.replace(" ", "/**/")
-        if level >= 3:
+        if level == 3:
             value = urllib.parse.quote(urllib.parse.quote(value)) + "%00"
         return value
 

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -143,7 +143,7 @@ class SQLiModule(BaseModule):
                 final_hit, final_evidences = await verify_sqli_logic(
                     response, payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
                 )
-                return final_hit, final_evidences, payload
+                return final_hit
             finally:
                 async with self._counter_lock:
                     self._global_fast_completed += 1
@@ -194,7 +194,7 @@ class SQLiModule(BaseModule):
                             is_hit, evidences = await verify_sqli_logic(
                                 real_res, actual_payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
                             )
-                        return is_hit, evidences, actual_payload
+                        return is_hit
 
                     except asyncio.TimeoutError:
                         is_hit, evidences, _ = detect_sqli(
@@ -204,7 +204,7 @@ class SQLiModule(BaseModule):
                             mismatch_signatures=self.mismatch_signatures,
                             original_res=original_res
                         )
-                        return True, evidences, actual_payload
+                        return True
             finally:
                 async with self._counter_lock:
                     self._time_attack_in_flight -= 1
@@ -213,4 +213,4 @@ class SQLiModule(BaseModule):
                             self._barrier_event.clear()
                             self._time_phase_active = False
 
-        return False, [], payload
+        return False

--- a/modules/sqli/payloads.py
+++ b/modules/sqli/payloads.py
@@ -1,5 +1,6 @@
 import os
 import random
+import dataclasses
 from core.models import Payload
 
 def _resolve_payload_file() -> str | None:
@@ -12,7 +13,6 @@ def _resolve_payload_file() -> str | None:
     return None
 
 def get_dbms_specific_marker(text: str, dbms: str) -> str:
-
     if not text:
         return "''"
     
@@ -36,7 +36,6 @@ def get_dbms_specific_marker(text: str, dbms: str) -> str:
 
     # 5. 기타/Generic: 문자열 쪼개기 시도
     else:
-        # 'v' + 'un' 형태로 쪼개서 반사 제거 우회
         return " + ".join([f"'{c}'" for c in text])
 
 def get_sqli_payloads() -> list[Payload]:
@@ -47,8 +46,6 @@ def get_sqli_payloads() -> list[Payload]:
 
     DELIM_START = "SVSDAAAA"
     DELIM_STOP = "VASDAAAA"
-    
-    # 구조: { "MySQL": (start_m, stop_m, vun_m), "Oracle": (...) }
     marker_cache = {}
 
     with open(file_path, "r", encoding="utf-8") as f:
@@ -57,7 +54,7 @@ def get_sqli_payloads() -> list[Payload]:
             if not line or ":::" not in line:
                 continue
 
-            parts = [p.strip() for p in line.split(":::")]
+            parts = [p.strip() for p in line.split(":::", 3)]
 
             if len(parts) >= 4:
                 raw_value = parts[0]
@@ -65,7 +62,6 @@ def get_sqli_payloads() -> list[Payload]:
                 risk_level = parts[2]
                 dbms = parts[3]
 
-                # 해당 DBMS에 대한 마커가 이미 계산되어 캐시된 값 있는지 확인하고 없는 경우에만 계산
                 if dbms not in marker_cache:
                     marker_cache[dbms] = (
                         get_dbms_specific_marker(DELIM_START, dbms),
@@ -81,7 +77,7 @@ def get_sqli_payloads() -> list[Payload]:
                 final_value = final_value.replace("'[STOP_M]'", stop_marker).replace("[STOP_M]", stop_marker)
                 final_value = final_value.replace("'vun'", vun_marker).replace('"vun"', vun_marker)
 
-                # 2. 기타 플레이스홀더 처리
+                # 2. 숫자형 및 기타 플레이스홀더 최종 처리
                 for i in range(1, 10):
                     final_value = final_value.replace(f"[RANDNUM{i}]", str(i))
                 final_value = final_value.replace("[RANDNUM]", "1")


### PR DESCRIPTION
## 📌 PR 목적 (What)
sqli 모듈의 탐지 로직 수정과 시간 페이로드 직렬 처리를 위한 engine.py의 analyze 반환 타입 수정

## 🛠️ 주요 변경 사항 (How)
- analyzer.py
  - 응답을 비교할 때 순수 텍스트의 유사도를 비교할 수 있도록 get_text_ratio, _get_pure_text 추가, 이전 비교 방식 제거
  - boolean 취약점 검증 조건을 'baseline과 유사하거나, baseline 보다 10% 이상 길면서 20 바이트 이상 길 것'으로 수정
- core.model.py: payload 의 evidence 삭제
- fuzzer/engine.py: 분석 결과를 tuple로 result에 저장
- sqli/module.py: 결과를 tuple로 반환하도록 수정

###  추가 변경 사항(26/5/6)
- payload.py:
  - sqli.txt를 3개까지만 분할하여 페이로드 내부에 ::: 가 포함되어도 파싱 깨짐 방지.
- engine.py:
  - 시간 페이로드 처리 시 엔진으로 보내는 최초 페이로드가 서버 자원 점유와 노이즈 문제를 일으키지 않도록 더미 값 '1'을 보내도록 했으므로 리포트에 출력할 실제 페이로드를 받아오기 위해서 analyze의 반환 타입을 3 tuple로(하위 호환 가능) 수정.
- analyzer.py:
  - 탐지 로직 전면 수정.
- module.py:
  - 시간 페이로드를 분리해서 직렬로 실행하도록 각 attack surface의 파라미터 당 일반 페이로드 개수 계산 후 일반 페이로드가 모두 완료되기 전까지 시간 페이로드는 워커를 하나씩 점유하고 대기하다가 모든 워커가 점유되었거나, 일반 페이로드가 모두 실행되면 deadlock 해제 후 시간 페이로드 직렬 수행한 뒤, 워커의 시간 페이로드가 모두 소진되면 다시 일반 페이로드 실행하도록 수정.

###  추가 변경 사항(26/5/7)
- engine.py:
  - 브랜치 분리를 위한 롤백.
- module.py:
  - 롤백된 engine.py 와 호환되도록 analyze 메서드 반환 수정
## 🧪 테스트 결과 (Testing & Verification)
- 테스트 환경
  - 입력값: py main.py -u "http://snowden.kr" -t sqli -c "PHPSESSID=세션ID; security=low" -r 50   --sqli-evasion-level 0
  - Attack Surface:  vulnerabilities/sqli/, vulnerabilities/sqli_blind/
- 테스트 결과
  - 에러 기반 67개, boolean 기반 141개로 총 208개 검출되었고 이전 pr에서 코멘트 해주신 제대로 탐지되지 않는 페이로드들은 잘 탐지되는 거 확인했습니다. 
  
### 추가 테스트 결과(25/5/6)
- 테스트 환경
  - 입력값: py main.py -u "http://snowden.kr" -t sqli -c "PHPSESSID=세션ID; security=low" -r 50   --sqli-evasion-level 0
  - Attack Surface:  vulnerabilities/sqli/, vulnerabilities/sqli_blind/
 - 테스트 결과
   - 에러 기반 29개, boolean 기반 53개로 총 82개 검출되었습니다.
## 💡 리뷰어 참고 사항
@팀B(김진우): 시간 기반 페이로드를 추가하면 쓰로틀값을 -r 3 까지 낮춰도 시간 기반 페이로드가 아닌 페이로드에서 boolean 취약점이 추가로 검출되는 문제와 같은 설정값으로 테스트 해도 매번 탐지 결과가 다른 문제가 있습니다.  엔진에 이중 semaphore를 적용해서 시간 기반 페이로드가 나갈 때는 다른 시간 기반 페이로드의 진입을 막는 등의 조치가 필요할 거 같습니다. 

sqli 모듈은 아래와 같은 구조로 수정하면 해결될 거 같습니다.

동적 baseline 적용 -> 시간 기반 페이로드가 아니면 시간 기반 탐지하지 않게 수정 + 정상적인 속도보다 매우 느린 응답을 받은 일반 페이로드는 최대 전송 횟수까지 재전송

### 추가 참고 사항(26/5/2)
 통합 테스트의 AttributeError 발생 원인은 core.model의 payload에 evidence 필드 누락이었습니다. 원래 core.model의 Payload 데이터 클래스에 evidence 필드를 추가해서 이를 sqli/analyzer.py 에서 수정 후 engine.py 에서 받아오도록 되어 있었는데, 데이터 흐름의 명시성 확보를 위해 result를 각 모듈의 analyze 메서드로부터 탐지/비탐지를 나타내는 boolean과 상세 증거 리스트 evidence의 tuple로 반환받도록 수정했습니다.
 
 ### 추가 참고 사항(26/5/6)
 시간 페이로드 300개를 level 0부터 3까지 넣어서 135종류의 페이로드로 285건 탐지했는데 같은 페이로드도 level별로 탐지 결과가 다르고 다른 코드로 테스트해 보면 114건의 탐지는 재현이 안 되는데 원인을 더 찾아봐야 할 거 같습니다.

 ### 추가 참고 사항(26/5/7)
 엔진 롤백과 호환성 관련 수정 완료했습니다. 엔진 수정 사항은 별도 브랜치에서 pr 올리겠습니다. 
 
## ✅ 다음 작업 (Next Step)
- time based payload 테스트 결과 검증, OS Command Injection 모듈 구현
