### PR TITLE
[feat] engine.py의 sqli 모듈의 시간 페이로드 전달을 위한 analyze 메서드 변환 형식 수정

### DIFF
--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -73,7 +73,8 @@ class AttackModule(Protocol):
         elapsed_time: float,
         original_res: Any | None = None,
         requester: Callable[[str], Awaitable[Any]] | None = None,
-    ) -> bool | Awaitable[bool]: ...
+    ) -> tuple[bool, list[str], Any] | Awaitable[tuple[bool, list[str], Any]]: ...
+    #또는) -> bool | Awaitable[bool]: 
 
 
 class FuzzerEngine:
@@ -263,8 +264,6 @@ class FuzzerEngine:
         is_hit = await verdict if isawaitable(verdict) else verdict
         if not is_hit:
             return
-
-        evidences = getattr(job.payload, "last_evidences", None)
 
         finding = Finding(
             surface=job.surface,
@@ -528,7 +527,24 @@ class FuzzerEngine:
             original_res=baseline_response,
             requester=module_requester
         )
-        is_hit = await verdict if isawaitable(verdict) else verdict
+
+        if isawaitable(verdict):
+            verdict = await verdict
+
+        if isinstance(verdict, tuple):
+            if len(verdict) == 3:
+                is_hit, evidences, actual_payload = verdict
+            elif len(verdict) == 2:
+                is_hit, evidences = verdict
+                actual_payload = payload
+            else:
+                is_hit = verdict[0]
+                evidences = []
+                actual_payload = payload
+        else:
+            is_hit = bool(verdict)
+            evidences = []
+            actual_payload = payload
 
         async with self._stats_lock:
             self._stats.completed += 1
@@ -542,7 +558,7 @@ class FuzzerEngine:
                 session=session,
                 surface=surface,
                 parameter=parameter,
-                payload=payload,
+                payload=actual_payload,
                 response=response,
                 baseline_response=baseline_response,
             )
@@ -552,12 +568,10 @@ class FuzzerEngine:
             if not is_verified:
                 return
 
