### PR TITLE
[feat] sqli 분석기 로직 수정, cli에 dbms 옵션 추가

### DIFF
--- a/cli/output.py
+++ b/cli/output.py
@@ -40,6 +40,7 @@ def print_scan_configuration(
     module_count: int,
     payload_count: int,
     level: int | None,
+    target_dbms: str,
     target_os: str,
     sqli_evasion_level: int,
     osci_evasion_level: int,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -270,6 +270,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="SQLi: max time/stacked payloads when --sqli-time-based is set (0=all)",
     )
     parser.add_argument(
+        "--target-dbms",
+        choices=["mysql", "mssql", "oracle", "postgres", "sqlite", "access", "all"],
+        default="all",
+        help="selects target dbms for SQLi module (default: all)"
+    )
+    parser.add_argument(
         "--osci-evasion-level",
         type=int,
         choices=[0, 1, 2, 3],

--- a/cli/runner.py
+++ b/cli/runner.py
@@ -55,6 +55,7 @@ async def run_scan(args, *, base_url: str, surfaces) -> None:
         module_count=len(context["modules"]),
         payload_count=context["payload_count"],
         level=args.level,
+        target_dbms=args.target_dbms, 
         target_os=args.target_os,
         sqli_evasion_level=args.sqli_evasion_level,
         osci_evasion_level=args.osci_evasion_level,

--- a/fuzzer/setup.py
+++ b/fuzzer/setup.py
@@ -17,6 +17,7 @@ def select_modules(args) -> list:
             include_time_based=args.sqli_time_based,
             max_time_payloads=args.sqli_time_max,
             evasion_level=args.sqli_evasion_level,
+            target_dbms=args.target_dbms,
         )
         selected.append(sqli_module)
 
@@ -25,7 +26,7 @@ def select_modules(args) -> list:
             include_time_based=args.osci_time_based,
             max_time_payloads=args.osci_time_max,
             evasion_level=args.osci_evasion_level,
-            target_os=args.target_os
+            target_os=args.target_os,
         )
         selected.append(osci_module)
 

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -4,8 +4,13 @@ import asyncio
 from urllib.parse import unquote
 from difflib import SequenceMatcher
 
+# 블라인드 인젝션 시 에러 상태 분류를 위한 범용 키워드
+GENERIC_DB_ERROR_KEYWORDS = re.compile(
+    r'(error|syntax|mysql|mariadb|oracle|postgres|sql server|xpath|exception|unclosed|statement)', 
+    re.I
+)
+
 def _get_pure_text(html_content: str) -> str:
-    """HTML 태그, 스크립트 등을 제거하여 순수 텍스트만 추출 (노이즈 제거)"""
     if not html_content:
         return ""
     text = re.sub(r'<(script|style).*?>.*?</\1>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
@@ -15,20 +20,30 @@ def _get_pure_text(html_content: str) -> str:
     return text
 
 def get_text_ratio(text1: str, text2: str) -> float:
-    """순수 텍스트 유사도 비율 계산"""
     pure1 = _get_pure_text(text1)
     pure2 = _get_pure_text(text2)
     if not pure1 and not pure2: return 1.0
     if not pure1 or not pure2: return 0.0
     return SequenceMatcher(None, pure1, pure2).ratio()
 
-def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None):
+# 반사 제거 함수
+def _remove_direct_reflection(text: str, payload_value: str) -> str:
+    scrubbed = text
+    payload_variants = [
+        payload_value,
+        unquote(payload_value),
+        unquote(unquote(payload_value)),
+        html.escape(payload_value),
+        html.unescape(payload_value)
+    ]
+    for variant in filter(None, set(payload_variants)):
+        scrubbed = scrubbed.replace(variant, "[DIRECT_REFLECTION_REMOVED]")
+    return scrubbed
 
+def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None):
     evidences = []
     res_text = response.text
     
-    current_status = getattr(response, "status", getattr(response, "status_code", None))
-    orig_status = getattr(original_res, "status", getattr(original_res, "status_code", None)) if original_res else None
     orig_elapsed = getattr(original_res, "elapsed_time", getattr(getattr(original_res, "elapsed", object()), "total_seconds", lambda: 0.0)()) if original_res else 0.0
 
     attack_type = payload.attack_type.lower()
