### PR TITLE
[feat] stored_xss 옵션 추가 및 공용 옵션 추가

### DIFF
--- a/cli/cli/parser.py
+++ b/cli/cli/parser.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Modular Web Scanner (MWS) - integrated web vulnerability scanner CLI"
+    )
+    parser.add_argument(
+        "-u",
+        "--url",
+        required=True,
+        help="DVWA base URL (e.g. http://127.0.0.1/DVWA)",
+    )
+    parser.add_argument(
+        "-r",
+        "--rps",
+        type=int,
+        default=100,
+        help="Target requests per second throttle (default: 100)",
+    )
+    parser.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=0,
+        help="Number of queue workers (0 = auto-calculate based on rps)",
+    )
+    parser.add_argument(
+        "-c",
+        "--cookie",
+        type=str,
+        default="",
+        help="Cookie header value (e.g. 'PHPSESSID=abc; security=low')",
+    )
+    parser.add_argument(
+        "--login-url",
+        type=str,
+        default="",
+        help="Login page URL used before crawling (e.g. http://target/login.php)",
+    )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default="",
+        help="Login username used before crawling",
+    )
+    parser.add_argument(
+        "--password",
+        type=str,
+        default="",
+        help="Login password used before crawling",
+    )
+    parser.add_argument(
+        "--username-field",
+        type=str,
+        default="username",
+        help="Form field name for username (default: username)",
+    )
+    parser.add_argument(
+        "--password-field",
+        type=str,
+        default="password",
+        help="Form field name for password (default: password)",
+    )
+    parser.add_argument(
+        "--csrf-field",
+        type=str,
+        default="user_token",
+        help="CSRF token field name on login form (default: user_token)",
+    )
+    parser.add_argument(
+        "--submit-field",
+        type=str,
+        default="Login",
+        help="Submit field name on login form (default: Login)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="scan_report.json",
+        help="JSON report output path",
+    )
+    parser.add_argument(
+        "--surfaces-output",
+        type=str,
+        default="attack_surfaces.json",
+        help="JSON output path for crawled attack surfaces",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        type=str,
+        default="all",
+        choices=["sqli", "bruteforce", "lfi", "file_upload", "ssrf", "stored_xss", "all"],
+        help="Attack category to run (default: all, excludes bruteforce)",
+    )
+    parser.add_argument(
+        "--level",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=None,
+        metavar="N",
+        help=(
+            "Set SQLi, LFI, and SSRF evasion level to N at once (bruteforce unchanged). "
+            "SSRF is capped at 2. Overrides --sqli-evasion-level, --lfi-evasion-level, "
+            "and --ssrf-evasion-level when set."
+        ),
+    )
+    parser.add_argument(
+        "--bf-wordlist",
+        type=str,
+        default=os.path.join("config", "payloads", "bruteforce", "common_passwords.txt"),
+        help="Bruteforce dictionary file path (absolute or relative)",
+    )
+    parser.add_argument(
+        "--bf-disable-mutation",
+        action="store_true",
+        help="Disable password mutation in bruteforce dictionary mode",
+    )
+    parser.add_argument(
+        "--bf-mutation-level",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=1,
+        help=(
+            "Mutation intensity for bruteforce dictionary mode "
+            "(0=none, 1=basic, 2=extended suffixes, 3=extended+leet)"
+        ),
+    )
+    parser.add_argument(
+        "--bf-true-random",
+        action="store_true",
+        help="Enable exclusive true-random bruteforce mode (dictionary disabled)",
+    )
+    parser.add_argument(
+        "--bf-charset",
+        type=str,
+        default="abcdefghijklmnopqrstuvwxyz0123456789",
+        help="Charset for true random bruteforce mode",
+    )
+    parser.add_argument(
+        "--bf-max-length",
+        type=int,
+        default=3,
+        help="Maximum length for true random bruteforce mode",
+    )
+    parser.add_argument(
+        "--bf-min-length",
+        type=int,
+        default=1,
+        help="Minimum length for true random bruteforce mode",
+    )
+    parser.add_argument(
+        "--bf-length",
+        type=str,
+        default="",
+        help=(
+            "True-random brute-force length or range. "
+            "Examples: --bf-length 8 (means 1~8), --bf-length 2~8. "
+            "Overrides --bf-max-length."
+        ),
+    )
+    parser.add_argument(
+        "--bf-max-dictionary",
+        type=int,
+        default=0,
+        help="Cap dictionary payload count (0=all)",
+    )
+    parser.add_argument(
+        "--bf-max-true-random",
+        type=int,
+        default=0,
+        help="Cap true random payload count (0=all)",
+    )
+    parser.add_argument(
+        "--bf-stop-on-first-hit",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Stop bruteforce module after first verified credential hit (default: enabled)",
+    )
+    parser.add_argument(
+        "--bf-request-file",
+        type=str,
+        default="",
+        metavar="FILE",
+        help=(
+            "Path to a raw HTTP request file (Burp-style). "
+            "Mark the brute-force target parameter value with 'FUZZ'. "
+            "Supports GET query strings and POST form-encoded / JSON bodies."
+        ),
+    )
+    parser.add_argument(
+        "--bf-target-url",
+        type=str,
+        default="",
+        metavar="URL",
+        help=(
+            "Direct target URL for bruteforce (simple mode, no request file). "
+            "Combine with --bf-fuzz-param and --bf-extra-params."
+        ),
+    )
+    parser.add_argument(
+        "--bf-method",
+        type=str,
+        choices=["GET", "POST"],
+        default="GET",
+        help="HTTP method used with --bf-target-url (default: GET)",
+    )
+    parser.add_argument(
+        "--bf-fuzz-param",
+        type=str,
+        default="password",
+        metavar="PARAM",
+        help=(
+            "Parameter name to brute-force when using --bf-target-url "
+            "(its value is set to FUZZ automatically). Default: password"
+        ),
+    )
+    parser.add_argument(
+        "--bf-target-param",
+        type=str,
+        default="",
+        metavar="PARAM",
+        help=(
+            "Force target parameter in parser/target-url modes. "
+            "If omitted, bruteforce target parameter is auto-selected."
+        ),
+    )
+    parser.add_argument(
+        "--bf-username-param",
+        type=str,
+        default="username",
+        metavar="PARAM",
+        help="Parameter name to override with --bf-username (default: username)",
+    )
+    parser.add_argument(
+        "--bf-username",
+        type=str,
+        default="admin",
+        metavar="VALUE",
+        help="Username value used in bruteforce mode (default: admin)",
+    )
+    parser.add_argument(
+        "--bf-extra-params",
+        type=str,
+        nargs="*",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Additional fixed parameters sent alongside FUZZ when using --bf-target-url. "
+            "Example: --bf-extra-params username=admin Login=Login"
+        ),
+    )
+    parser.add_argument(
+        "--sqli-evasion-level",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=0,
+        help=(
+            "SQLi evasion intensity (cumulative per payload pass): "
+            "0=raw only; 1=keyword mixed-case; 2=+space as /**/; "
+            "3=+double URL-encode and %%00 suffix"
+        ),
+    )
+    parser.add_argument(
+        "--sqli-time-based",
+        action="store_true",
+        help="SQLi: include time/stacked payloads (separate set; much slower)",
+    )
+    parser.add_argument(
+        "--sqli-time-max",
+        type=int,
+        default=0,
+        help="SQLi: max time/stacked payloads when --sqli-time-based is set (0=all)",
+    )
+    parser.add_argument(
+        "--session-pool-size",
+        type=int,
+        default=3,
+        help="Number of HTTP sessions to use in parallel (default: 3)",
+    )
+    parser.add_argument(
+        "--lfi-evasion-level",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=1,
+        help=(
+            "LFI payload mutation level "
+            "(0=raw only, 1=url-encoding, 2=double+null-byte, 3=path/case bypass)"
+        ),
+    )
+    parser.add_argument(
+        "--ssrf-evasion-level",
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        help=(
+            "SSRF mutation level "
+            "(0=off, 1=path encode, 2=path encode + IP obfuscation)"
+        ),
+    )
+    parser.add_argument(
+        "--ssrf-oob",
+        action="store_true",
+        help="SSRF: add OOB/template payloads to the runtime payload set",
+    )
+
+    parser.add_argument(
+        "--sxss-evasion-level",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=1,
+        help="stored_XSS payload mutation level (0=off/raw, 1=basic WAF bypass, 2=advanced/encoding, 3=obfuscation)"
+        )
+
+    parser.add_argument(
+        "--exclude-urls",
+        nargs="+",
+        default=[],
+        help="크롤링 및 공격에서 제외할 URL 정규식 패턴 목록 (예: '/setup\.php' '/admin/.*')"
+    )
+
+    return parser
+
+
+def parse_arguments() -> argparse.Namespace:
+    return build_parser().parse_args()
+

