### PR TITLE
[feat] stored_xss옵션, worker 옵션, url 필터 옵션 추가

### DIFF
--- a/cli/parser.py
+++ b/cli/parser.py
@@ -29,6 +29,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Cookie header value (e.g. 'PHPSESSID=abc; security=low')",
     )
     parser.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=0,
+        help="Number of queue workers (0 = auto-calculate based on rps)",
+    )
+    parser.add_argument(
         "--login-url",
         type=str,
         default="",
@@ -88,7 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--type",
         type=str,
         default="all",
-        choices=["sqli", "bruteforce", "lfi", "file_upload", "ssrf", "all"],
+        choices=["sqli", "bruteforce", "lfi", "file_upload", "ssrf", "stored_xss", "all"],
         help=(
             "Attack category (default: all). For bruteforce without --bf-target-url, "
             "surfaces come from the crawler; BruteforceModule.get_target_parameters filters targets."
@@ -292,6 +299,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--ssrf-oob",
         action="store_true",
         help="SSRF: add OOB/template payloads to the runtime payload set",
+    )
+    parser.add_argument(
+        "--sxss-evasion-level",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=1,
+        help="stored_XSS payload mutation level (0=off/raw, 1=basic WAF bypass, 2=advanced/encoding, 3=obfuscation)"
+    )
+    parser.add_argument(
+        "--exclude-urls",
+        nargs="+",
+        default=[],
+        help="크롤링 및 공격에서 제외할 URL 정규식 패턴 목록(예: '/setup\.php' '/admin/.*')"
     )
     return parser
 

--- a/cli/runner.py
+++ b/cli/runner.py
@@ -27,7 +27,10 @@ def prepare_scan_context(args, surfaces):
 
     delay = (1.0 / args.rps) if args.rps > 0 else 0.0
     concurrency = max(1, args.rps)
-    queue_workers = max(1, args.rps * 2)
+    if hasattr(args, 'workers') and args.workers > 0:
+        queue_workers = args.workers
+    else:
+        queue_workers = max(1, args.rps * 2)
     total_requests = estimate_total_requests(surfaces, selected_modules)
 
     return {

--- a/cli/surfaces.py
+++ b/cli/surfaces.py
@@ -12,7 +12,7 @@ from modules.bruteforce.target_prep import (
     build_targeted_bruteforce_surface,
 )
 from parsers.surface_builder import SurfaceBuilder
-
+from crawler.url_filter import URLFilter
 
 def _export_surfaces_json(surfaces: list[AttackSurface], output_path: str) -> None:
     payload = [surface.to_dict() for surface in surfaces]
@@ -55,6 +55,12 @@ async def _resolve_crawled_surfaces(
         queue_manager=queue_manager,
         config=CrawlConfig(),
     )
+    # CLI 인자로 받은 제외 패턴을 URLFilter에 주입
+    exclude_patterns = getattr(args, "exclude_urls", [])
+    if exclude_patterns:
+        custom_filter = URLFilter(excluded_patterns=exclude_patterns)
+        crawler.url_filter = custom_filter
+        crawler.session_manager.url_filter = custom_filter
 
     # CLI에서 전달받은 쿠키(-c 옵션)를 크롤러 세션에 주입
     if cookies:


### PR DESCRIPTION
## 📌 PR 목적 (What)
cli에 stored_xss 옵션,  동시성 해결을 위한 워커 옵션, url 필터 옵션 추가
## 🛠️ 주요 변경 사항 (How)
### cli/parser.py
####  stored_xss 옵션 추가
```
parser.add_argument(
"-t",
"--type",
type=str,
default="all",
choices=["sqli", "bruteforce", "lfi", "file_upload", "ssrf", "stored_xss", "all"],
help="Attack category to run (default: all, excludes bruteforce)",
```
```
 parser.add_argument(
        "--sxss-evasion-level",
        type=int,
        choices=[0, 1, 2, 3],
        default=1,
        help="stored_XSS payload mutation level (0=off/raw, 1=basic WAF bypass, 2=advanced/encoding, 3=obfuscation)"
        )
```
#### worker 옵션추가
```
parser.add_argument(
    "-w",
    "--workers",
    type=int,
    default=0,
    help="Number of queue workers (0 = auto-calculate based on rps)",
)
```
#### url 필터 옵션 추가
```
parser.add_argument(
    "--exclude-urls",
    nargs="+",
    default=[],
    help="크롤링 및 공격에서 제외할 URL 정규식 패턴 목록(예: '/setup\.php' '/admin/.*')"
)
```
### cli/runner.py
#### queue_workers 부분 변경

```
delay = (1.0 / args.rps) if args.rps > 0 else 0.0
concurrency = max(1, args.rps)
if hasattr(args, 'workers') and args.workers > 0:    ----> 추가
    queue_workers = args.workers                     ----> 추가
else:                                                ----> 추가
    queue_workers = max(1, args.rps * 2)
total_requests = estimate_total_requests(surfaces, selected_modules)
```

### Cli/surface.py

#### import 추가

`from crawler.url_filter import URLFilter`

#### url 필터 옵션 적용 추가
```
#CLI 인자로 받은 제외 패턴을URLFilter에 주입
exclude_patterns=getattr(args,"exclude_urls",[])
ifexclude_patterns:
    custom_filter = URLFilter(excluded_patterns=exclude_patterns)
    crawler.url_filter = custom_filter
    crawler.session_manager.url_filter = custom_filter

```