@@ -39,174 +54,150 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
 
     has_syntax_error = False
     has_execution_error = False
-    has_potential_mismatch = False
 
-    timing_keywords = ["sleep(", "waitfor delay", "pg_sleep", "benchmark(", "dbms_pipe.receive_message", "regexp_substring", "repeat("]
-    has_timing_intent = any(k in payload_value.lower() for k in timing_keywords)
-    is_time_related = "time" in attack_type or "stacked" in attack_type or has_timing_intent
-    # 시간 페이로드 타임아웃 탐지
-    if is_time_related and response is None:
-        if elapsed_time >= 4.0:
+    is_time_related = "time" in attack_type or "stacked" in attack_type
+    
+    # [1] 시간 페이로드 타임아웃 탐지
+    if is_time_related:
+        if response is None and elapsed_time >= 4.5:
             evidences.append(f"[Time] Request Timed Out: {elapsed_time:.2f}s")
-        return len(evidences) > 0, evidences, False
+            return True, evidences, False
+        elif elapsed_time >= (4.5 + orig_elapsed):
+            evidences.append(f"[Time] Response delayed: {elapsed_time:.2f}s")
+            return True, evidences, False
 
-    # [1] 문법 오류 식별
+    # [2] 문법 오류 식별
     scrubbed_text = res_text
     for pattern in syntax_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
             has_syntax_error = True
             scrubbed_text = re.sub(pattern, "[FULL_SYNTAX_ERROR_REMOVED]", scrubbed_text, flags=re.I | re.DOTALL)
+            break 
 
-    # [2] 직접 반사 제거
-    payload_variants = [payload_value, unquote(payload_value), html.escape(payload_value)]
-    for var in filter(None, set(payload_variants)):
-        scrubbed_text = scrubbed_text.replace(var, "[DIRECT_REFLECTION_REMOVED]")
+    # [3] 직접 반사 제거 적용
+    scrubbed_text = _remove_direct_reflection(scrubbed_text, payload_value)
 
-    # 1. 시간 기반 탐지
-    if is_time_related and elapsed_time >= (4.0 + orig_elapsed):
-        evidences.append(f"[Time] Response delayed: {elapsed_time:.2f}s")
-
-    # 2. 에러 기반 탐지
+    # [4] 에러 기반 탐지
     for pattern in exploit_signatures:
         if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
             marker_match = dynamic_marker_pattern.search(res_text)
-            
             if marker_match:
                 extracted_data = marker_match.group(1)
-                evidences.append(f"[Error] SQL Execution Error (Marker Found: '{extracted_data}'): {pattern}")
-                has_execution_error = True
+                evidences.append(f"[Error] SQL Execution Error (Marker Found: '{extracted_data}')")
             else:
-                evidences.append(f"[ExecutionErr] SQL Execution Error (No Marker): {pattern}")
+                evidences.append(f"[PotentialError] SQL Execution Error (No Marker): {pattern}")
+            
+            has_execution_error = True
             break
 
-    if not has_execution_error and not any("[ExecutionErr]" in e for e in evidences):
+    # [5] 미스매치 탐지
+    if not has_execution_error:
         for pattern in mismatch_signatures:
             if re.search(pattern, scrubbed_text, re.I | re.DOTALL):
-                evidences.append(f"[Mismatch] DBMS Mismatch Error: {pattern}")
-                has_potential_mismatch = True
+                evidences.append(f"[PotentialMismatch] DBMS Mismatch Error")
+                has_execution_error = True 
                 break
 
-    # 3. 마커 검증
+    # [6] 마커 단독 검증
     if not has_execution_error:
-        # 동적 마커 패턴 검색
-        marker_match_res = dynamic_marker_pattern.search(res_text)
-        marker_match_scrubbed = dynamic_marker_pattern.search(scrubbed_text)
-
-        if marker_match_res and marker_match_scrubbed:
-            extracted_data = marker_match_res.group(1)
-            
-            if has_syntax_error or any("executionerr" in e.lower() for e in evidences):
-                evidences.append(f"[Error] SQLi execution marker ('{extracted_data}') confirmed in DB output context")
+        if dynamic_marker_pattern.search(scrubbed_text):
+            if has_syntax_error:
+                evidences.append(f"[Error] SQLi execution marker confirmed in DB output context")
                 has_execution_error = True
             else:
