### PR TITLE
[feat] 리포트에서 CWE 참고 매핑과 시큐어 코딩 가이드 제공

### DIFF
--- a/reporter/dedupe.py
+++ b/reporter/dedupe.py
@@ -289,3 +289,112 @@ def full_report_path(output_path: str | Path) -> Path:
     """scan_report.json -> scan_report_full.json"""
     p = Path(output_path)
     return p.with_name(f"{p.stem}_full{p.suffix}")
+
+
+_SQLI_GUIDE = (
+    "모든 동적 데이터베이스 조회 연산 수행 시 f-string 문자열 조립을 전면 금지하고 파라미터 바인딩 기반의 "
+    "PreparedStatement를 고정 적용하십시오. 웹 애플리케이션용 DB 접속 계정에서 DDL(CREATE, ALTER, DROP 등) "
+    "권한을 거세하고, JPA/Hibernate 등 ORM 프레임워크 활용 시에도 Native Query 작성 시 내부 문자열 결합이 "
+    "유발되지 않도록 주의해야 합니다."
+)
+_OSCI_GUIDE = (
+    "시스템 운영체제 명령어 실행 쉘을 개방하는 os.system, popen 함수 또는 subprocess의 shell=True 설정을 "
+    "엄격히 금지하십시오. 가급적 언어 내장 API나 안전한 프레임워크 함수로 로직을 교체하고, 외부 인자 주입이 "
+    "불가피하다면 정규표현식을 적용한 화이트리스트 방식으로 입력값을 사전 정제하여 Argument Injection 우회 "
+    "구문까지 원천 차단해야 합니다."
+)
+_LFI_GUIDE = (
+    "외부에서 전달되는 문자열을 파일 I/O 시스템 경로 스트림에 즉시 바인딩하지 마십시오. 불가피하게 물리 경로를 "
+    "조립해야 하는 상황이라면 입력값 내 Null Byte 문자(\\x00, %00)를 검증 후 하드 기각하고, realpath() 및 "
+    "abspath() 함수를 통해 경로를 정규화한 뒤 os.path.commonpath()를 활용해 타깃 자원이 사전에 약속된 "
+    "화이트리스트 디렉토리 Prefix의 내부 경로 구조를 절대 이탈하지 않는지 이중 검증해야 합니다."
+)
+_SSRF_GUIDE = (
+    "요청 대상 호스트 도메인을 DNS Resolution 처리하여 변환된 실제 IP 주소가 사설망 대역(RFC 1918 범위: "
+    "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/12, 127.0.0.0/8 등) 및 링크 로컬 대역에 수렴하는지 철저히 "
+    "화이트리스트 필터링하십시오. 특히 검증 단계와 실제 커넥션을 맺는 실행 단계의 시간 차이를 유도해 목적지를 "
+    "변조하는 DNS Rebinding 공격을 원천 봉쇄하기 위해, DNS 조회가 완료된 IP 주소로 통신 주소 자체를 하드 "
+    "고정(IP Pinning)하여 요청을 생성하고, 원래의 도메인 텍스트는 HTTP Host 헤더 필드에 명시적으로 주입하는 "
+    "규칙을 구현하십시오."
+)
+_FILE_UPLOAD_GUIDE = (
+    "클라이언트 요청 프레임에서 전송되어 조작이 지극히 간단한 Content-Type(MIME) 헤더 검증에만 절대 단독 "
+    "의존하지 마십시오. 대소문자를 통합 관리하는 엄격한 확장자 화이트리스트 체계를 구성함과 동시에, 바이너리 "
+    "도입부를 정밀 대조하는 파일 시그니처(Magic Number) 검증 엔진을 교차 수행하십시오. 업로드 파일명은 UUID "
+    "등의 난수로 전면 대치하여 웹 루트 외부의 별도 독립 스토리지에 격리 저장하고 실행 권한을 완벽 박탈해야 "
+    "합니다. 이미지 업로드 인터페이스의 경우, 이미지 구조 내부에 악성 페이로드가 난독화되어 내장되는 공격을 "
+    "완전 소멸시키기 위해 백엔드 레벨에서 그래픽 라이브러리를 통한 재인코딩(Re-encoding) 연산을 필수 "
+    "통과시키십시오."
+)
+_STORED_XSS_GUIDE = (
+    "사용자 측에서 주입되는 원시 입력값을 정제 처리 없이 영구 저장소에 보관하거나 그대로 클라이언트 응답 화면에 "
+    "출력하지 마십시오. 데이터가 출력되어 브라우저에 의해 해석되는 컨텍스트 경계면에서 HTML 엔티티 인코딩 연산 "
+    "(< → &lt;, > → &gt;, \" → &quot;, ' → &#x27;, & → &amp;)을 전역적으로 강제 적용해야 합니다. "
+    "프레임워크가 제공하는 기본 자동 이스케이프(Auto-escaping) 파이프라인의 규격을 준수하고, 원시 입력을 "
+    "무가공 상태로 출력하는 기능의 사용을 지양하며 최상위 계층에 콘텐츠 보안 정책(CSP) 헤더를 보강하십시오."
+)
+_REFLECTED_XSS_GUIDE = (
+    "HTTP 요청 아웃풋 스트림(GET 파라미터, POST 폼 필드 등)에 바인딩되는 모든 변동 인자는 유효성 교정 처리를 "
+    "거치지 않았다면 브라우저 응답 본문에 즉시 에코(Echo) 형태로 재출력하지 마십시오. 최종 렌더링 단계 직전에 "
+    "HTML 엔티티 인코딩을 예외 없이 강제화하고, HTTP 응답 헤더 필드에 X-Content-Type-Options: nosniff 정책을 "
+    "선언하여 브라우저 환경이 임의의 악성 MIME 스니핑 가정을 수립해 구문을 해석하는 행위를 원천 제어해야 합니다."
+)
+_BRUTEFORCE_GUIDE = (
+    "로그인 연산 실패 시 반환되는 예외 문구가 계정의 실제 실재 유무를 해커가 판별하여 열거(User Enumeration)하는 "
+    "힌트로 악용되지 않도록, 실패 원인과 무관하게 통일되고 완전 표준화된 예외 메시지(\"아이디 또는 비밀번호가 "
+    "올바르지 않습니다.\")만을 대외 인터페이스에 출력하십시오. 임계값을 제어하기 위해 클라이언트 IP 대역 및 "
+    "타깃 로그인 ID 식별 코드 기준의 다중 계층 처리율 제한(Rate Limiting) 방어 모델을 도입하고, 비정상적인 "
+    "로그 흐름을 모니터링하여 이상 감지 시 멀티 팩터 인증(MFA) 또는 CAPTCHA 시스템을 트리거해야 합니다."
+)
+
+_SQLI_REF = "OWASP Top 10:2021 A03:Injection / CWE-89"
+_OSCI_REF = "OWASP Top 10:2021 A03:Injection / CWE-78"
+_LFI_REF = "OWASP Top 10:2021 A01:Broken Access Control / CWE-22"
+_SSRF_REF = "OWASP Top 10:2021 A10:Server-Side Request Forgery / CWE-918"
+_FILEUPLOAD_REF = "OWASP Top 10:2021 A04:Insecure Design / CWE-434"
+_XSS_REF = "OWASP Top 10:2021 A03:Injection / CWE-79"
+_BRUTEFORCE_REF = "OWASP Top 10:2021 A07:Identification and Authentication Failures / CWE-307"
+
+SECURE_CODING_DB: dict[str, dict[str, str]] = {
+    "SQLi": {"reference": _SQLI_REF, "secure_coding_guide": _SQLI_GUIDE},
+    "SQLi-error_based": {"reference": _SQLI_REF, "secure_coding_guide": _SQLI_GUIDE},
+    "SQLi-boolean_blind": {"reference": _SQLI_REF, "secure_coding_guide": _SQLI_GUIDE},
+    "SQLi-time_blind": {"reference": _SQLI_REF, "secure_coding_guide": _SQLI_GUIDE},
+    "OSCi": {"reference": _OSCI_REF, "secure_coding_guide": _OSCI_GUIDE},
+    "OSCi-in_band": {"reference": _OSCI_REF, "secure_coding_guide": _OSCI_GUIDE},
+    "OSCi-time_based": {"reference": _OSCI_REF, "secure_coding_guide": _OSCI_GUIDE},
+    "LFI": {"reference": _LFI_REF, "secure_coding_guide": _LFI_GUIDE},
+    "LFI_Basic_Linux": {"reference": _LFI_REF, "secure_coding_guide": _LFI_GUIDE},
+    "LFI_Basic_Windows": {"reference": _LFI_REF, "secure_coding_guide": _LFI_GUIDE},
+    "LFI_PHP_Wrapper": {"reference": _LFI_REF, "secure_coding_guide": _LFI_GUIDE},
+    "LFI_RCE_Wrapper": {
+        "reference": f"{_LFI_REF} (보조 매핑: CWE-94 Code Injection)",
+        "secure_coding_guide": _LFI_GUIDE,
+    },
+    "SSRF": {"reference": _SSRF_REF, "secure_coding_guide": _SSRF_GUIDE},
+    "SSRF-Internal": {"reference": _SSRF_REF, "secure_coding_guide": _SSRF_GUIDE},
+    "SSRF-OOB": {"reference": _SSRF_REF, "secure_coding_guide": _SSRF_GUIDE},
+    "File Upload": {"reference": _FILEUPLOAD_REF, "secure_coding_guide": _FILE_UPLOAD_GUIDE},
+    "FileUpload-Webshell": {"reference": _FILEUPLOAD_REF, "secure_coding_guide": _FILE_UPLOAD_GUIDE},
+    "FileUpload-StoredXSS": {
+        "reference": f"{_FILEUPLOAD_REF} (보조 매핑: OWASP A03 / CWE-79 Cross-Site Scripting)",
+        "secure_coding_guide": _FILE_UPLOAD_GUIDE,
+    },
+    "FileUpload-PathTraversal": {
+        "reference": "OWASP Top 10:2021 A01:Broken Access Control / CWE-22 (Path Traversal)",
+        "secure_coding_guide": _FILE_UPLOAD_GUIDE,
+    },
+    "FileUpload-TemplateInjection": {
+        "reference": f"{_FILEUPLOAD_REF} (보조 매핑: CWE-1336 Server-Side Template Injection / CWE-94)",
+        "secure_coding_guide": _FILE_UPLOAD_GUIDE,
+    },
+    "stored_xss": {"reference": _XSS_REF, "secure_coding_guide": _STORED_XSS_GUIDE},
+    "Stored XSS": {"reference": _XSS_REF, "secure_coding_guide": _STORED_XSS_GUIDE},
+    "Reflected XSS": {"reference": _XSS_REF, "secure_coding_guide": _REFLECTED_XSS_GUIDE},
+    "Bruteforce": {"reference": _BRUTEFORCE_REF, "secure_coding_guide": _BRUTEFORCE_GUIDE},
+}
+
+
+def get_attack_guidance(attack_type: str) -> dict[str, str]:
+    """Return reference mapping and secure coding guide for the given attack type."""
+    return SECURE_CODING_DB.get(attack_type, {})

