### PR TITLE
[fix] process job의 NameError수정

### DIFF
--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -270,7 +270,6 @@ class FuzzerEngine:
             parameter=job.parameter,
             payload=job.payload,
             response=response,
-            evidences=evidences
         )
         self._findings.append(finding)
         async with self._stats_lock:


### PR DESCRIPTION
## 📌 PR 목적 (What)

Fuzzer 엔진에서 발생하는 NameError: name 'evidences' is not defined 크래시 버그 수정
🛠️ 주요 변경 사항 (How)
 - engine.py: process_job 메서드에서 Finding 생성자 호출부에서 evidences=evidences 인자를 삭제하여 해당 스코프에 선언되지 않은 evidences 변수를 참조하여 발생하는 NameError 오류 제거

## 💡 리뷰어 참고 사항

 @김진우: 모듈 기반 실행(_process_module_attack)에서는 분석 결과로부터 evidences를 정상적으로 할당받아 사용하고 있으나, 기본 실행(_process_job)에서는 해당 로직이 없어 변수 미선언 오류가 발생하고 있었습니다.
Finding 데이터 클래스에서 evidences는 list[str] | None = None으로 기본값이 정의되어 있으므로, 인자를 넘기지 않는 방식으로 수정했습니다.

## ✅ 다음 작업 (Next Step)

sqli 모듈 boolean 로직 수정