-                # 에러가 확인되지 않았는데 마커만 발견된 경우 단순 반사 또는 exploit_signatures에 없는 에러 메시지에서 데이터 추출
-                evidences.append(f"[Reflection] SQLi marker ('{extracted_data}') confirmed in legitimate content")
-
-    # 4. 불리언 기반 탐지
-    if (not evidences or has_potential_mismatch or any("[ExecutionErr]" in e for e in evidences)) and not has_syntax_error and original_res:
-        if current_status != orig_status:
-            evidences.append(f"[Boolean] Status Code changed: {orig_status} -> {current_status}")
-
-        ratio = get_text_ratio(original_res.text, res_text)
-        if ratio < 0.995:
-            evidences.append(f"[Boolean] Text similarity ratio: {ratio:.4f} (Baseline Status: {orig_status})")
-            
-            orig_pure = _get_pure_text(original_res.text).lower()
-            curr_pure = _get_pure_text(res_text).lower()
-            blind_keywords = ["exists", "missing", "found", "success", "failed", "invalid", "true", "false"]
-            for kw in blind_keywords:
-                if (kw in orig_pure) != (kw in curr_pure):
-                    evidences.append(f"[Boolean] Blind keyword '{kw}' state inverted")
-                    break
+                evidences.append(f"[Potential] Marker reflected (requires Boolean verification)")
 
     return len(evidences) > 0, evidences, has_syntax_error
 
+
 async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_1st, evidences, has_syntax_error, syntax_signatures=None):
-    if not requester or not original_res:
+    if not requester:
         return is_vuln_1st, evidences
 
     val = payload.value
     res_text = response.text
-    orig_text = original_res.text
-    orig_status = getattr(original_res, "status", getattr(original_res, "status_code", None))
     
-    true_ratio = get_text_ratio(orig_text, res_text)
-    pure_res = _get_pure_text(res_text)
-    pure_orig = _get_pure_text(orig_text)
+    # 1. 확정 증거
+    if is_vuln_1st and any(tag in str(evidences) for tag in ["[Error]", "[Time]"]):
+        return True, evidences
+
+    # 2. 페이로드 논리 분석
+    logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1|true|exists"
+    has_logic = re.search(logic_pattern, val, re.I) or "1=1" in val
     
-    logic_pattern = r"(['\"]?\w+['\"]?)\s*=\s*\1"
-    is_true_expanded = (len(pure_res) >= len(pure_orig) * 1.1) and (len(pure_res) - len(pure_orig) >= 20)
-    is_blind_candidate = (99 > true_ratio >= 0.95) and (not is_true_expanded)
-
-    # [A] 1차 탐지에서 변화 감지
-    if is_vuln_1st: 
-        if any(tag in str(evidences) for tag in ["[Error]", "[Reflection]", "[Time]"]):
-            return True, evidences
-
-        # Path 1: 구조적 파손 검증 (주석 처리)
-        if not is_true_expanded and not is_blind_candidate:
-            if val.strip().endswith("'") or val.strip().endswith('"'):
-                fix_res = await requester(val + " -- ")
-                ratio = get_text_ratio(fix_res.text, orig_text)
-                if ratio >= 0.99:
-                    return True, evidences + [f"[Verified] Syntax Fix Test(broken) Ratio: {ratio:.4f}"]
-
-        # Path 2: 논리 반전 테스트
-        has_logic = re.search(logic_pattern, val) or "1=1" in val
+    # 3. 논리 구조가 있으면 T!=F 대조 시도
+    if has_logic or is_vuln_1st:
         
-        if is_true_expanded or is_blind_candidate or has_logic or any(tag in str(evidences) for tag in ["[ExecutionErr]"]):
+        true_logic = ""
+        false_logic = ""
+        
+        if "1=1" in val:
+            true_logic = "1=1"
+            false_logic = "1=2"
+            false_payload = val.replace(true_logic, false_logic)
+        else:
+            match = re.search(logic_pattern, val, re.I)
+            if match:
+                true_logic = match.group(0)
+                false_logic = "1=2"
+                false_payload = val.replace(true_logic, false_logic)
+            else:
+                true_logic = ""
+                false_logic = "AND 1=2"
+                false_payload = val + " AND 1=2"
             
