### PR TITLE
[fix] Content-Type 헤더 오염 수정

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -93,4 +93,3 @@ async def run_scan(args, *, base_url: str, surfaces) -> None:
 
 async def _request_sender(session, surface, parameter, payload):
     return await build_and_send_request(session, surface, parameter, payload)
-

--- a/fuzzer/request_builder.py
+++ b/fuzzer/request_builder.py
@@ -29,6 +29,35 @@ _HOP_BY_HOP_OR_RESPONSE_HEADERS = {
     "via",
 }
 
+# Names almost always copied from an HTML *response* into crawled AttackSurface.headers.
+# Forwarding them on fuzz requests looks like a browser POST but confuses servers and logs.
+_CRAWLED_RESPONSE_METADATA_HEADERS = frozenset(
+    {
+        "content-type",
+        "etag",
+        "x-powered-by",
+        "last-modified",
+        "expires",
+        "vary",
+        "age",
+        "cache-control",
+        "pragma",
+        "cf-ray",
+        "cf-cache-status",
+        "x-cache",
+        "x-served-by",
+        "x-frame-options",
+        "x-content-type-options",
+        "content-security-policy",
+        "strict-transport-security",
+        "report-to",
+        "nel",
+        "server-timing",
+    }
+)
+
+_HEADERS_STRIP_FROM_OUTBOUND = _HOP_BY_HOP_OR_RESPONSE_HEADERS | _CRAWLED_RESPONSE_METADATA_HEADERS
+
 
 @dataclass(slots=True)
 class FuzzerResponse:
@@ -112,6 +141,9 @@ async def fetch_dynamic_tokens(
     cookies = copy.deepcopy(cookies_override) if cookies_override is not None else (
         copy.deepcopy(surface.cookies) if surface.cookies else {}
     )
+
+    if headers:
+        headers = _sanitize_headers_for_request(headers)
 
     request_kwargs: dict[str, Any] = {}
     if headers:
@@ -239,17 +271,18 @@ def _resolve_payload_value(payload: Any) -> str:
     return str(payload)
 
 
-def _sanitize_headers_for_request(headers: dict[str, Any], *, is_file_payload: bool) -> dict[str, Any]:
+def _sanitize_headers_for_request(headers: dict[str, Any]) -> dict[str, Any]:
     """
-    AttackSurface may carry crawled response headers.
-    Strip response-only headers and let aiohttp set multipart Content-Type.
+    AttackSurface may carry crawled *response* headers.
+
+    Drop hop-by-hop / response metadata so outbound requests resemble a normal
+    client: aiohttp sets ``Content-Type`` for form/json/multipart; crawled
+    ``Etag``, ``X-Powered-By``, etc. must not be replayed on POST.
     """
     sanitized: dict[str, Any] = {}
     for key, value in headers.items():
         key_lower = str(key).lower()
-        if key_lower in _HOP_BY_HOP_OR_RESPONSE_HEADERS:
-            continue
-        if is_file_payload and key_lower == "content-type":
+        if key_lower in _HEADERS_STRIP_FROM_OUTBOUND:
             continue
         sanitized[key] = value
     return sanitized
@@ -324,7 +357,7 @@ async def build_and_send_request(
     payload_value = _resolve_payload_value(payload)
     is_file_payload = _is_file_payload(payload)
     is_lfi_payload = type(payload).__name__ == "LFIPayload"
-    headers = _sanitize_headers_for_request(headers, is_file_payload=is_file_payload)
+    headers = _sanitize_headers_for_request(headers)
 
     if surface.param_location == ParamLocation.QUERY:
         req_params[parameter] = payload_value
@@ -459,6 +492,8 @@ async def send_baseline_request(
 
     if isinstance(req_params, list):
         req_params = {str(k): "" for k in req_params}
+
+    headers = _sanitize_headers_for_request(headers)
 
     request_kwargs: dict[str, Any] = {}
     if req_params:


### PR DESCRIPTION
## 📌 PR 목적 (What)
Node.js(Express) 서버는 클라이언트가 데이터를 보낼 때 Content-Type 헤더를 보고 Body를 해석하는데 크롤러가 서버가 응답했던 헤더를 다음 공격의 요청 헤더로 긁어와서 그대로 집어넣고 있는 것으로 보임.

```
Request-Headers: {'X-Powered-By': 'Express', 'Content-Type': 'text/html; charset=utf-8', 'Etag': 'W/"12c1-u4zDb9Slr6yLD86ahzEhfPG+TPg"'}
```
Request-Headers를 확인해 봤을 때 `Content-Type`이 응답 헤더인 `text/html`로 들어가 있는 것을 확인할 수 있음. 크롤러가 `text/html`이라고 보내버렸기 때문에, 서버의 바디 파서(Body Parser)는 "이건 HTML 문서니까 내가 파싱할 로그인 데이터가 아니네" 하고 무시하여 미/오탐이 발생.
## 🛠️ 주요 변경 사항 (How)
- `request_builder.py`에 `file_upload` 모듈의 패킷을 대상으로 `Content-Type`을 삭제하여  초기화해주는 로직이 이미 존재.
    - 로직의 적용 범위를 전체 모듈로 변경. 
- 추가로 `X-Powered-By`, `Etag`라는 응답 전용 헤더도 같이 제거.
## 🧪 테스트 결과 (Testing & Verification)
패킷을 전송할 때 Request-Headers가 제거된 것을 확인. 아래는 테스트용 sqli 패킷.
```
POST http://54.180.113.193/vulnerabilities/javascript/

Cookies: {'PHPSESSID': 'tbibj9fsnjcg5k1plm74qpvjg2', 'security': 'low'}

Body (data): {'token': '', 'phrase': 'ChangeMe', 'send': '" AND (SELECT (CASE WHEN (1=1) THEN NULL ELSE CAST(CHR(118)||CHR(117)||CHR(110) AS NUMERIC) END)) IS NULL --'}
```
## 💡 리뷰어 참고 사항
**@강제윤:**
Stored XSS 탐지 과정에서 크롤러가 가져온 Content-Type: text/html을 달고 POST 요청을 쏘면, 서버의 Body Parser는 페이로드를 쓰레기값으로 취급하여 파싱하지 않으므로 페이로드가 DB에 아예 저장되지 않거나, `null`, `undefined` 같은 빈 값으로 저장될 수 있다고 합니다. 

또한 응답 전용 헤더인 `Etag`도 문제가 될 수 있습니다. `Etag`는 브라우저가 "나 예전 화면 그대로 가지고 있는데, 새로 받을 필요 있어?"라고 서버에 물어볼 때 쓰는 캐시 식별자입니다.
만약 퍼저가 Stored XSS 페이로드를 쏜 직후에 게시판을 확인하러 가면서 옛날 Etag를 달고 GET 요청을 보낸다면, 서버는 "어, 데이터 안 변했어. 캐시 된 거 써(304 Not Modified)"라고 응답해 버릴 수 있습니다.
결국 퍼저는 스크립트가 적용된 '최신 화면'이 아니라, 공격하기 전의 '옛날 화면'을 검사하게 되어 취약점을 놓치게 됩니다.

develop 브랜치에서 merge 후 다시 테스트해보시면 좋을 것 같습니다.

**@전체:**
Stored XSS뿐만 아니라 HTTP Body(본문)에 페이로드를 담아 보내는 모든 공격 모듈의 미/오탐도 해결될 수 있을 것 같습니다.