-        evidences = getattr(payload, "last_evidences", [])
-
         finding = Finding(
             surface=surface,
             parameter=parameter,
-            payload=payload,
+            payload=actual_payload,
             response=response,
             module_name=module.name,
             evidences=evidences

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -1,8 +1,29 @@
 import re
 import html
+import asyncio
 from urllib.parse import unquote
+from difflib import SequenceMatcher
+
+def _get_pure_text(html_content: str) -> str:
+    """HTML 태그, 스크립트 등을 제거하여 순수 텍스트만 추출 (노이즈 제거)"""
+    if not html_content:
+        return ""
+    text = re.sub(r'<(script|style).*?>.*?</\1>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<[^>]+?>', ' ', text)
+    text = html.unescape(text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+def get_text_ratio(text1: str, text2: str) -> float:
+    """순수 텍스트 유사도 비율 계산"""
+    pure1 = _get_pure_text(text1)
+    pure2 = _get_pure_text(text2)
+    if not pure1 and not pure2: return 1.0
+    if not pure1 or not pure2: return 0.0
+    return SequenceMatcher(None, pure1, pure2).ratio()
 
 def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None):
+
     evidences = []
     res_text = response.text
     
@@ -12,13 +33,24 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
 
     attack_type = payload.attack_type.lower()
     payload_value = payload.value
-    marker = "SVSDAAAAvunVASDAAAA"
+    marker_start = "SVSDAAAA"
+    marker_stop = "VASDAAAA"
+    dynamic_marker_pattern = re.compile(f"{marker_start}(.*?){marker_stop}", re.I | re.DOTALL)
 
     has_syntax_error = False
     has_execution_error = False
     has_potential_mismatch = False
 
-    # [1] 문법 오류 식별 및 영역 제거
+    timing_keywords = ["sleep(", "waitfor delay", "pg_sleep", "benchmark(", "dbms_pipe.receive_message", "regexp_substring", "repeat("]
+    has_timing_intent = any(k in payload_value.lower() for k in timing_keywords)
+    is_time_related = "time" in attack_type or "stacked" in attack_type or has_timing_intent
+    # 시간 페이로드 타임아웃 탐지
+    if is_time_related and response is None:
+        if elapsed_time >= 4.0:
+            evidences.append(f"[Time] Request Timed Out: {elapsed_time:.2f}s")
+        return len(evidences) > 0, evidences, False
+
+    # [1] 문법 오류 식별
     scrubbed_text = res_text
     for pattern in syntax_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
@@ -30,125 +62,150 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
     for var in filter(None, set(payload_variants)):
         scrubbed_text = scrubbed_text.replace(var, "[DIRECT_REFLECTION_REMOVED]")
 
-    # --- 탐지 로직 시작 ---
-
     # 1. 시간 기반 탐지
-    timing_keywords = ["sleep(", "waitfor delay", "pg_sleep", "benchmark(", "dbms_pipe.receive_message"]
-    has_timing_intent = any(k in payload_value.lower() for k in timing_keywords)
-    is_time_related = "time" in attack_type or "stacked" in attack_type or has_timing_intent
-    if is_time_related and elapsed_time >= (4.5 + orig_elapsed):
+    if is_time_related and elapsed_time >= (4.0 + orig_elapsed):
         evidences.append(f"[Time] Response delayed: {elapsed_time:.2f}s")
 
-    # 2. 실행 에러 및 DBMS 불일치 판별
+    # 2. 에러 기반 탐지
     for pattern in exploit_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
-            evidences.append(f"[Error] SQL Execution Error: {pattern}")
-            has_execution_error = True
+            marker_match = dynamic_marker_pattern.search(res_text)
+            
+            if marker_match:
+                extracted_data = marker_match.group(1)
+                evidences.append(f"[Error] SQL Execution Error (Marker Found: '{extracted_data}'): {pattern}")
+                has_execution_error = True
+            else:
+                evidences.append(f"[ExecutionErr] SQL Execution Error (No Marker): {pattern}")
             break
 
-    if not has_execution_error:
+    if not has_execution_error and not any("[ExecutionErr]" in e for e in evidences):
         for pattern in mismatch_signatures:
             if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
-                evidences.append(f"[Potential] DBMS Mismatch Error: {pattern}")
+                evidences.append(f"[Mismatch] DBMS Mismatch Error: {pattern}")
                 has_potential_mismatch = True
                 break
 
     # 3. 마커 검증
-    marker_lower = marker.lower()
-    if marker_lower in res_text.lower() and marker_lower in scrubbed_text.lower():
-        if has_syntax_error or has_execution_error:
-            evidences.append(f"[Error] SQLi execution marker confirmed in DB output")
-        else:
-            evidences.append(f"[Reflection] SQLi marker confirmed in legitimate content")
+    if not has_execution_error:
+        # 동적 마커 패턴 검색
+        marker_match_res = dynamic_marker_pattern.search(res_text)
+        marker_match_scrubbed = dynamic_marker_pattern.search(scrubbed_text)
+
+        if marker_match_res and marker_match_scrubbed:
+            extracted_data = marker_match_res.group(1)
+            
+            if has_syntax_error or any("executionerr" in e.lower() for e in evidences):
+                evidences.append(f"[Error] SQLi execution marker ('{extracted_data}') confirmed in DB output context")
+                has_execution_error = True
+            else:
+                # 에러가 확인되지 않았는데 마커만 발견된 경우 단순 반사 또는 exploit_signatures에 없는 에러 메시지에서 데이터 추출
+                evidences.append(f"[Reflection] SQLi marker ('{extracted_data}') confirmed in legitimate content")
 
     # 4. 불리언 기반 탐지
-    if (not evidences or has_potential_mismatch) and not has_syntax_error and original_res:
+    if (not evidences or has_potential_mismatch or any("[ExecutionErr]" in e for e in evidences)) and not has_syntax_error and original_res:
         if current_status != orig_status:
             evidences.append(f"[Boolean] Status Code changed: {orig_status} -> {current_status}")
 
-        orig_text_lower = original_res.text.lower()
-        curr_text_lower = scrubbed_text.lower()
-
-        if len(orig_text_lower) > 0:
-            diff_bytes = abs(len(original_res.text) - len(res_text))
-            if diff_bytes > 0:
-                evidences.append(f"[Boolean] Content length changed by {diff_bytes} bytes")
+        ratio = get_text_ratio(original_res.text, res_text)
+        if ratio < 0.995:
+            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f}")
             
+            orig_pure = _get_pure_text(original_res.text).lower()
+            curr_pure = _get_pure_text(res_text).lower()
             blind_keywords = ["exists", "missing", "found", "success", "failed", "invalid", "true", "false"]
             for kw in blind_keywords:
-                if (kw in orig_text_lower) != (kw in curr_text_lower):
+                if (kw in orig_pure) != (kw in curr_pure):
                     evidences.append(f"[Boolean] Blind keyword '{kw}' state inverted")
                     break
 
     return len(evidences) > 0, evidences, has_syntax_error
 
-async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_1st, evidences, has_syntax_error):
+async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_1st, evidences, has_syntax_error, syntax_signatures=None):
     if not requester or not original_res:
         return is_vuln_1st, evidences
 
     val = payload.value
     res_text = response.text
     orig_text = original_res.text
-    is_true_legit = is_similar_pure(res_text, orig_text)
+    orig_status = getattr(original_res, "status", getattr(original_res, "status_code", None))
+    
+    true_ratio = get_text_ratio(orig_text, res_text)
+    pure_res = _get_pure_text(res_text)
+    pure_orig = _get_pure_text(orig_text)
+    
+    logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
+    is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
+    is_blind_candidate = (true_ratio >= 0.95) and (not is_true_expanded)
 
-    # [A] 1차 탐지에서 변화가 감지된 경우
-    if is_vuln_1st:
-        if any(tag in str(evidences) for tag in ["[Error]", "[Time]", "[Reflection]"]):
+    # [A] 1차 탐지에서 변화 감지
+    if is_vuln_1st: 
+        if any(tag in str(evidences) for tag in ["[Error]", "[Reflection]", "[Time]"]):
             return True, evidences
 
-        # 참 조건이 원본과 비슷할 때만 수행
-        if is_true_legit:
-            # 전략 1: 구문 복구 테스트 (Quote 복구)
+        # Path 1: 구조적 파손 검증 (주석 처리)
+        if not is_true_expanded and not is_blind_candidate:
             if val.strip().endswith("'") or val.strip().endswith('"'):
                 fix_res = await requester(val + " -- ")
-                if is_similar_pure(fix_res.text, orig_text):
-                    return True, evidences + ["[Verified] Syntax Fix Test"]
+                ratio = get_text_ratio(fix_res.text, orig_text)
+                if ratio >= 0.99:
+                    return True, evidences + [f"[Verified] Syntax Fix Test(broken) Ratio: {ratio:.4f}"]
 
-            # 전략 2: 논리 패턴 반전
-            logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
-            if re.search(logic_pattern, val) or "1=1" in val:
+        # Path 2: 논리 반전 테스트
+        has_logic = re.search(logic_pattern, val) or "1=1" in val
+        
+        if is_true_expanded or is_blind_candidate or has_logic or any(tag in str(evidences) for tag in ["[ExecutionErr]"]):
+            
+            # 주석 복구 시도
+            if val.strip().endswith("'") or val.strip().endswith('"'):
+                fix_res = await requester(val + " -- ")
+                fix_ratio = get_text_ratio(fix_res.text, orig_text)
+                if fix_ratio >= 0.99:
+                    return True, evidences + [f"[Verified] Syntax Fix Test Ratio: {fix_ratio:.4f}"]
+
+            # 논리 반전 테스트
+            if has_logic:
                 false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
                 false_res = await requester(false_payload)
-                if not is_similar(false_res.text, res_text):
-                    return True, evidences + ["[Verified] Logic Swapping (True!=False)"]
+                false_res_text = false_res.text
+                false_pure_res = _get_pure_text(false_res_text)
+                false_status = getattr(false_res, "status", getattr(false_res, "status_code", None))
+                
+                # 거짓 응답 문법 에러 확인
+                false_has_syntax_error = False
+                if syntax_signatures:
+                    for pattern in syntax_signatures:
+                        if re.search(pattern, false_res_text, re.I | re.DOTALL):
+                            false_has_syntax_error = True
+                            break
 