-            # 주석 복구 시도
-            if val.strip().endswith("'") or val.strip().endswith('"'):
-                fix_res = await requester(val + " -- ")
-                fix_ratio = get_text_ratio(fix_res.text, orig_text)
-                if fix_ratio >= 0.99:
-                    return True, evidences + [f"[Verified] Syntax Fix Test Ratio: {fix_ratio:.4f}"]
-
-            # 논리 반전 테스트
-            if has_logic:
-                false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
-                false_res = await requester(false_payload)
-                false_res_text = false_res.text
-                false_pure_res = _get_pure_text(false_res_text)
-                false_status = getattr(false_res, "status", getattr(false_res, "status_code", None))
-                
-                # 거짓 응답 문법 에러 확인
-                false_has_syntax_error = False
-                if syntax_signatures:
-                    for pattern in syntax_signatures:
-                        if re.search(pattern, false_res_text, re.I | re.DOTALL):
-                            false_has_syntax_error = True
-                            break
-
-                # [검증 1] 참 조건 응답에 데이터가 추가되었고 참 조건 응답과 거짓 조건 응답이 다른가
-                if is_true_expanded:
-                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
-                    if f_to_t_ratio < 0.98:
-                        tag = f"[Verified] Logic Swapping (Expansion) Ratio: {f_to_t_ratio:.4f}"
-                        return True, evidences + [tag]
-                
-                # [검증 2] 참 조건 응답이 baseline과 조금 다르고, 거짓 조건 응답은 baseline과 같으면서 참 조건 응답과 다른가
-                elif is_blind_candidate:
-                    f_to_orig_ratio = get_text_ratio(false_res.text, orig_text)
-                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
-                    if f_to_t_ratio < 0.99 and false_status == orig_status and f_to_orig_ratio >= 0.98:
-                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False==Baseline) Ratio: {f_to_orig_ratio:.4f}"]
-
-                # [검증 3] 거짓 조건 응답에 데이터가 추가되었고, 참 조건 응답과 거짓조건 응답이 다른가
-                is_false_expanded = (len(false_pure_res) >= len(pure_orig) * 1.1) and (len(false_pure_res) - len(pure_orig) >= 20)
-                if not false_has_syntax_error and is_false_expanded:
-                    f_to_t_ratio = get_text_ratio(false_res.text, res_text)
-                    if f_to_t_ratio < 0.98:
-                        return True, evidences + [f"[Verified] Inverted Logic Swapping (False Expansion) Ratio: {f_to_t_ratio:.4f}"]
-
-    # [B]: 1차 탐지에서 변화 미감지
-    elif not has_syntax_error:
-        if re.search(logic_pattern, val) or "1=1" in val:
-            false_payload = val.replace("1=1", "1=2") if "1=1" in val else re.sub(logic_pattern, "1=2", val)
+        try:
             false_res = await requester(false_payload)