--- a/cli/cli/runner.py
+++ b/cli/cli/runner.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from cli.output import print_scan_configuration, progress_printer
+from fuzzer import FuzzerEngine
+from fuzzer.request_builder import build_and_send_request
+from fuzzer.setup import count_module_payloads, estimate_total_requests, select_modules
+from reporter import ReportGenerator
+
+
+def prepare_scan_context(args, surfaces):
+    selected_modules = select_modules(args)
+    if not selected_modules:
+        print(f"No modules registered for attack type {args.type!r}. Exiting.")
+        return None
+
+    if args.type == "bruteforce" and not os.path.exists(args.bf_wordlist):
+        print(f"Bruteforce wordlist not found: {args.bf_wordlist}")
+        return None
+
+    payload_count = count_module_payloads(selected_modules)
+    if payload_count == 0:
+        print("No payloads loaded for selected modules. Exiting.")
+        return None
+
+    delay = (1.0 / args.rps) if args.rps > 0 else 0.0
+    concurrency = max(1, args.rps)
+    if hasattr(args, 'workers') and args.workers > 0:
+        queue_workers = args.workers
+    else:
+        queue_workers = max(1, args.rps * 2)
+    total_requests = estimate_total_requests(surfaces, selected_modules)
+
+    return {
+        "modules": selected_modules,
+        "payload_count": payload_count,
+        "delay": delay,
+        "concurrency": concurrency,
+        "queue_workers": queue_workers,
+        "total_requests": total_requests,
+    }
+
+
+async def run_scan(args, *, base_url: str, surfaces) -> None:
+    context = prepare_scan_context(args, surfaces)
+    if context is None:
+        return
+
+    print_scan_configuration(
+        base_url=base_url,
+        surface_count=len(surfaces),
+        attack_type=args.type,
+        module_count=len(context["modules"]),
+        payload_count=context["payload_count"],
+        level=args.level,
+        sqli_evasion_level=args.sqli_evasion_level,
+        lfi_evasion_level=args.lfi_evasion_level,
+        ssrf_evasion_level=args.ssrf_evasion_level,
+        ssrf_oob=args.ssrf_oob,
+        sqli_time_based=args.sqli_time_based,
+        sqli_time_max=args.sqli_time_max,
+        total_requests=context["total_requests"],
+        rps=args.rps,
+        delay=context["delay"],
+        queue_workers=context["queue_workers"],
+        session_pool_size=args.session_pool_size,
+    )
+
+    engine = FuzzerEngine(
+        max_concurrent_requests=context["concurrency"],
+        worker_count=context["queue_workers"],  # queue consumption workers
+        modules=context["modules"],
+        concurrency_per_module=context["queue_workers"],
+        session_pool_size=max(1, args.session_pool_size),
+        delay=context["delay"],
+    )
+
+    scan_task = asyncio.create_task(
+        engine.run_with_attack_modules(
+            surfaces=surfaces,
+            request_sender=_request_sender,
+        )
+    )
+    progress_task = asyncio.create_task(
+        progress_printer(engine, context["total_requests"], scan_task)
+    )
+    stats = await scan_task
+    await progress_task
+
+    reporter = ReportGenerator(stats=stats, findings=engine.findings)
+    reporter.print_cli_report()
+    reporter.export_to_json(args.output)
+
+
+async def _request_sender(session, surface, parameter, payload):
+    return await build_and_send_request(session, surface, parameter, payload)