-    # [B] 변화 미감지 시
+                # [검증 1] 참 조건 응답에 데이터가 추가되었고 참 조건 응답과 거짓 조건 응답이 다른가
+                if is_true_expanded:
+                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+                    if f_to_t_ratio < 0.98:
+                        tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}"
+                        return True, evidences + [tag]
+                
+                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 같은가
+                elif is_blind_candidate:
+                    f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
+                    if false_status == orig_status and f_to_orig_ratio >= 0.98:
+                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False==Baseline) Ratio: {f_to_orig_ratio:.4f}"]
+
+                # [검증 3] 거짓 조건 응답에 데이터가 추가되었고, 참 조건 응답과 거짓조건 응답이 다른가
+                is_false_expanded = (len(false_pure_res) >= len(pure_orig) * 1.1) and (len(false_pure_res) - len(pure_orig) >= 20)
+                if not false_has_syntax_error and is_false_expanded:
+                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+                    if f_to_t_ratio < 0.98:
+                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False Expansion) Ratio: {f_to_t_ratio:.4f}"]
+
+    # [B]: 1차 탐지에서 변화 미감지
     elif not has_syntax_error:
-        logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
         if re.search(logic_pattern, val) or "1=1" in val:
             false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
-            if false_payload != val:
-                false_res = await requester(false_payload)
-                if is_true_legit and not is_similar(false_res.text, res_text):
-                    return True, ["[Verified] Blind SQLi (Baseline==True and True!=False)"]
+            false_res = await requester(false_payload)
+            f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+            if f_to_t_ratio < 0.99:
+                return True, [f"[Verified] Blind SQLi (Baseline==True and True!=False) Ratio: {f_to_t_ratio:.4f}"]
 
     return False, []
-
-def is_similar(text1: str, text2: str) -> bool:
-    if not text1 or not text2: return False
-    l1, l2 = len(text1), len(text2)
-    diff = abs(l1 - l2)
-    return (diff / max(l1, l2)) < 0.015
-
-def _get_pure_text(html_content: str) -> str:
-    if not html_content:
-        return ""
-    # 1. Script 및 Style 내용 제거
-    text = re.sub(r'<(script|style).*?>.*?</\1>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
-    # 2. HTML 태그 제거
-    text = re.sub(r'<[^>]+?>', ' ', text)
-    # 3. HTML 엔티티 변환 (&nbsp; 등)
-    text = html.unescape(text)
-    # 4. 연속된 공백 및 줄바꿈 정리
-    text = re.sub(r'\s+', ' ', text).strip()
-    return text
-
-def is_similar_pure(text1: str, text2: str) -> bool:
-    pure1 = _get_pure_text(text1)
-    pure2 = _get_pure_text(text2)
-    
-    if not pure1 and not pure2: return True
-    if not pure1 or not pure2: return False
-    
-    diff = abs(len(pure1) - len(pure2))
-    return (diff / max(len(pure1), len(pure2))) < 0.015

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -109,7 +109,7 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
 
         ratio = get_text_ratio(original_res.text, res_text)
         if ratio < 0.995:
-            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f}")
+            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f} (Baseline Status: {orig_status})")
             
             orig_pure = _get_pure_text(original_res.text).lower()
             curr_pure = _get_pure_text(res_text).lower()
@@ -136,7 +136,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
     
     logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
     is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
-    is_blind_candidate = (true_ratio >= 0.95) and (not is_true_expanded)
+    is_blind_candidate = (99 > true_ratio >= 0.95) and (not is_true_expanded)
 
     # [A] 1차 탐지에서 변화 감지
     if is_vuln_1st: 
@@ -186,10 +186,11 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
                         tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}"
                         return True, evidences + [tag]
                 
-                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 같은가
+                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 baseline과 같으면서 참 조건 응답과 다른가
                 elif is_blind_candidate:
                     f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
-                    if false_status == orig_status and f_to_orig_ratio >= 0.98:
+                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
+                    if f_to_t_ratio < 0.99 and false_status == orig_status and f_to_orig_ratio >= 0.98:
                         return True, evidences + [f"[Verified] Inverted Logic Swapping (False==Baseline) Ratio: {f_to_orig_ratio:.4f}"]
 
                 # [검증 3] 거짓 조건 응답에 데이터가 추가되었고, 참 조건 응답과 거짓조건 응답이 다른가
@@ -206,6 +207,6 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
             false_res = await requester(false_payload)
             f_to_t_ratio = get_text_ratio(false_res.text, res_text)
             if f_to_t_ratio < 0.99:
-                return True, [f"[Verified] Blind SQLi (Baseline==True and True!=False) Ratio: {f_to_t_ratio:.4f}"]
+                return True, [f"[Verified] Blind SQLi (Baseline==True(Status: {orig_status}) and True!=False) Ratio: {f_to_t_ratio:.4f}"]
 
     return False, []

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -4,10 +4,20 @@ import urllib.parse
 import re
 import dataclasses
 import random
