### PR TITLE
[fix] time-based 페이로드 장벽 강제 돌파 조건에 진행도 변화 감지 추가

### DIFF
--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -159,12 +159,25 @@ class SQLiModule(BaseModule):
             try:
                 # 1. 장벽 대기
                 if not self._barrier_event.is_set():
-                    try:
-                        # 25초 후 데드락 해제
-                        await asyncio.wait_for(self._barrier_event.wait(), timeout=25.0)
-                    except asyncio.TimeoutError:
-                        if not self._time_phase_active:
-                            pass
+                    last_completed = -1
+                    stuck_count = 0
+                    
+                    while not self._barrier_event.is_set():
+                        try:
+                            await asyncio.wait_for(self._barrier_event.wait(), timeout=10.0)
+                        except asyncio.TimeoutError:
+                            current_completed = self._global_fast_completed
+                            
+                            if current_completed == last_completed:
+                                stuck_count += 1
+                            else:
+                                stuck_count = 0
+                                last_completed = current_completed
+                            
+                            # 30초(10초 * 3) 동안 일반 페이로드 완료 없으면 강제 돌파
+                            if stuck_count >= 3:
+                                self._barrier_event.set()
+                                break
                     
                 if not self._time_phase_active:
                     self._time_phase_active = True


### PR DESCRIPTION
## 📌 PR 목적 (What)
 surface 별 일반 페이로드 처리 속도가 다른 경우 일반 페이로드 병렬 처리 중에 deadlock breaker가 동작하여 time-based 페이로드가 같이 처리되는 문제 해결 
## 🛠️ 주요 변경 사항 (How)
- module.py: deadlock breaker 동작 조건에 "30초 동안 일반 페이로드 진행도 변화 없음" 을 추가 

## 💡 리뷰어 참고 사항
 @김진우:  osci 모듈도 동일하게 수정했습니다.
## ✅ 다음 작업 (Next Step)
-  SQLi 모듈 boolean 탐지 로직 일반적인 페이지 응답 기준으로 수정.