-            f_to_t_ratio = get_text_ratio(false_res.text, res_text)
-            if f_to_t_ratio < 0.99:
-                return True, [f"[Verified] Blind SQLi (Baseline==True(Status: {orig_status}) and True!=False) Ratio: {f_to_t_ratio:.4f}"]
+            
+            scrubbed_true = _remove_direct_reflection(res_text, val)
+            scrubbed_false = _remove_direct_reflection(false_res.text, false_payload)
+            
+            if true_logic and false_logic:
+                for t_var in filter(None, set([true_logic, unquote(true_logic), html.escape(true_logic)])):
+                    scrubbed_true = scrubbed_true.replace(t_var, "[LOGIC_NORMALIZED]")
+                for f_var in filter(None, set([false_logic, unquote(false_logic), html.escape(false_logic)])):
+                    scrubbed_false = scrubbed_false.replace(f_var, "[LOGIC_NORMALIZED]")
+            
+            t_f_ratio = get_text_ratio(scrubbed_true, scrubbed_false)
+            
+            # 일치도가 0에 수렴할 경우 재검증
+            if t_f_ratio <= 0.05:
+                await asyncio.sleep(3.0) # 3초 대기
+                
+                retry_true_res = await requester(val)
+                retry_false_res = await requester(false_payload)
+                
+                retry_scrubbed_true = _remove_direct_reflection(retry_true_res.text, val)
+                retry_scrubbed_false = _remove_direct_reflection(retry_false_res.text, false_payload)
+                
+                if true_logic and false_logic:
+                    for t_var in filter(None, set([true_logic, unquote(true_logic), html.escape(true_logic)])):
+                        retry_scrubbed_true = retry_scrubbed_true.replace(t_var, "[LOGIC_NORMALIZED]")
+                    for f_var in filter(None, set([false_logic, unquote(false_logic), html.escape(false_logic)])):
+                        retry_scrubbed_false = retry_scrubbed_false.replace(f_var, "[LOGIC_NORMALIZED]")
+                        
+                retry_t_f_ratio = get_text_ratio(retry_scrubbed_true, retry_scrubbed_false)
+                
+                # 재검증에서 두 응답이 같으면 오탐으로 간주
+                if retry_t_f_ratio >= 0.98:
+                    return False, evidences
+                    
+                t_f_ratio = retry_t_f_ratio
+                false_res = retry_false_res
+                scrubbed_false = retry_scrubbed_false
 
-    return False, []
+            #  일치도가 98미만이면 정탐으로 확정
+            if t_f_ratio < 0.98:
+                pure_false = _get_pure_text(scrubbed_false)
+                
+                if GENERIC_DB_ERROR_KEYWORDS.search(pure_false):
+                    evidences.append(f"[Verified] Conditional Error SQLi. T!=F ratio: {t_f_ratio:.4f}")
+                else:
+                    evidences.append(f"[Verified] Boolean SQLi. T!=F ratio: {t_f_ratio:.4f}")
+                    
+                return True, evidences
+                
+        except Exception:
+            pass 
+
+    return False, evidences

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -5,7 +5,6 @@ import re
 import dataclasses
 import random
 import asyncio
-import time
 from dataclasses import dataclass
 from typing import Iterator, Any, Tuple, List, Optional, Iterable
 
@@ -16,6 +15,7 @@ from core.models import Payload
 
 @dataclass(frozen=True, slots=True)
 class SQLiInternalPayload(Payload):
+    target_dbms: str = "All"
     _is_serial: bool = False
     _real_time_value: Optional[str] = None
 
@@ -25,6 +25,16 @@ class SQLiModule(BaseModule):
         self.exploit_signatures = self._load_json("exploit_errors.json")
         self.syntax_signatures = self._load_json("syntax_errors.json")
         self.mismatch_signatures = self._load_json("mismatch_errors.json")
+        
+        # CLI에서 입력받은 DBMS 텍스트 정규화 매핑 (기본값: all)
+        raw_dbms = kwargs.get('target_dbms', 'all').lower()
+        if raw_dbms == 'mysql': self.target_dbms = "MySQL"
+        elif raw_dbms in ('mssql', 'microsoft sql server'): self.target_dbms = "Microsoft SQL Server"
+        elif raw_dbms == 'oracle': self.target_dbms = "Oracle"
+        elif raw_dbms in ('postgres', 'postgresql'): self.target_dbms = "PostgreSQL"
+        elif raw_dbms == 'sqlite': self.target_dbms = "SQLite"
+        elif raw_dbms == 'access': self.target_dbms = "MS Access"
+        else: self.target_dbms = "all"
         
         self.evasion_level = kwargs.get('evasion_level', 0)
         self.include_time_based = kwargs.get('include_time_based', False)
@@ -58,6 +68,8 @@ class SQLiModule(BaseModule):
         return "time" in attack_type or "stacked" in attack_type
 
     def get_target_parameters(self, surface: Any, all_params: Iterable[str]) -> Iterable[str]:
+        if self._fast_per_param == 0:
+            self.get_payload_count()
         params = list(all_params)
         url = getattr(surface, "url", "")
         method = getattr(surface, "method", "GET")
@@ -69,9 +81,10 @@ class SQLiModule(BaseModule):
         return params
 
     def get_payload_count(self) -> int:
-        all_raw = get_sqli_payloads()
-        fast_c = sum(1 for p in all_raw if not self._is_time_payload(p))
-        time_c = sum(1 for p in all_raw if self._is_time_payload(p))
+        filtered = get_sqli_payloads(self.target_dbms)
+        
+        fast_c = sum(1 for p in filtered if not self._is_time_payload(p))
+        time_c = sum(1 for p in filtered if self._is_time_payload(p))
         
         selected_time_count = 0
         if self.include_time_based:
@@ -86,39 +99,49 @@ class SQLiModule(BaseModule):
         if self._fast_per_param == 0: 
             self.get_payload_count()
 
-        all_raw = get_sqli_payloads()
-        fast_indices = [i for i, p in enumerate(all_raw) if not self._is_time_payload(p)]
-        time_indices = [i for i, p in enumerate(all_raw) if self._is_time_payload(p)]
+        # payload.py 에서 필터링된 페이로드 리스트 로드
+        filtered = get_sqli_payloads(self.target_dbms)
+        
+        fast_payloads = [p for p in filtered if not self._is_time_payload(p)]
+        time_payloads = [p for p in filtered if self._is_time_payload(p)]
 
+        # 1. 일반 페이로드 생성
         for level in range(self.evasion_level + 1):
-            for idx in fast_indices:
-                p = all_raw[idx]
+            for p in fast_payloads:
                 yield SQLiInternalPayload(
                     value=self._apply_evasion_by_level(p.value, level),
-                    attack_type=p.attack_type, risk_level=p.risk_level, _is_serial=False
+                    attack_type=p.attack_type,
+                    risk_level=p.risk_level,
+                    target_dbms=getattr(p, 'target_dbms', 'Generic'),
+                    _is_serial=False
                 )
 
-        if self.include_time_based and time_indices:
+        # 2. 시간 기반 페이로드 생성
+        if self.include_time_based and time_payloads:
             random.seed(self.random_seed)
-            limit = self.max_time_payloads if self.max_time_payloads > 0 else len(time_indices)
-            selected_indices = random.sample(time_indices, min(limit, len(time_indices)))
+            limit = self.max_time_payloads if self.max_time_payloads > 0 else len(time_payloads)
+            selected = random.sample(time_payloads, min(limit, len(time_payloads)))
+            
             for level in range(self.evasion_level + 1):
-                for idx in selected_indices:
-                    p = all_raw[idx]
+                for p in selected:
                     yield SQLiInternalPayload(
-                        value="1", attack_type=p.attack_type, risk_level=p.risk_level,
-                        _is_serial=True, _real_time_value=self._apply_evasion_by_level(p.value, level)
+                        value="1",
+                        attack_type=p.attack_type,
+                        risk_level=p.risk_level,
+                        target_dbms=getattr(p, 'target_dbms', 'Generic'),
+                        _is_serial=True,
+                        _real_time_value=self._apply_evasion_by_level(p.value, level)
                     )
 
     def _apply_evasion_by_level(self, value: str, level: int) -> str:
         if level == 0: return value
-        if level == 1:
+        if level >= 1:
             value = value.replace("SELECT", "sElEcT").replace("UNION", "uNiOn")\
                          .replace("AND", "aNd").replace("OR", "oR")\
                          .replace("CASE", "cAsE").replace("WHEN", "wHeN")
-        if level == 2:
+        if level >= 2:
             value = value.replace(" ", "/**/")
-        if level == 3:
+        if level >= 3:
             value = urllib.parse.quote(urllib.parse.quote(value)) + "%00"
         return value
 
@@ -176,10 +199,13 @@ class SQLiModule(BaseModule):
                             
                             # 30초(10초 * 3) 동안 일반 페이로드 완료 없으면 강제 돌파
                             if stuck_count >= 3:
+                                if not self._time_phase_active:
+                                    print(f"\n[!] Deadlock Breaker: Network drop-offs detected. Forcing time-based phase (SQLi).")
                                 self._barrier_event.set()
                                 break
                     
                 if not self._time_phase_active:
+                    print(f"\n[★TRANSITION] Barrier cleared. Starting REAL time-based SQLi attacks!")
                     self._time_phase_active = True
 
                 # 2. 전역 직렬 실행 락