-from typing import Any, Iterator
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Iterator, Any, Tuple, List, Optional, Iterable
+
 from modules.base_module import BaseModule
 from modules.sqli.payloads import get_sqli_payloads
-from modules.sqli.analyzer import detect_sqli, verify_sqli_logic 
+from modules.sqli.analyzer import detect_sqli, verify_sqli_logic
+from core.models import Payload
+
+@dataclass(frozen=True, slots=True)
+class SQLiInternalPayload(Payload):
+    _is_serial: bool = False
+    _real_time_value: Optional[str] = None
 
 class SQLiModule(BaseModule):
     def __init__(self, **kwargs):
@@ -20,117 +30,187 @@ class SQLiModule(BaseModule):
         self.include_time_based = kwargs.get('include_time_based', False)
         self.max_time_payloads = kwargs.get('max_time_payloads', 0)
         self.random_seed = kwargs.get('random_seed', 37)
+        
+        self._global_time_lock = asyncio.Lock()
+        self._fast_per_param = 0
+        self._known_targets = set()
+        self._total_fast_expected = 0
+        self._global_fast_completed = 0
+        self._counter_lock = asyncio.Lock()
+        
+        # 이벤트 기반 장벽을 통해 시간 페이로드 직렬 처리
+        self._barrier_event = asyncio.Event()
+        self._time_attack_in_flight = 0
+        self._time_phase_active = False
 
-    def _load_json(self, filename):
+    def _load_json(self, filename: str) -> list:
         file_path = os.path.join("config", "payloads", filename)
         if os.path.exists(file_path):
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     return json.load(f)
-            except Exception as e:
-                print(f"[-] [{self.name}] {filename} load failed: {e}")
+            except Exception:
+                return []
         return []
 
-    def _is_time_payload(self, payload) -> bool:
+    def _is_time_payload(self, payload: Payload) -> bool:
         attack_type = str(getattr(payload, "attack_type", "")).lower()
         return "time" in attack_type or "stacked" in attack_type
 
-    def get_payloads(self) -> Iterator[Any]:
+    def get_target_parameters(self, surface: Any, all_params: Iterable[str]) -> Iterable[str]:
+        params = list(all_params)
+        url = getattr(surface, "url", "")
+        method = getattr(surface, "method", "GET")
+        for p in params:
+            tid = (method, url, p)
+            if tid not in self._known_targets:
+                self._known_targets.add(tid)
+                self._total_fast_expected += self._fast_per_param
+        return params
 
-        # 1. 원본 소스 로드
+    def get_payload_count(self) -> int:
         all_raw = get_sqli_payloads()
+        fast_c = sum(1 for p in all_raw if not self._is_time_payload(p))
+        time_c = sum(1 for p in all_raw if self._is_time_payload(p))
         
-        # 2. 인덱스 기반 분류
-        fast_indices = []
-        time_indices = []
+        selected_time_count = 0
+        if self.include_time_based:
+            limit = self.max_time_payloads if self.max_time_payloads > 0 else time_c
+            selected_time_count = min(limit, time_c)
+        
+        multiplier = self.evasion_level + 1
+        self._fast_per_param = fast_c * multiplier
+        return self._fast_per_param + (selected_time_count * multiplier)
 
-        for i, p in enumerate(all_raw):
-            if self._is_time_payload(p):
-                time_indices.append(i)
-            else:
-                fast_indices.append(i)
+    def get_payloads(self) -> Iterator[Payload]:
+        if self._fast_per_param == 0: 
+            self.get_payload_count()
 
-        # 3. 랜덤 부여된 인덱스로 시간 기반 페이로드 샘플링
-        selected_time_indices = []
+        all_raw = get_sqli_payloads()
+        fast_indices = [i for i, p in enumerate(all_raw) if not self._is_time_payload(p)]
+        time_indices = [i for i, p in enumerate(all_raw) if self._is_time_payload(p)]
+
+        for level in range(self.evasion_level + 1):
+            for idx in fast_indices:
+                p = all_raw[idx]
+                yield SQLiInternalPayload(
+                    value=self._apply_evasion_by_level(p.value, level),
+                    attack_type=p.attack_type, risk_level=p.risk_level, _is_serial=False
+                )
+
         if self.include_time_based and time_indices:
             random.seed(self.random_seed)
             limit = self.max_time_payloads if self.max_time_payloads > 0 else len(time_indices)