--- a/cli/cli/surfaces.py
+++ b/cli/cli/surfaces.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from core import AttackSurface
+from core.queue_manager import QueueManager
+from crawler.engine import CrawlConfig, CrawlerEngine
+from crawler.session_manager import AuthConfig
+from crawler.url_filter import URLFilter
+from modules.bruteforce.request_parser import parse_raw_request
+from modules.bruteforce.target_prep import (
+    build_targeted_bruteforce_surface,
+    prepare_bruteforce_surfaces,
+)
+from parsers.surface_builder import SurfaceBuilder
+
+
+def _export_surfaces_json(surfaces: list[AttackSurface], output_path: str) -> None:
+    payload = [surface.to_dict() for surface in surfaces]
+    with open(output_path, "w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+
+async def resolve_surfaces(args, base_url: str, cookies: dict[str, str]) -> list[AttackSurface]:
+    if args.type == "bruteforce":
+        return await _resolve_bruteforce_surfaces(args, base_url, cookies)
+
+    surfaces = await _resolve_crawled_surfaces(
+        args=args,
+        start_url=base_url,
+        cookies=cookies,
+    )
+    if not surfaces:
+        print("Crawler returned no attack surfaces. Exiting.")
+        return []
+    return surfaces
+
+
+async def _resolve_crawled_surfaces(
+    args,
+    start_url: str,
+    cookies: dict[str, str] | None = None,
+) -> list[AttackSurface]:
+    """
+    크롤러(CrawlerEngine) → 큐(QueueManager) → 파서(SurfaceBuilder) 파이프라인을 실행하고
+    파서가 만들어낸 AttackSurface 목록을 반환한다.
+    """
+    queue_manager = QueueManager()
+    surfaces: list[AttackSurface] = []
+
+    async def _collect(surface: AttackSurface) -> None:
+        surfaces.append(surface)
+
+    surface_builder = SurfaceBuilder(fuzzer_callback=_collect)
+    crawler = CrawlerEngine(
+        queue_manager=queue_manager,
+        config=CrawlConfig(),
+    )
+    # CLI 인자로 받은 제외 패턴을 URLFilter에 주입
+    exclude_patterns = getattr(args, "exclude_urls", [])
+    if exclude_patterns:
+        custom_filter = URLFilter(excluded_patterns=exclude_patterns)
+        crawler.url_filter = custom_filter
+        crawler.session_manager.url_filter = custom_filter
+
+    # CLI에서 전달받은 쿠키(-c 옵션)를 크롤러 세션에 주입
+    if cookies:
+        crawler.session_manager.set_cookies(cookies)
+
+    try:
+        login_ready = await _login_if_configured(args, crawler)
+        if not login_ready:
+            return []
+
+        # 크롤러(생산자)와 파서(소비자)를 동시에 실행
+        # crawler.start()가 종료 신호(sentinel=None)를 큐에 넣으면
+        # surface_builder.consume_from_queue()가 루프를 빠져나와 완료
+        await asyncio.gather(
+            surface_builder.consume_from_queue(queue_manager),
+            crawler.start(start_url),
+        )
+    except Exception as exc:
+        print(f"Failed to crawl target URL {start_url}: {exc}")
+        return []
+    finally:
+        # login 단계에서 조기 종료되면 crawler.start() context manager가
+        # 실행되지 않아 세션이 남을 수 있으므로 여기서 항상 정리한다.
+        try:
+            await crawler.session_manager.close()
+        except Exception:
+            pass
+
+    print(f"[*] Crawler mode: discovered {len(surfaces)} attack surface(s).")
+    surfaces_output = (getattr(args, "surfaces_output", "") or "").strip()
+    if surfaces_output:
+        try:
+            _export_surfaces_json(surfaces, surfaces_output)
+            print(f"[*] Attack surfaces exported: {surfaces_output}")
+        except OSError as exc:
+            print(f"Failed to export attack surfaces JSON: {exc}")
+    return surfaces
+
+
+async def _login_if_configured(args, crawler: CrawlerEngine) -> bool:
+    username = (args.username or "").strip()
+    password = (args.password or "").strip()
+    login_url = (args.login_url or "").strip()
+
+    if not username and not password and not login_url:
+        return True
+
+    if not (username and password and login_url):
+        print("Login requires --login-url, --username, and --password together.")
+        return False
+
+    auth_config = AuthConfig(
+        login_url=login_url,
+        username=username,
+        password=password,
+        username_field=args.username_field,
+        password_field=args.password_field,
+        csrf_token_name=args.csrf_field or None,
+        submit_field=args.submit_field or None,
+    )
+
+    if not await crawler.session_manager.login(auth_config):
+        print(f"Login failed: {login_url}")
+        return False
+
+    print(f"[*] Login succeeded: {login_url}")
+    return True
+
+
+async def _resolve_bruteforce_surfaces(
+    args,
+    base_url: str,
+    cookies: dict[str, str],
+) -> list[AttackSurface]:
+    if args.bf_request_file:
+        return _resolve_raw_request_mode(args, cookies)
+
+    if args.bf_target_url:
+        target_label = args.bf_target_param or args.bf_fuzz_param
+        print(f"[*] Targeted URL mode: {args.bf_target_url} [{target_label}=FUZZ]")
+        return [build_targeted_bruteforce_surface(args, cookies)]
+
+    # 실제 크롤러로 표면을 수집한 뒤 bruteforce용으로 가공
+    surfaces = await _resolve_crawled_surfaces(
+        args=args,
+        start_url=base_url,
+        cookies=cookies,
+    )
+    surfaces = prepare_bruteforce_surfaces(surfaces, args)
+    if not surfaces:
+        print(
+            "No suitable parser surfaces found for bruteforce mode. "
+            "Use --bf-target-url or --bf-request-file."
+        )
+        return []
+    print(f"[*] Parser mode: prepared {len(surfaces)} brute-force surface(s).")
+    return surfaces
+
+
+def _resolve_raw_request_mode(args, cookies: dict[str, str]) -> list[AttackSurface]:
+    if not os.path.exists(args.bf_request_file):
+        print(f"Request file not found: {args.bf_request_file}")
+        return []
+    try:
+        surface = parse_raw_request(args.bf_request_file)
+        # CLI cookies override request file cookies when provided.
+        if cookies:
+            surface.cookies.update(cookies)
+    except (ValueError, OSError) as exc:
+        print(f"Failed to parse request file: {exc}")
+        return []
+
+    print(f"[*] Raw request mode: {surface.description}")
+    return [surface]


### PR DESCRIPTION
## 📌 PR 목적 (What)
cli에 stored_xss 옵션,  동시성 해결을 위한 워커 옵션, url 필터 옵션 추가
## 🛠️ 주요 변경 사항 (How)
### cli/parser.py
####  stored_xss 옵션 추가
```
parser.add_argument(
"-t",
"--type",
type=str,
default="all",
choices=["sqli", "bruteforce", "lfi", "file_upload", "ssrf", "stored_xss", "all"],
help="Attack category to run (default: all, excludes bruteforce)",
```
```
 parser.add_argument(
        "--sxss-evasion-level",
        type=int,
        choices=[0, 1, 2, 3],
        default=1,
        help="stored_XSS payload mutation level (0=off/raw, 1=basic WAF bypass, 2=advanced/encoding, 3=obfuscation)"
        )
```
#### worker 옵션추가
```
parser.add_argument(
    "-w",
    "--workers",
    type=int,
    default=0,
    help="Number of queue workers (0 = auto-calculate based on rps)",
)
```
#### url 필터 옵션 추가
```
parser.add_argument(
    "--exclude-urls",
    nargs="+",
    default=[],
    help="크롤링 및 공격에서 제외할 URL 정규식 패턴 목록(예: '/setup\.php' '/admin/.*')"
)
```
### cli/runner.py
#### queue_workers 부분 변경

```
delay = (1.0 / args.rps) if args.rps > 0 else 0.0
concurrency = max(1, args.rps)
if hasattr(args, 'workers') and args.workers > 0:    ----> 추가
    queue_workers = args.workers                     ----> 추가
else:                                                ----> 추가
    queue_workers = max(1, args.rps * 2)
total_requests = estimate_total_requests(surfaces, selected_modules)
```

### Cli/surface.py

#### import 추가

`from crawler.url_filter import URLFilter`

#### url 필터 옵션 적용 추가
```
#CLI 인자로 받은 제외 패턴을URLFilter에 주입
exclude_patterns=getattr(args,"exclude_urls",[])
ifexclude_patterns:
    custom_filter = URLFilter(excluded_patterns=exclude_patterns)
    crawler.url_filter = custom_filter
    crawler.session_manager.url_filter = custom_filter

```