--- a/reporter/generator.py
+++ b/reporter/generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 from datetime import datetime
 from typing import Any
 
@@ -9,6 +10,7 @@ from fuzzer import EngineStats, Finding
 from reporter.dedupe import (
     dedupe_vulnerabilities,
     full_report_path,
+    get_attack_guidance,
     vulnerability_sort_key,
 )
 
@@ -151,6 +153,63 @@ class ReportGenerator:
             row["ssrf_channel"] = ch
         return row
 
+    def _group_vulnerabilities_by_type(
+        self, records: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """
+        Group flat vulnerability records by attack_type.
+
+        Each group contains:
+          - attack_type, severity (worst across instances), reference,
+            secure_coding_guide, count, instances[]
+        Instance objects retain target / attack_info (without redundant type field)
+        / evidence / module.
+        """
+        _sev_rank_to_label = {0: "critical", 1: "high", 2: "medium", 3: "low"}
+
+        groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        group_sev_rank: dict[str, int] = {}
+
+        for rec in records:
+            attack_info = rec.get("attack_info") or {}
+            attack_type = str(attack_info.get("type") or "Unknown")
+            sev = _severity_rank(str(attack_info.get("severity") or "high"))
+            if attack_type not in group_sev_rank:
+                group_sev_rank[attack_type] = sev
+            else:
+                group_sev_rank[attack_type] = min(group_sev_rank[attack_type], sev)
+
+            instance_attack: dict[str, Any] = {
+                k: v for k, v in attack_info.items() if k != "type"
+            }
+            instance: dict[str, Any] = {
+                "target": rec.get("target"),
+                "attack_info": instance_attack,
+                "evidence": rec.get("evidence"),
+            }
+            if rec.get("module"):
+                instance["module"] = rec["module"]
+            if rec.get("ssrf_channel"):
+                instance["ssrf_channel"] = rec["ssrf_channel"]
+            groups[attack_type].append(instance)
+
+        result: list[dict[str, Any]] = []
+        for attack_type, instances in groups.items():
+            guidance = get_attack_guidance(attack_type)
+            sev_label = _sev_rank_to_label.get(group_sev_rank[attack_type], "info")
+            entry: dict[str, Any] = {
+                "attack_type": attack_type,
+                "severity": sev_label,
+                "reference": guidance.get("reference", ""),
+                "secure_coding_guide": guidance.get("secure_coding_guide", ""),
+                "count": len(instances),
+                "instances": instances,
+            }
+            result.append(entry)
+
+        result.sort(key=lambda g: (_severity_rank(g["severity"]), g["attack_type"]))
+        return result
+
     def export_to_json(self, filepath: str = "scan_result.json") -> None:
         """
         Writes a deduplicated report to ``filepath`` (one PoC per URL / parameter / type)
@@ -162,6 +221,7 @@ class ReportGenerator:
         discovery_vulnerabilities = [self._finding_to_dict(f) for f in self.findings]
         deduped = dedupe_vulnerabilities(discovery_vulnerabilities, mode="first_in_order")
         deduped_sorted = sorted(deduped, key=vulnerability_sort_key)
+        grouped = self._group_vulnerabilities_by_type(deduped_sorted)
 
         full_report: dict[str, Any] = {
             "metadata": {
@@ -182,11 +242,12 @@ class ReportGenerator:
                     "queued": self.stats.queued,
                     "completed": self.stats.completed,
                     "failures": self.stats.failures,
-                    "findings": len(deduped_sorted),
+                    "vulnerability_types": len(grouped),
+                    "findings_deduped": len(deduped_sorted),
                     "findings_raw": self.stats.findings,
                 },
             },
-            "vulnerabilities": deduped_sorted,
+            "vulnerabilities": grouped,
         }
 
         full_path = full_report_path(filepath)

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -467,6 +467,131 @@
     }
     .muted { color: var(--muted); font-size: 0.84rem; }
 
+    /* ── Grouped vulnerability cards ── */
+    .vuln-group {
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      border-left-width: 4px;
+      border-left-color: #64748b;
+      background: rgba(18, 26, 45, 0.5);
+      overflow: hidden;
+    }
+    .vuln-group--low    { border-left-color: #22c55e; border-color: rgba(34,197,94,0.25);  background: rgba(34,197,94,0.05); }
+    .vuln-group--medium { border-left-color: #eab308; border-color: rgba(234,179,8,0.3);   background: rgba(234,179,8,0.05); }
+    .vuln-group--high   { border-left-color: #f97316; border-color: rgba(249,115,22,0.35); background: rgba(249,115,22,0.05); }
+    .vuln-group--critical { border-left-color: #ef4444; border-color: rgba(239,68,68,0.4);  background: rgba(244,63,94,0.05); }
+
+    .vuln-group-header {
+      padding: 12px 14px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .vuln-group-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .vuln-type-name {
+      font-weight: 700;
+      font-size: 0.93rem;
+      color: #dbeafe;
+      font-family: "JetBrains Mono", monospace;
+    }
+    .count-badge {
+      background: rgba(71,85,105,0.45);
+      border: 1px solid #475569;
+      border-radius: 999px;
+      padding: 1px 9px;
+      font-size: 0.69rem;
+      color: #94a3b8;
+    }
+    .guide-toggle-btn {
+      background: rgba(14,22,40,0.6);
+      border: 1px solid #2d3f5f;
+      border-radius: 6px;
+      color: #7dd3fc;
+      font-size: 0.72rem;
+      padding: 4px 11px;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+      white-space: nowrap;
+    }
+    .guide-toggle-btn:hover { border-color: var(--accent); color: #e0f2fe; }
+
+    .vuln-group-meta {
+      padding: 2px 14px 11px;
+      border-bottom: 1px solid rgba(38,53,80,0.55);
+    }
+    .reference-row {
+      font-size: 0.77rem;
+      color: #7dd3fc;
+      margin-bottom: 6px;
+      line-height: 1.5;
+    }
+    .guide-text-box {
+      margin-top: 4px;
+      background: rgba(5,10,24,0.55);
+      border: 1px solid #1e3050;
+      border-radius: 8px;
+      padding: 10px 12px;
+      font-size: 0.78rem;
+      color: #a8c0d8;
+      line-height: 1.7;
+    }
+
+    .vuln-instances { padding: 10px 14px 13px; }
+    .instance-label {
+      font-size: 0.69rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 7px;
+    }
+    .instance-item {
+      background: rgba(5,10,24,0.45);
+      border: 1px solid #1e2d48;
+      border-radius: 7px;
+      padding: 8px 11px;
+      margin-bottom: 6px;
+    }
+    .instance-item:last-child { margin-bottom: 0; }
+    .instance-row {
+      display: flex;
+      gap: 7px;
+      margin-bottom: 3px;
+      align-items: baseline;
+    }
+    .instance-row:last-child { margin-bottom: 0; }
+    .instance-key {
+      color: #64748b;
+      font-size: 0.71rem;
+      flex-shrink: 0;
+      min-width: 58px;
+    }
+    .instance-val {
+      color: #cbd5e1;
+      font-size: 0.8rem;
+      word-break: break-all;
+      line-height: 1.4;
+    }
+    .instance-payload {
+      color: #94a3b8;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 0.71rem;
+      word-break: break-all;
+      line-height: 1.45;
+    }
+    .report-summary-row {
+      font-size: 0.74rem;
+      color: #64748b;
+      margin-bottom: 10px;
+      font-family: "JetBrains Mono", monospace;
+    }
+
     @media (min-width: 1240px) {
       .left-scroll {
         display: grid;
@@ -907,7 +1032,7 @@
           <div class="stat-value" id="reportTarget" style="font-size: 0.95rem;">-</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">취약점 수</div>
+          <div class="stat-label" id="reportFindingsLabel">공격 유형 수</div>
           <div class="stat-value" id="reportFindings">0</div>
         </div>
       </div>
@@ -1103,12 +1228,6 @@
 
     const SEVERITY_SORT_ORDER = { critical: 0, high: 1, medium: 2, low: 3, unknown: 4 };
 
-    function severityRank(item) {
-      const raw = item.attack_info?.severity ?? item.severity;
-      const tier = severityTier(raw);
-      return SEVERITY_SORT_ORDER[tier] ?? 4;
-    }
-
     function escapeHtml(str) {
       return String(str)
         .replace(/&/g, "&amp;")
@@ -1117,56 +1236,146 @@
         .replace(/"/g, "&quot;");
     }
 
-    function renderReport(scan) {
-      const reportVulns = scan.report_json?.vulnerabilities || [];
-      const findings = reportVulns.length ? reportVulns : (scan.findings || []);
-      reportScanId.textContent = `scan_id: ${scan.scan_id || "(없음)"}`;
-      reportStatus.textContent = scan.status || "-";
-      reportProgress.textContent = formatProgressPercent(scan);
-      reportTarget.textContent = scan.target || scan.request?.url || "-";
-      reportFindings.textContent = String(findings.length);
+    /* ── 취약점 렌더링 헬퍼 ── */
+    function isGroupedFormat(vulns) {
+      return vulns.length > 0 && "attack_type" in vulns[0];
+    }
 
-      if (!findings.length) {
-        findingList.innerHTML = '<div class="muted">발견된 취약점이 없습니다.</div>';
+    let _guideCounter = 0;
+    function toggleGuide(id) {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.hidden = !el.hidden;
+      const btn = document.querySelector(`[data-guide-target="${id}"]`);
+      if (btn) btn.textContent = el.hidden ? "시큐어 코딩 가이드 ▾" : "시큐어 코딩 가이드 ▴";
+    }
+
+    function renderGroupCard(group) {
+      const tier = severityTier(group.severity || "unknown");
+      const sevLabel = escapeHtml((group.severity || "unknown").toUpperCase());
+      const typeName = escapeHtml(group.attack_type || "Unknown");
+      const reference = escapeHtml(group.reference || "");
+      const guideText = escapeHtml(group.secure_coding_guide || "");
+      const count = group.count ?? group.instances?.length ?? 0;
+      const instances = group.instances || [];
+      const guideId = `guide-${++_guideCounter}`;
+
+      const instancesHtml = instances.map((inst) => {
+        const tgt = inst.target || {};
+        const ai  = inst.attack_info || {};
+        const ev  = inst.evidence || {};
+        const url      = escapeHtml(tgt.url || "-");
+        const param    = escapeHtml(tgt.parameter || "-");
+        const location = escapeHtml(tgt.location || "-");
+        const method   = escapeHtml(tgt.method || "-");
+        const variant  = escapeHtml(ai.attack_variant || "");
+        const rawPayload = String(ai.payload_value || "-");
+        const payloadShort = escapeHtml(rawPayload.length > 130 ? rawPayload.slice(0, 130) + "…" : rawPayload);
+        const status   = ev.status_code ?? "-";
+        const elapsed  = ev.response_time != null ? `${ev.response_time}s` : "-";
+        return `
+          <div class="instance-item">
+            <div class="instance-row"><span class="instance-key">URL</span><span class="instance-val">${url}</span></div>
+            <div class="instance-row"><span class="instance-key">파라미터</span><span class="instance-val">${param}</span></div>
+            <div class="instance-row"><span class="instance-key">위치</span><span class="instance-val">${location} · ${method}</span></div>
+            ${variant ? `<div class="instance-row"><span class="instance-key">변형</span><span class="instance-val">${variant}</span></div>` : ""}
+            <div class="instance-row"><span class="instance-key">응답</span><span class="instance-val">HTTP ${status} · ${elapsed}</span></div>
+            <div class="instance-row"><span class="instance-key">페이로드</span><span class="instance-payload">${payloadShort}</span></div>
+          </div>`;
+      }).join("");
+
+      const metaHtml = (reference || guideText) ? `
+        <div class="vuln-group-meta">
+          ${reference ? `<div class="reference-row">📎 ${reference}</div>` : ""}
+          ${guideText ? `<div class="guide-text-box" id="${guideId}" hidden>${guideText}</div>` : ""}
+        </div>` : "";
+
+      return `
+        <div class="vuln-group vuln-group--${tier}">
+          <div class="vuln-group-header">
+            <div class="vuln-group-title">
+              <span class="badge-sev badge-sev--${tier}">${sevLabel}</span>
+              <span class="vuln-type-name">${typeName}</span>
+              <span class="count-badge">${count}건</span>
+            </div>
+            ${guideText ? `<button class="guide-toggle-btn" data-guide-target="${guideId}" onclick="toggleGuide('${guideId}')">시큐어 코딩 가이드 ▾</button>` : ""}
+          </div>
+          ${metaHtml}
+          <div class="vuln-instances">
+            ${instances.length > 1 ? `<div class="instance-label">발견 인스턴스 (${instances.length}건)</div>` : ""}
+            ${instancesHtml}
+          </div>
+        </div>`;
+    }
+
+    function renderFlatCard(item, scan) {
+      const severityRaw = item.attack_info?.severity || item.severity || "Unknown";
+      const tier      = severityTier(severityRaw);
+      const severity  = escapeHtml(severityRaw);
+      const type      = escapeHtml(item.attack_info?.type || item.type || "Unknown");
+      const parameter = escapeHtml(item.target?.parameter || item.parameter || "-");
+      const targetUrl = escapeHtml(item.target?.url || item.url || scan.target || "-");
+      const location  = escapeHtml(item.target?.location || item.location || "-");
+      const payload   = escapeHtml(item.attack_info?.payload_value || item.payload || "-");
+      return `
+        <div class="vuln-item vuln-item--${tier}">
+          <div class="vuln-head">
+            <span class="badge-sev badge-sev--${tier}">${severity}</span>
+            <span class="muted">${type}</span>
+          </div>
+          <div class="muted vuln-url">타겟 URL: ${targetUrl}</div>
+          <div class="muted">파라미터: ${parameter}</div>
+          <div class="muted">위치: ${location}</div>
+          <div class="muted">페이로드: ${payload}</div>
+        </div>`;
+    }
+
+    function renderReport(scan) {
+      reportScanId.textContent  = `scan_id: ${scan.scan_id || "(없음)"}`;
+      reportStatus.textContent  = scan.status || "-";
+      reportProgress.textContent = formatProgressPercent(scan);
+      reportTarget.textContent  = scan.target || scan.request?.url || "-";
+
+      const reportVulns  = scan.report_json?.vulnerabilities || [];
+      const rawFindings  = scan.findings || [];
+      const useGrouped   = reportVulns.length > 0 && isGroupedFormat(reportVulns);
+      const flatFallback = !useGrouped && (rawFindings.length > 0 || reportVulns.length > 0);
+
+      /* ── 요약 카운트 ── */
+      const findingsLabel = document.getElementById("reportFindingsLabel");
+      if (useGrouped) {
+        const sum = scan.report_json?.metadata?.summary || {};
+        reportFindings.textContent = String(sum.vulnerability_types ?? reportVulns.length);
+        if (findingsLabel) findingsLabel.textContent = "공격 유형 수";
+      } else {
+        const n = rawFindings.length || reportVulns.length;
+        reportFindings.textContent = String(n);
+        if (findingsLabel) findingsLabel.textContent = "취약점 수";
+      }
+
+      if (useGrouped) {
+        const sum = scan.report_json?.metadata?.summary || {};
+        const deduped = sum.findings_deduped != null ? `중복제거 ${sum.findings_deduped}건` : "";
+        const raw     = sum.findings_raw     != null ? `원본 ${sum.findings_raw}건` : "";
+        const summaryLine = [deduped, raw].filter(Boolean).join(" · ");
+        findingList.innerHTML =
+          (summaryLine ? `<div class="report-summary-row">${escapeHtml(summaryLine)}</div>` : "") +
+          reportVulns.map(renderGroupCard).join("");
         return;
       }
 
-      const sorted = [...findings].sort((a, b) => {
-        const ra = severityRank(a);
-        const rb = severityRank(b);
+      const items = rawFindings.length > 0 ? rawFindings : reportVulns;
+      if (!items.length) {
+        findingList.innerHTML = '<div class="muted">발견된 취약점이 없습니다.</div>';
+        return;
+      }
+      const sorted = [...items].sort((a, b) => {
+        const ra = SEVERITY_SORT_ORDER[severityTier(a.attack_info?.severity ?? a.severity)] ?? 4;
+        const rb = SEVERITY_SORT_ORDER[severityTier(b.attack_info?.severity ?? b.severity)] ?? 4;
         if (ra !== rb) return ra - rb;
-        const ua = String(a.target?.url || a.url || "");
-        const ub = String(b.target?.url || b.url || "");
-        if (ua !== ub) return ua.localeCompare(ub);
-        const pa = String(a.target?.parameter || a.parameter || "");
-        const pb = String(b.target?.parameter || b.parameter || "");
-        return pa.localeCompare(pb);
+        return (a.target?.url || a.url || "").localeCompare(b.target?.url || b.url || "");
       });
-
-      findingList.innerHTML = sorted.map((item) => {
-        const severityRaw = item.attack_info?.severity || item.severity || "Unknown";
-        const tier = severityTier(severityRaw);
-        const severity = escapeHtml(severityRaw);
-        const type = escapeHtml(item.attack_info?.type || item.type || "Unknown");
-        const parameter = escapeHtml(item.target?.parameter || item.parameter || "-");
-        const targetUrl = escapeHtml(
-          item.target?.url || item.url || scan.target || scan.request?.url || "-"
-        );
-        const location = escapeHtml(item.target?.location || item.location || "-");
-        const payload = escapeHtml(item.attack_info?.payload_value || item.payload || "-");
-        return `
-          <div class="vuln-item vuln-item--${tier}">
-            <div class="vuln-head">
-              <span class="badge-sev badge-sev--${tier}">${severity}</span>
-              <span class="muted">${type}</span>
-            </div>
-            <div class="muted vuln-url">타겟 URL: ${targetUrl}</div>
-            <div class="muted">파라미터: ${parameter}</div>
-            <div class="muted">위치: ${location}</div>
-            <div class="muted">페이로드: ${payload}</div>
-          </div>
-        `;
-      }).join("");
+      findingList.innerHTML = sorted.map((item) => renderFlatCard(item, scan)).join("");
     }
 
     async function syncScanState() {


### PR DESCRIPTION
## 📌 PR 목적 (What)
`scan_report.json`을 URL·파라미터 단위의 플랫 목록 대신 공격 유형별로 묶어 출력하고, 각 유형에 OWASP/CWE 참고 매핑과 시큐어 코딩 가이드를 함께 제공. 웹 UI 결과 리포트도 동일한 그룹 구조를 반영해 동일 유형의 여러 취약점을 한 카드에서 확인할 수 있게 구현.
## 🛠️ 주요 변경 사항 (How)
- `reporter/dedupe.py`: 공격 유형별 SECURE_CODING_DB(참고 매핑 + 시큐어 코딩 가이드) 추가, get_attack_guidance() 헬퍼 제공
- `reporter/generator.py`: dedupe 후 attack_type 기준 그룹핑(_group_vulnerabilities_by_type) 적용 — scan_report.json은 그룹 구조, scan_report_full.json은 기존 플랫 전체 목록 유지
- `scan_report.json` summary: vulnerability_types, findings_deduped, findings_raw로 요약 지표 분리
- `webapp/static/index.html`: 그룹 카드 UI(심각도, 참고 매핑, 가이드 토글, instances 목록) 및 renderReport 그룹/플랫 포맷 자동 분기 (스캔 중 플랫, 완료 후 그룹)

## 🧪 테스트 결과 (Testing & Verification)
<img width="1071" height="1734" alt="image" src="https://github.com/user-attachments/assets/16174784-b034-438f-a10a-44ef35a48f96" />