-            limit = min(limit, len(time_indices))
-            selected_time_indices = random.sample(time_indices, limit)
+            selected_indices = random.sample(time_indices, min(limit, len(time_indices)))
+            for level in range(self.evasion_level + 1):
+                for idx in selected_indices:
+                    p = all_raw[idx]
+                    yield SQLiInternalPayload(
+                        value="1", attack_type=p.attack_type, risk_level=p.risk_level,
+                        _is_serial=True, _real_time_value=self._apply_evasion_by_level(p.value, level)
+                    )
 
-        # 추가 리스트 없이 순회하며 생성
-        for idx in (fast_indices + selected_time_indices):
-            p = all_raw[idx]
-            
-            # 우회 기법 필요할 때만 적용
-            evasion_value = self._apply_evasion_by_level(p.value)
-            yield dataclasses.replace(p, value=evasion_value)
-
-        del all_raw
-        del fast_indices
-        del time_indices
-
-    def get_payload_count(self) -> int:
-
-        all_raw = get_sqli_payloads()
-        
-        fast_count = 0
-        time_total_count = 0
-
-        # 페이로드 추가 시 한 번만 개수 카운트
-        for p in all_raw:
-            if self._is_time_payload(p):
-                time_total_count += 1
-            else:
-                fast_count += 1
-        
-        selected_time_count = 0
-        if self.include_time_based and time_total_count > 0:
-            limit = self.max_time_payloads if self.max_time_payloads > 0 else time_total_count
-            selected_time_count = min(limit, time_total_count)
-            
-        return fast_count + selected_time_count
-
-    def _apply_evasion_by_level(self, value: str) -> str:
-        if self.evasion_level <= 0: return value
-        if self.evasion_level >= 1:
-            value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")
-            value = value.replace("AND", "aNd").replace("OR", "oR")
-            value = value.replace("CASE", "cAsE").replace("WHEN", "wHeN")
-        if self.evasion_level >= 2:
+    def _apply_evasion_by_level(self, value: str, level: int) -> str:
+        if level <= 0: return value
+        if level >= 1:
+            value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")\
+                         .replace("AND", "aNd").replace("OR", "oR")\
+                         .replace("CASE", "cAsE").replace("WHEN", "wHeN")
+        if level >= 2:
             value = value.replace(" ", "/**/")
-        if self.evasion_level >= 3:
-            value = urllib.parse.quote(urllib.parse.quote(value))
-            value += "%00"
+        if level >= 3:
+            value = urllib.parse.quote(urllib.parse.quote(value)) + "%00"
         return value
 
-    async def analyze(self, response, payload, elapsed_time, original_res=None, requester=None):
-        is_vuln_1st, evidences, has_syntax_error = detect_sqli(
-            response=response,
-            payload=payload,
-            elapsed_time=elapsed_time,
-            exploit_signatures=self.exploit_signatures,
-            syntax_signatures=self.syntax_signatures,
-            mismatch_signatures=self.mismatch_signatures,
-            original_res=original_res
-        )
+    async def analyze(self, response: Any, payload: Any, elapsed_time: float, 
+                      original_res: Any = None, requester: Any = None) -> Tuple[bool, List[str], Any]:
+        is_serial = getattr(payload, "_is_serial", False)
 
-        final_hit, final_evidences = await verify_sqli_logic(
-            response=response,
-            payload=payload,
-            original_res=original_res,
-            requester=requester,
-            is_vuln_1st=is_vuln_1st,
-            evidences=evidences,
-            has_syntax_error=has_syntax_error
-        )
+        # [A] 일반 페이로드 분석 (병렬)
+        if not is_serial:
+            # 시간 페이즈 종료까지 대기
+            while self._time_phase_active:
+                await asyncio.sleep(2.0)
 
-        if final_hit:
-            # Payload can be a frozen/slots dataclass. In that case attaching
-            # ad-hoc metadata raises AttributeError; keep scan running anyway.
             try:
