### PR TITLE
[feat] 리포트 중복 취약점 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .json
 scan_report.json
 attack_surfaces.json
+scan_report_full.json

--- a/modules/ssrf/module.py
+++ b/modules/ssrf/module.py
@@ -7,6 +7,9 @@ from modules.base_module import BaseModule
 from modules.ssrf.analyzer import analyze_ssrf
 from modules.ssrf.payloads import SSRFPayload, get_ssrf_payloads
 
+# Default display name; keep in sync with ``__init__(name=...)`` default.
+SSRF_MODULE_REPORT_NAME = "Server-Side Request Forgery"
+
 
 class SSRFModule(BaseModule):
     _NAME_TARGETS = (
@@ -52,7 +55,7 @@ class SSRFModule(BaseModule):
 
     def __init__(
         self,
-        name: str = "Server-Side Request Forgery",
+        name: str = SSRF_MODULE_REPORT_NAME,
         *,
         include_oob_templates: bool = False,
         bypass_level: int = 0,

--- a/modules/ssrf/payloads.py
+++ b/modules/ssrf/payloads.py
@@ -12,9 +12,11 @@ class SSRFPayload:
     attack_type: str
     risk_level: str
     expected_signature: str | None = None
+    # In-band payloads (ssrf_inband.txt) vs OOB/template payloads (ssrf_oob_template.txt).
+    channel: str = "inband"
 
 
-def _load_ssrf_payload_file(file_path: str) -> list[SSRFPayload]:
+def _load_ssrf_payload_file(file_path: str, *, channel: str = "inband") -> list[SSRFPayload]:
     payloads: list[SSRFPayload] = []
     if not os.path.exists(file_path):
         return payloads
@@ -41,6 +43,7 @@ def _load_ssrf_payload_file(file_path: str) -> list[SSRFPayload]:
                     attack_type=attack_type,
                     risk_level=risk_level,
                     expected_signature=expected_signature or None,
+                    channel=channel,
                 )
             )
 
@@ -99,6 +102,7 @@ def _apply_ssrf_bypass(payload: SSRFPayload, bypass_level: int) -> list[SSRFPayl
                     attack_type=f"{payload.attack_type}_path_encode",
                     risk_level=payload.risk_level,
                     expected_signature=payload.expected_signature,
+                    channel=payload.channel,
                 )
             )
 
@@ -128,6 +132,7 @@ def _apply_ssrf_bypass(payload: SSRFPayload, bypass_level: int) -> list[SSRFPayl
                             attack_type=f"{payload.attack_type}_{suffix}",
                             risk_level=payload.risk_level,
                             expected_signature=payload.expected_signature,
+                            channel=payload.channel,
                         )
                     )
         except ValueError:
@@ -145,12 +150,12 @@ def get_ssrf_payloads(
     fallback_path = os.path.join("config", "payloads", "ssrf", "ssrf.txt")
 
     # Prefer split files; fallback keeps backward compatibility.
-    payloads = _load_ssrf_payload_file(inband_path)
+    payloads = _load_ssrf_payload_file(inband_path, channel="inband")
     if not payloads:
-        payloads = _load_ssrf_payload_file(fallback_path)
+        payloads = _load_ssrf_payload_file(fallback_path, channel="inband")
 
     if include_oob_templates:
-        payloads.extend(_load_ssrf_payload_file(oob_path))
+        payloads.extend(_load_ssrf_payload_file(oob_path, channel="oob"))
     seen: set[str] = set()
     expanded: list[SSRFPayload] = []
     for payload in payloads:

--- a/reporter/__init__.py
+++ b/reporter/__init__.py
@@ -1,5 +1,9 @@
+from .dedupe import dedupe_report_document, dedupe_vulnerabilities, full_report_path
 from .generator import ReportGenerator
 
 __all__ = [
     "ReportGenerator",
+    "dedupe_report_document",
+    "dedupe_vulnerabilities",
+    "full_report_path",
 ]

--- a/reporter/dedupe.py
+++ b/reporter/dedupe.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Literal
+
+
+def severity_rank(raw: str) -> int:
+    """Lower is more severe (critical first)."""
+    key = str(raw or "").strip().lower()
+    if key in ("critical", "crit"):
+        return 0
+    if key == "high":
+        return 1
+    if key in ("medium", "med"):
+        return 2
+    if key == "low":
+        return 3
+    return 4
+
+
+# Evasion / encoding variants of the same logical attack (group under one finding).
+_MUTATION_TYPE_SUFFIXES: tuple[str, ...] = (
+    "_Double_Encoded",
+    "_URL_Encoded",
+    "_Null_Byte",
+    "_Path_Bypass_1",
+    "_Path_Bypass_2",
+    "_Case_Bypass",
+    "_path_encode",
+    "_ip_decimal",
+    "_ip_hex",
+)
+
+
+def canonical_attack_type_for_grouping(raw: str) -> str:
+    """Strip known mutation suffixes so e.g. LFI_PHP_Wrapper_URL_Encoded -> LFI_PHP_Wrapper."""
+    original = str(raw or "")
+    s = original
+    changed = True
+    while changed:
+        changed = False
+        for suf in _MUTATION_TYPE_SUFFIXES:
+            if s.endswith(suf):
+                s = s[: -len(suf)]
+                changed = True
+                break
+    return s if s else original
+
+
+def vulnerability_group_key(record: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    """
+    Group by URL, HTTP method, parameter placement, parameter name, and attack class
+    (mutation suffixes on ``attack_info.type`` are ignored for grouping).
+    """
+    target = record.get("target") or {}
+    attack = record.get("attack_info") or {}
+    raw_type = str(attack.get("type") or "")
+    return (
+        str(target.get("url") or ""),
+        str(target.get("method") or ""),
+        str(target.get("location") or ""),
+        str(target.get("parameter") or ""),
+        canonical_attack_type_for_grouping(raw_type),
+    )
+
+
+def vulnerability_sort_key(record: dict[str, Any]) -> tuple[int, str, str]:
+    attack = record.get("attack_info") or {}
+    target = record.get("target") or {}
+    return (
+        severity_rank(str(attack.get("severity") or "high")),
+        str(target.get("url") or ""),
+        str(target.get("parameter") or ""),
+    )
+
+
+def dedupe_vulnerabilities(
+    records: list[dict[str, Any]],
+    *,
+    mode: Literal["first_in_order", "best_evidence"] = "first_in_order",
+) -> list[dict[str, Any]]:
+    """
+    Collapse records that share the same group key to a single entry (one PoC).
+
+    - first_in_order: keep the first record per key (scan / discovery order).
+    - best_evidence: for each key, pick the lowest severity rank, then shortest
+      payload string, then earliest index in the input list (for offline JSON).
+    """
+    if mode == "first_in_order":
+        seen: set[tuple[str, str, str, str, str]] = set()
+        out: list[dict[str, Any]] = []
+        for rec in records:
+            key = vulnerability_group_key(rec)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(rec)
+        return out
+
+    buckets: dict[tuple[str, str, str, str, str], list[tuple[int, dict[str, Any]]]] = (
+        defaultdict(list)
+    )
+    for index, rec in enumerate(records):
+        buckets[vulnerability_group_key(rec)].append((index, rec))
+
+    picked: list[dict[str, Any]] = []
+    for _key, items in sorted(buckets.items(), key=lambda kv: kv[0]):
+        def score(item: tuple[int, dict[str, Any]]) -> tuple[int, int, int]:
+            idx, rec = item
+            attack = rec.get("attack_info") or {}
+            payload = str(attack.get("payload_value") or "")
+            return (severity_rank(str(attack.get("severity") or "high")), len(payload), idx)
+
+        picked.append(min(items, key=score)[1])
+    return picked
+
+
+def dedupe_report_document(
+    report: dict[str, Any],
+    *,
+    mode: Literal["first_in_order", "best_evidence"] = "best_evidence",
+) -> dict[str, Any]:
+    """Return a deep-copied report with vulnerabilities deduped and summary updated."""
+    import copy
+
+    data = copy.deepcopy(report)
+    vulns = list(data.get("vulnerabilities") or [])
+    raw_count = len(vulns)
+    deduped = dedupe_vulnerabilities(vulns, mode=mode)
+    deduped_sorted = sorted(deduped, key=vulnerability_sort_key)
+    data["vulnerabilities"] = deduped_sorted
+    meta = data.setdefault("metadata", {})
+    summary = meta.setdefault("summary", {})
+    summary["findings"] = len(deduped_sorted)
+    summary["findings_raw"] = raw_count
+    return data
+
+
+def full_report_path(output_path: str | Path) -> Path:
+    """scan_report.json -> scan_report_full.json"""
+    p = Path(output_path)
+    return p.with_name(f"{p.stem}_full{p.suffix}")

--- a/reporter/dedupe.py
+++ b/reporter/dedupe.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import copy
 import json
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Literal
+
+from modules.ssrf.module import SSRF_MODULE_REPORT_NAME
+
+_SSRF_INTERNAL_CLASS = "SSRF-Internal"
 
 
 def severity_rank(raw: str) -> int:
@@ -49,20 +54,51 @@ def canonical_attack_type_for_grouping(raw: str) -> str:
     return s if s else original
 
 
-def vulnerability_group_key(record: dict[str, Any]) -> tuple[str, str, str, str, str]:
-    """
-    Group by URL, HTTP method, parameter placement, parameter name, and attack class
-    (mutation suffixes on ``attack_info.type`` are ignored for grouping).
-    """
-    target = record.get("target") or {}
+def _is_inband_ssrf_record(record: dict[str, Any]) -> bool:
+    if record.get("ssrf_channel") == "oob":
+        return False
+    if record.get("ssrf_channel") == "inband":
+        return True
+    # Legacy JSON without channel: treat SSRF module rows as in-band.
+    return record.get("module") == SSRF_MODULE_REPORT_NAME
+
+
+def grouping_attack_class(record: dict[str, Any]) -> str:
+    """Logical attack class for dedupe keys (in-band SSRF collapses to one bucket)."""
+    if _is_inband_ssrf_record(record):
+        return _SSRF_INTERNAL_CLASS
     attack = record.get("attack_info") or {}
     raw_type = str(attack.get("type") or "")
+    return canonical_attack_type_for_grouping(raw_type)
+
+
+def presentation_for_vulnerability_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Apply display labels after dedupe (e.g. in-band SSRF -> SSRF-Internal)."""
+    out = copy.deepcopy(record)
+    if not _is_inband_ssrf_record(out):
+        return out
+    attack = out.setdefault("attack_info", {})
+    original = str(attack.get("type") or "")
+    attack["type"] = _SSRF_INTERNAL_CLASS
+    if original and original != _SSRF_INTERNAL_CLASS:
+        attack["ssrf_variant"] = original
+    return out
+
+
+def vulnerability_group_key(record: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    """
+    Group by URL, HTTP method, parameter placement, parameter name, and attack class.
+
+    In-band SSRF rows share one class (``SSRF-Internal``). Other types use
+    ``attack_info.type`` with mutation suffixes stripped.
+    """
+    target = record.get("target") or {}
     return (
         str(target.get("url") or ""),
         str(target.get("method") or ""),
         str(target.get("location") or ""),
         str(target.get("parameter") or ""),
-        canonical_attack_type_for_grouping(raw_type),
+        grouping_attack_class(record),
     )
 
 
@@ -96,7 +132,7 @@ def dedupe_vulnerabilities(
             if key in seen:
                 continue
             seen.add(key)
-            out.append(rec)
+            out.append(presentation_for_vulnerability_record(rec))
         return out
 
     buckets: dict[tuple[str, str, str, str, str], list[tuple[int, dict[str, Any]]]] = (
@@ -114,7 +150,7 @@ def dedupe_vulnerabilities(
             return (severity_rank(str(attack.get("severity") or "high")), len(payload), idx)
 
         picked.append(min(items, key=score)[1])
-    return picked
+    return [presentation_for_vulnerability_record(r) for r in picked]
 
 
 def dedupe_report_document(
@@ -123,8 +159,6 @@ def dedupe_report_document(
     mode: Literal["first_in_order", "best_evidence"] = "best_evidence",
 ) -> dict[str, Any]:
     """Return a deep-copied report with vulnerabilities deduped and summary updated."""
-    import copy
-
     data = copy.deepcopy(report)
     vulns = list(data.get("vulnerabilities") or [])
     raw_count = len(vulns)

--- a/reporter/generator.py
+++ b/reporter/generator.py
@@ -125,7 +125,7 @@ class ReportGenerator:
             str(getattr(finding.surface, "param_location", "unknown")),
         )
 
-        return {
+        row: dict[str, Any] = {
             "target": {
                 "url": finding.surface.url,
                 "method": method,
@@ -144,6 +144,12 @@ class ReportGenerator:
                 "error_log": error_log,
             },
         }
+        if finding.module_name:
+            row["module"] = finding.module_name
+        ch = getattr(payload_obj, "channel", None)
+        if ch is not None:
+            row["ssrf_channel"] = ch
+        return row
 
     def export_to_json(self, filepath: str = "scan_result.json") -> None:
         """

--- a/reporter/generator.py
+++ b/reporter/generator.py
@@ -6,6 +6,12 @@ from typing import Any
 
 from fuzzer import EngineStats, Finding
 
+from reporter.dedupe import (
+    dedupe_vulnerabilities,
+    full_report_path,
+    vulnerability_sort_key,
+)
+
 
 def _severity_rank(raw: str) -> int:
     """Lower is more severe (critical first)."""
@@ -100,11 +106,58 @@ class ReportGenerator:
         print(f"Total findings: {len(self.findings)}")
         print("=" * table_width + "\n")
 
+    def _finding_to_dict(self, finding: Finding) -> dict[str, Any]:
+        payload_obj = finding.payload
+        payload_value = getattr(payload_obj, "value", str(payload_obj))
+        attack_type = getattr(payload_obj, "attack_type", "Unknown")
+        severity = getattr(payload_obj, "risk_level", "high")
+        description = getattr(payload_obj, "description", "")
+
+        response = finding.response
+        status_code = getattr(response, "status", 0)
+        response_time = getattr(response, "elapsed_time", getattr(response, "elapsed", 0.0))
+        error_log = getattr(response, "error", None)
+
+        method = getattr(finding.surface.method, "name", str(finding.surface.method))
+        location = getattr(
+            getattr(finding.surface, "param_location", "unknown"),
+            "name",
+            str(getattr(finding.surface, "param_location", "unknown")),
+        )
+
+        return {
+            "target": {
+                "url": finding.surface.url,
+                "method": method,
+                "location": location,
+                "parameter": finding.parameter,
+            },
+            "attack_info": {
+                "payload_value": payload_value,
+                "type": attack_type,
+                "severity": severity,
+                "description": description,
+            },
+            "evidence": {
+                "status_code": status_code,
+                "response_time": round(float(response_time), 4),
+                "error_log": error_log,
+            },
+        }
+
     def export_to_json(self, filepath: str = "scan_result.json") -> None:
         """
-        Exports the scan result to a JSON file.
+        Writes a deduplicated report to ``filepath`` (one PoC per URL / parameter / type)
+        and the complete per-payload list to ``<stem>_full<suffix>``.
         """
-        report_data: dict[str, Any] = {
+        full_vulnerabilities = [
+            self._finding_to_dict(f) for f in sorted(self.findings, key=_finding_sort_key)
+        ]
+        discovery_vulnerabilities = [self._finding_to_dict(f) for f in self.findings]
+        deduped = dedupe_vulnerabilities(discovery_vulnerabilities, mode="first_in_order")
+        deduped_sorted = sorted(deduped, key=vulnerability_sort_key)
+
+        full_report: dict[str, Any] = {
             "metadata": {
                 "scan_time": self.timestamp,
                 "summary": {
@@ -114,51 +167,27 @@ class ReportGenerator:
                     "findings": self.stats.findings,
                 },
             },
-            "vulnerabilities": [],
+            "vulnerabilities": full_vulnerabilities,
+        }
+        deduped_report: dict[str, Any] = {
+            "metadata": {
+                "scan_time": self.timestamp,
+                "summary": {
+                    "queued": self.stats.queued,
+                    "completed": self.stats.completed,
+                    "failures": self.stats.failures,
+                    "findings": len(deduped_sorted),
+                    "findings_raw": self.stats.findings,
+                },
+            },
+            "vulnerabilities": deduped_sorted,
         }
 
-        for finding in sorted(self.findings, key=_finding_sort_key):
-            payload_obj = finding.payload
-            payload_value = getattr(payload_obj, "value", str(payload_obj))
-            attack_type = getattr(payload_obj, "attack_type", "Unknown")
-            severity = getattr(payload_obj, "risk_level", "high")
-            description = getattr(payload_obj, "description", "")
-
-            response = finding.response
-            status_code = getattr(response, "status", 0)
-            response_time = getattr(response, "elapsed_time", getattr(response, "elapsed", 0.0))
-            error_log = getattr(response, "error", None)
-
-            method = getattr(finding.surface.method, "name", str(finding.surface.method))
-            location = getattr(
-                getattr(finding.surface, "param_location", "unknown"),
-                "name",
-                str(getattr(finding.surface, "param_location", "unknown")),
-            )
-
-            report_data["vulnerabilities"].append(
-                {
-                    "target": {
-                        "url": finding.surface.url,
-                        "method": method,
-                        "location": location,
-                        "parameter": finding.parameter,
-                    },
-                    "attack_info": {
-                        "payload_value": payload_value,
-                        "type": attack_type,
-                        "severity": severity,
-                        "description": description,
-                    },
-                    "evidence": {
-                        "status_code": status_code,
-                        "response_time": round(float(response_time), 4),
-                        "error_log": error_log,
-                    },
-                }
-            )
-
+        full_path = full_report_path(filepath)
         with open(filepath, "w", encoding="utf-8") as file:
-            json.dump(report_data, file, ensure_ascii=False, indent=2)
+            json.dump(deduped_report, file, ensure_ascii=False, indent=2)
+        with open(full_path, "w", encoding="utf-8") as file:
+            json.dump(full_report, file, ensure_ascii=False, indent=2)
 
-        print(f"report saved: {filepath}")
+        print(f"report saved (deduplicated): {filepath}")
+        print(f"report saved (full payloads): {full_path}")


### PR DESCRIPTION
## 📌 PR 목적 (What)
깔끔한 리포트를 위해 동일 url, 페이로드일 때 중복되는 취약점을 제거
## 🛠️ 주요 변경 사항 (How)
- `scan_report.json`에서 중복 취약점 제거
- `scan_report_full.json`을 새로 생성하도록 변경하여 전체 finding도 확인 가능
- ssrf 분류 시 in-band ssrf의 경우 전부 `SSRF Internal`으로 통합