@@ -223,6 +249,7 @@ class SQLiModule(BaseModule):
                     self._time_attack_in_flight -= 1
                     if self._time_attack_in_flight == 0:
                         if self._time_phase_active:
+                            print(f"[★TRANSITION] Going back to normal SQLi payloads")
                             self._barrier_event.clear()
                             self._time_phase_active = False
 

--- a/modules/sqli/payloads.py
+++ b/modules/sqli/payloads.py
@@ -1,7 +1,14 @@
 import os
 import random
-import dataclasses
-from core.models import Payload
+from dataclasses import dataclass
+from typing import List
+
+@dataclass(frozen=True, slots=True)
+class Payload:
+    value: str
+    attack_type: str
+    risk_level: str
+    target_dbms: str = "Generic"
 
 def _resolve_payload_file() -> str | None:
     candidates = [
@@ -13,6 +20,7 @@ def _resolve_payload_file() -> str | None:
     return None
 
 def get_dbms_specific_marker(text: str, dbms: str) -> str:
+    """DBMS 종류에 맞춘 직접 반사(Scrubbing) 우회 마커 인코딩"""
     if not text:
         return "''"
     
@@ -38,7 +46,10 @@ def get_dbms_specific_marker(text: str, dbms: str) -> str:
     else:
         return " + ".join([f"'{c}'" for c in text])
 
-def get_sqli_payloads() -> list[Payload]:
+def get_sqli_payloads(target_filter: str = "all") -> List[Payload]:
+    """
+    target_filter에 해당하는 DBMS의 페이로드만 로드하여 생성합니다.
+    """
     payloads = []
     file_path = _resolve_payload_file()
     if not file_path:
@@ -47,6 +58,8 @@ def get_sqli_payloads() -> list[Payload]:
     DELIM_START = "SVSDAAAA"
     DELIM_STOP = "VASDAAAA"
     marker_cache = {}
+
+    target_filter_lower = target_filter.lower()
 
     with open(file_path, "r", encoding="utf-8") as f:
         for line in f:
@@ -61,6 +74,9 @@ def get_sqli_payloads() -> list[Payload]:
                 attack_type = parts[1]
                 risk_level = parts[2]
                 dbms = parts[3]
+
+                if target_filter_lower != "all" and target_filter_lower != dbms.lower():
+                    continue
 
                 if dbms not in marker_cache:
                     marker_cache[dbms] = (
@@ -84,10 +100,12 @@ def get_sqli_payloads() -> list[Payload]:
                 final_value = final_value.replace("[ORIGVALUE]", "1")
                 final_value = final_value.replace("[SLEEPTIME]", "5")
 
+                # Payload 객체에 target_dbms 속성 전달
                 payloads.append(Payload(
                     value=final_value,
                     attack_type=attack_type,
-                    risk_level=risk_level
+                    risk_level=risk_level,
+                    target_dbms=dbms
                 ))
                 
     return payloads


### PR DESCRIPTION
## 📌 PR 목적 (What)
 sqli 모듈의 페이로드를 입력받은 dbms 옵션에 따라 필터링 하는 기능 추가, analyzer.py 로직 수정.
## 🛠️ 주요 변경 사항 (How)
- cli, setup.py: dbms 입력 옵션 추가.
- analyzer.py: boolean 탐지 조건을 "참 조건 응답과 거짓 조건 응답이 다를 것"으로 간소화.
## 🧪 테스트 결과 (Testing & Verification)
- 테스트 환경
  - url.filter.py 수정으로 board/write 테스트에서 제외.
  - 입력값: python main.py -u "http://54.180.113.193:3000/" -r 30 -w 2 --login-url "http://54.180.113.193:3000/login" --username "admin" --password "admin123!" --username-field "username" --password-field "password" -t sqli --sqli-evasion-level 0 --target-dbms mysql
- 테스트 결과
  - 총 27698번의 시도 중 168 개의 응답에서 취약점이 탐지되었습니다. 
## 💡 리뷰어 참고 사항
 board/write에서 높은 rps로 테스트 하면 사이트가 다운됩니다.
## ✅ 다음 작업 (Next Step)
- engine.py: 더미 값 무시 기능 추가, reporter\generator.py: 줄바꿈 이슈 해결.