-                object.__setattr__(payload, 'last_evidences', final_evidences)
-            except (AttributeError, TypeError):
-                pass
-            return True
-        return False
+                is_hit, evidences, has_syntax_error = detect_sqli(
+                    response=response, payload=payload, elapsed_time=elapsed_time,
+                    exploit_signatures=self.exploit_signatures,
+                    syntax_signatures=self.syntax_signatures,
+                    mismatch_signatures=self.mismatch_signatures,
+                    original_res=original_res
+                )
+                final_hit, final_evidences = await verify_sqli_logic(
+                    response, payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
+                )
+                return final_hit, final_evidences, payload
+            finally:
+                async with self._counter_lock:
+                    self._global_fast_completed += 1
+                    if self._global_fast_completed >= self._total_fast_expected and self._total_fast_expected > 0:
+                        if not self._barrier_event.is_set():
+                            self._barrier_event.set()
+
+        # [B] 시간 기반 페이로드 분석 (직렬)
+        if is_serial and requester:
+            async with self._counter_lock:
+                self._time_attack_in_flight += 1
+
+            try:
+                # 1. 장벽 대기
+                if not self._barrier_event.is_set():
+                    try:
+                        # 25초 후 데드락 해제
+                        await asyncio.wait_for(self._barrier_event.wait(), timeout=25.0)
+                    except asyncio.TimeoutError:
+                        if not self._time_phase_active:
+                            pass
+                    
+                if not self._time_phase_active:
+                    self._time_phase_active = True
+
+                # 2. 전역 직렬 실행 락
+                async with self._global_time_lock:
+                    real_val = getattr(payload, "_real_time_value", "1")
+                    actual_payload = dataclasses.replace(payload, value=real_val)
+                    
+                    try:
+                        start_ts = asyncio.get_event_loop().time()
+                        real_res = await requester(real_val)
+                        real_elapsed = asyncio.get_event_loop().time() - start_ts
+                        
+                        # 서버 회복 대기
+                        await asyncio.sleep(4.5)
+
+                        is_hit, evidences, has_syntax_error = detect_sqli(
+                            response=real_res, payload=actual_payload, elapsed_time=real_elapsed,
+                            exploit_signatures=self.exploit_signatures,
+                            syntax_signatures=self.syntax_signatures,
+                            mismatch_signatures=self.mismatch_signatures,
+                            original_res=original_res
+                        )
+
+                        if is_hit and not any(tag in str(evidences) for tag in ["[Time]", "[Error]", "[Reflection]"]):
+                            is_hit, evidences = await verify_sqli_logic(
+                                real_res, actual_payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
+                            )
+                        return is_hit, evidences, actual_payload
+
+                    except asyncio.TimeoutError:
+                        is_hit, evidences, _ = detect_sqli(
+                            response=None, payload=actual_payload, elapsed_time=15.0,
+                            exploit_signatures=self.exploit_signatures,
+                            syntax_signatures=self.syntax_signatures,
+                            mismatch_signatures=self.mismatch_signatures,
+                            original_res=original_res
+                        )
+                        return True, evidences, actual_payload
+            finally:
+                async with self._counter_lock:
+                    self._time_attack_in_flight -= 1
+                    if self._time_attack_in_flight == 0:
+                        if self._time_phase_active:
+                            self._barrier_event.clear()
+                            self._time_phase_active = False
+
+        return False, [], payload

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -111,14 +111,14 @@ class SQLiModule(BaseModule):
                     )
 
     def _apply_evasion_by_level(self, value: str, level: int) -> str:
-        if level <= 0: return value
-        if level >= 1:
+        if level == 0: return value
+        if level == 1:
             value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")\
                          .replace("AND", "aNd").replace("OR", "oR")\
                          .replace("CASE", "cAsE").replace("WHEN", "wHeN")
-        if level >= 2:
+        if level == 2:
             value = value.replace(" ", "/**/")
-        if level >= 3:
+        if level == 3:
             value = urllib.parse.quote(urllib.parse.quote(value)) + "%00"
         return value
 

--- a/modules/sqli/payloads.py
+++ b/modules/sqli/payloads.py
@@ -1,5 +1,6 @@
 import os
 import random
+import dataclasses
 from core.models import Payload
 
 def _resolve_payload_file() -> str | None:
@@ -12,7 +13,6 @@ def _resolve_payload_file() -> str | None:
     return None
 
 def get_dbms_specific_marker(text: str, dbms: str) -> str:
-
     if not text:
         return "''"
     
@@ -36,7 +36,6 @@ def get_dbms_specific_marker(text: str, dbms: str) -> str:
 
     # 5. 기타/Generic: 문자열 쪼개기 시도
     else:
-        # 'v' + 'un' 형태로 쪼개서 반사 제거 우회
         return " + ".join([f"'{c}'" for c in text])
 
 def get_sqli_payloads() -> list[Payload]:
@@ -47,8 +46,6 @@ def get_sqli_payloads() -> list[Payload]:
 
     DELIM_START = "SVSDAAAA"
     DELIM_STOP = "VASDAAAA"
-    
-    # 구조: { "MySQL": (start_m, stop_m, vun_m), "Oracle": (...) }
     marker_cache = {}
 
     with open(file_path, "r", encoding="utf-8") as f:
@@ -57,7 +54,7 @@ def get_sqli_payloads() -> list[Payload]:
             if not line or ":::" not in line:
                 continue
 
-            parts = [p.strip() for p in line.split(":::")]
+            parts = [p.strip() for p in line.split(":::", 3)]
 
             if len(parts) >= 4:
                 raw_value = parts[0]
@@ -65,7 +62,6 @@ def get_sqli_payloads() -> list[Payload]:
                 risk_level = parts[2]
                 dbms = parts[3]
 
-                # 해당 DBMS에 대한 마커가 이미 계산되어 캐시된 값 있는지 확인하고 없는 경우에만 계산
                 if dbms not in marker_cache:
                     marker_cache[dbms] = (
                         get_dbms_specific_marker(DELIM_START, dbms),
@@ -81,7 +77,7 @@ def get_sqli_payloads() -> list[Payload]:
                 final_value = final_value.replace("'[STOP_M]'", stop_marker).replace("[STOP_M]", stop_marker)
                 final_value = final_value.replace("'vun'", vun_marker).replace('"vun"', vun_marker)
 
-                # 2. 기타 플레이스홀더 처리
+                # 2. 숫자형 및 기타 플레이스홀더 최종 처리
                 for i in range(1, 10):
                     final_value = final_value.replace(f"[RANDNUM{i}]", str(i))
                 final_value = final_value.replace("[RANDNUM]", "1")


### PR DESCRIPTION
## 📌 PR 목적 (What)
 sqli 모듈에서 시간 기반 페이로드 값을 baseline 생성 이후에 엔진으로 전달할 수 있도록 analyze 메서드의 반환 형식 수정 및 sqli 모듈의 evasion 레벨 적용 방식을 lfi 모듈의 방식으로 통일.
## 🛠️ 주요 변경 사항 (How)
- engine.py: verdict 를 analyze 메서드에서 3 튜플로 반환 받을 수 있도록 수정.
- analyzer.py: 검증 로직의 조건 누락 수정.
## 🧪 테스트 결과 (Testing & Verification)
- 테스트 환경
  - 입력값: py main.py -u "http://snowden.kr" -r 30 --login-url "http://snowden.kr/login.php" --username "admin" --password "password" --username-field "username" --password-field "password" --csrf-field "user_token" --submit-field "Login" -t sqli --sqli-evasion-level 0
- 테스트 결과
  - /sqli/ id 에서 66개, /sqli_blind/ id 에서28개, /brute/ username 에서 54개 검출되었습니다. 
  - 매번 결과가 달라지는 file_upload 모듈 제외 다른 모듈에서 이전과 동일하게 검출되는 것 확인했습니다.
## 💡 리뷰어 참고 사항
 sqli 모듈에서 시간 기반 페이로드의 baseline을 일반 페이로드와 같이 엔진에서 basline 요청을 보내게 되면 서버에 과부하가 걸립니다. 따라서 엔진에는 우선 더미 페이로드 '1'을 보내서 받은 baseline은 무시하고, module.py 에서 시간 페이로드 분석 전 실제 공격 페이로드로 다시 baseline을 받도록 구현했고, 엔진에서도 실제 페이로드를 리포트에 전달할 수 있도록 sqli 모듈의 analyze 메서드의 반환 형식을 3 튜플로 변경했습니다. 
 
 통합 후 /sqli/에서 12개가 더 탐지되었는데, 기존의 mock_parser.py 에서 파라미터에 1을 넣어서 받아오던 baseline이 변경되어 결과가 달라졌습니다.
## ✅ 다음 작업 (Next Step)
- OS Command Injection 모듈 구현
