### PR TITLE
feat: stored_xss  동적 url 탐지 로직 수정 및 오탐 수정

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -11,6 +11,11 @@ from reporter import ReportGenerator
 
 
 def prepare_scan_context(args, surfaces):
+    if args.type == "stored_xss":
+        args.rps = 10
+        args.workers = 2
+        print("[SYSTEM] stored_xss 모듈 감지: 강제로 RPS 10, Worker 2로 하향 조정합니다.")
+
     selected_modules = select_modules(args)
     if not selected_modules:
         print(f"No modules registered for attack type {args.type!r}. Exiting.")

--- a/modules/stored_xss/analyzer.py
+++ b/modules/stored_xss/analyzer.py
@@ -107,9 +107,64 @@ class XSSContextParser(HTMLParser):
         ])
 
 
+_STRONG_ERROR_SNIPPET_MARKERS = (
+    "internal server error",
+    "sql syntax",
+    "sqlite_error",
+    "er_parse_error",
+    "syntaxerror",
+    "referenceerror",
+    "unhandled exception",
+    "stack trace",
+    "unexpected token",
+)
+
+_WEAK_ERROR_SNIPPET_MARKERS = (
+    "error",
+    "exception",
+    "at ",
+    "traceback",
+)
+
+
+def response_status(response: Any) -> int:
+    try:
+        return int(getattr(response, "status_code", getattr(response, "status", 200)) or 200)
+    except (TypeError, ValueError):
+        return 200
+
+
+def is_success_status(status: int) -> bool:
+    return 200 <= status < 300
+
+
+def looks_like_error_snippet(text: str) -> bool:
+    """에러 페이지·스택 트레이스 본문 — stored XSS 검증에서 제외."""
+    if not text:
+        return False
+    sample = text[:4000].lower()
+    if any(marker in sample for marker in _STRONG_ERROR_SNIPPET_MARKERS):
+        return True
+    weak_hits = sum(1 for marker in _WEAK_ERROR_SNIPPET_MARKERS if marker in sample)
+    return weak_hits >= 3
+
+
+def is_acceptable_verify_response(status: int, body: str, *, marker: str = "") -> bool:
+    """2차 검증 GET: 2xx만 허용, 에러 페이지 휴리스틱 적용."""
+    if not is_success_status(status):
+        return False
+    if marker and marker in body:
+        idx = body.find(marker)
+        start = max(0, idx - 500)
+        end = min(len(body), idx + len(marker) + 500)
+        if looks_like_error_snippet(body[start:end]):
+            return False
+    return True
+
+
 def _is_waf_blocked(response: Any, original_res: Any, baseline_text: Optional[str] = None) -> bool:
-    target_status = getattr(response, 'status_code', getattr(response, 'status', 200))
-    orig_status = getattr(original_res, 'status_code', getattr(original_res, 'status', 200)) if original_res else 200
+    target_status = response_status(response)
+    orig_status = response_status(original_res) if original_res else 200
 
     if target_status in [403, 406, 429, 501, 503] and orig_status < 400:
         return True
@@ -475,6 +530,16 @@ def analyze_stored_xss(
 
     if not response or not hasattr(response, 'text') or not response.text:
         result["context"] = "no_response"
+        return result
+
+    # 쿼리스트링 URL + 5xx: 에러 페이지 반사 가능성이 높아 1차 분석 스킵 (verify 부하 감소)
+    injection_status = response_status(response)
+    response_url = str(getattr(response, "url", "") or "")
+    if injection_status >= 500 and "?" in response_url:
+        result["context"] = "server_error_query"
+        result["evidence"] = (
+            f"Query injection returned HTTP {injection_status}; skipping (likely error reflection)"
+        )
         return result
 
     response_body = response.text[:MAX_RESPONSE_LENGTH]

--- a/modules/stored_xss/module.py
+++ b/modules/stored_xss/module.py
@@ -11,7 +11,14 @@ import asyncio
 from modules.base_module import BaseModule
 from core.models import Payload
 from modules.stored_xss.payloads import build_stored_xss_payloads, PayloadCategory, reload_payloads
-from modules.stored_xss.analyzer import analyze_stored_xss, _extract_injected_marker, _analyze_context_robust
+from modules.stored_xss.analyzer import (
+    analyze_stored_xss,
+    _analyze_context_robust,
+    _extract_injected_marker,
+    is_acceptable_verify_response,
+    is_success_status,
+)
+from modules.stored_xss.verify_urls import collect_verify_candidate_urls
 from fuzzer.request_builder import build_and_send_request
 
 
@@ -72,6 +79,7 @@ class StoredXSSModule(BaseModule):
             self._last_analysis_result = None
             self._logged_progress_blocks.clear()
             self._html_cache.clear()
+            self._target_locks.clear()
 
     def set_baseline(self, response: Any) -> None:
         if response and hasattr(response, 'text') and response.text:
@@ -183,9 +191,8 @@ class StoredXSSModule(BaseModule):
     async def verify(self, session: aiohttp.ClientSession, surface: Any, parameter: str, payload: Payload,
                      response: Any, baseline_response: Any) -> bool:
         """
-        [보완된 verify 로직]
-        1. 새 글 상세 페이지 직접 파싱 접근 로직 추가
-        2. HTML 캐시 제거로 항상 최신 응답 확인
+        2차 주입 마커를 넣은 뒤, 수집한 후보 URL들을 GET하여 저장·실행 여부를 확인한다.
+        후보 URL은 verify_urls.collect_verify_candidate_urls (앱별 하드코딩 없음)로 수집한다.
         """
         try:
             payload_value = payload.value or ""
@@ -211,51 +218,12 @@ class StoredXSSModule(BaseModule):
                 session, safe_surface, parameter, MockPayload(verify_payload_value)
             )
 
-            # =========================================================================
-            #  동적 URL 수집 로직 (상세 페이지 파싱 추가)
-            # =========================================================================
-            candidate_urls = []
-
-            # (1) 자동 리다이렉트된 최종 URL 수집
-            final_url = str(getattr(injection_res, 'url', ''))
-            if final_url and final_url not in candidate_urls:
-                candidate_urls.append(final_url)
-
-            # (2) 응답 HTML 내부에서 "가장 최근에 작성된 것으로 보이는 게시물 링크" 추출 시도
-            injection_body = getattr(injection_res, 'text', '')
-            if injection_body and '/board' in final_url:
-                try:
-                    from bs4 import BeautifulSoup
-                    try:
-                        soup = BeautifulSoup(injection_body, 'lxml')
-                    except Exception:
-                        soup = BeautifulSoup(injection_body, 'html.parser')
-
-                    links = soup.find_all('a', href=lambda href: href and '/board/view?id=' in href)
-
-                    if links:
-                        from urllib.parse import urljoin
-                        for link in links[:5]:
-                            full_url = urljoin(base_url, link['href'])
-                            if full_url not in candidate_urls:
-                                candidate_urls.append(full_url)
-                except Exception:
-                    pass
-
-            # (3) 폼을 제출했던 원래 URL 추가
-            surface_url = getattr(surface, 'url', base_url)
-            if surface_url not in candidate_urls:
-                candidate_urls.append(surface_url)
-
-            # (4) Referer 헤더 출처 추가
-            req_headers = getattr(surface, 'headers', {}) or {}
-            referer = req_headers.get('Referer') or req_headers.get('referer')
-            if referer and referer not in candidate_urls:
-                candidate_urls.append(referer)
-
-            if base_url not in candidate_urls:
-                candidate_urls.append(base_url)
-            # =========================================================================
+            req_headers = getattr(surface, "headers", {}) or {}
+            candidate_urls = collect_verify_candidate_urls(
+                base_url=base_url,
+                surface=safe_surface,
+                injection_res=injection_res,
+            )
 
             await asyncio.sleep(2.5)
 
@@ -268,14 +236,23 @@ class StoredXSSModule(BaseModule):
                     self._target_locks[check_url] = asyncio.Lock()
 
                 verify_body = ""
+                verify_status = 0
                 async with self._target_locks[check_url]:
                     try:
                         req_cookies = getattr(surface, 'cookies', None)
                         async with session.get(check_url, headers=req_headers, cookies=req_cookies,
                                                timeout=15) as verify_res:
+                            verify_status = verify_res.status
+                            if not is_success_status(verify_status):
+                                continue
                             verify_body = await verify_res.text()
                     except Exception:
                         continue
+
+                if not is_acceptable_verify_response(
+                    verify_status, verify_body, marker=verify_marker
+                ):
+                    continue
 
                 if verify_marker in verify_body:
                     marker_indices = [m.start() for m in re.finditer(re.escape(verify_marker), verify_body)]

--- a/modules/stored_xss/verify_urls.py
+++ b/modules/stored_xss/verify_urls.py
@@ -1,0 +1,172 @@
+"""
+Stored XSS 2차 검증용 후보 URL 수집 (앱/게시판 하드코딩 없음).
+
+우선순위:
+1. 주입 응답 최종 URL · Location/Refresh 헤더
+2. 응답 HTML/JSON에서 상세·목록 페이지 링크 (공통 패턴)
+3. 폼 surface / source / Referer / 관련 상위 경로
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+from modules.file_upload.path_discovery import (
+    extract_post_detail_urls,
+    iter_related_crawl_urls,
+)
+
+_JSON_URL_KEYS = frozenset(
+    {
+        "url",
+        "uri",
+        "link",
+        "href",
+        "path",
+        "location",
+        "redirect",
+        "redirecturl",
+        "redirect_url",
+        "next",
+        "continue",
+    }
+)
+
+_REFRESH_URL_RE = re.compile(r"url\s*=\s*['\"]?([^;'\"]+)", re.IGNORECASE)
+
+
+def _append_unique(ordered: list[str], seen: set[str], raw_url: str) -> None:
+    url = (raw_url or "").strip()
+    if not url or url in seen:
+        return
+    seen.add(url)
+    ordered.append(url)
+
+
+def _normalize_absolute(base_url: str, raw: str) -> str:
+    raw = (raw or "").strip()
+    if not raw:
+        return ""
+    if raw.startswith(("http://", "https://")):
+        return raw
+    if raw.startswith("//"):
+        split = urlsplit(base_url)
+        if split.scheme:
+            return f"{split.scheme}:{raw}"
+        return raw
+    return urljoin(base_url, raw)
+
+
+def _location_from_headers(headers: dict[str, Any] | None, base_url: str) -> list[str]:
+    if not headers:
+        return []
+    found: list[str] = []
+    for key, value in headers.items():
+        if not value:
+            continue
+        key_lower = str(key).lower()
+        if key_lower == "location":
+            found.append(_normalize_absolute(base_url, str(value)))
+        elif key_lower == "refresh":
+            match = _REFRESH_URL_RE.search(str(value))
+            if match:
+                found.append(_normalize_absolute(base_url, match.group(1)))
+    return [u for u in found if u]
+
+
+def _urls_from_json(node: Any, base_url: str, found: set[str], *, depth: int = 0) -> None:
+    if depth > 6:
+        return
+    if isinstance(node, dict):
+        for key, value in node.items():
+            key_lower = str(key).lower()
+            if key_lower in _JSON_URL_KEYS and isinstance(value, str) and value.strip():
+                found.add(_normalize_absolute(base_url, value))
+            else:
+                _urls_from_json(value, base_url, found, depth=depth + 1)
+    elif isinstance(node, list):
+        for item in node:
+            _urls_from_json(item, base_url, found, depth=depth + 1)
+
+
+def _urls_from_json_body(body: str, base_url: str) -> list[str]:
+    text = (body or "").strip()
+    if not text or text[0] not in "{[":
+        return []
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    found: set[str] = set()
+    _urls_from_json(data, base_url, found)
+    return list(found)
+
+
+def collect_verify_candidate_urls(
+    *,
+    base_url: str,
+    surface: Any,
+    injection_res: Any,
+    max_detail_pages: int = 5,
+) -> list[str]:
+    """
+    저장형 XSS 재검증에 GET할 URL 후보 목록 (중복 제거, 삽입 순서 유지).
+    """
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str) -> None:
+        normalized = _normalize_absolute(resolve_base, raw)
+        if normalized:
+            _append_unique(ordered, seen, normalized)
+
+    resolve_base = (base_url or "").strip()
+    if not resolve_base:
+        resolve_base = str(getattr(injection_res, "url", "") or getattr(surface, "url", "") or "")
+
+    final_url = str(getattr(injection_res, "url", "") or "")
+    if final_url:
+        add(final_url)
+        if not resolve_base:
+            resolve_base = final_url
+
+    inj_headers = getattr(injection_res, "headers", None) or {}
+    for header_url in _location_from_headers(inj_headers, resolve_base):
+        add(header_url)
+
+    injection_body = getattr(injection_res, "text", "") or ""
+    if injection_body:
+        for detail_url in extract_post_detail_urls(
+            injection_body,
+            resolve_base,
+            max_posts=max_detail_pages,
+        ):
+            add(detail_url)
+        for json_url in _urls_from_json_body(injection_body, resolve_base):
+            add(json_url)
+
+    surface_url = str(getattr(surface, "url", "") or "")
+    source_url = getattr(surface, "source_url", None)
+    for related in iter_related_crawl_urls(
+        surface_url=surface_url,
+        source_url=str(source_url) if source_url else None,
+    ):
+        add(related)
+
+    if surface_url:
+        add(surface_url)
+
+    req_headers = getattr(surface, "headers", {}) or {}
+    referer = req_headers.get("Referer") or req_headers.get("referer")
+    if referer:
+        add(str(referer))
+
+    if base_url:
+        add(base_url)
+    elif resolve_base and resolve_base not in seen:
+        add(resolve_base)
+
+    return ordered


### PR DESCRIPTION
## 📌 PR 목적 (What)
stored_xss 동적 탐지 로직 하드 코딩 된 부분을 범용 스캐너에 맞게 수정 및 미세 오탐을 걸러내는 코드 추
## 🛠️ 주요 변경 사항 (How)
### `cli/runner.py`
```
    if args.type == "stored_xss":
        args.rps = 10
        args.workers = 2
        print("[SYSTEM] stored_xss 모듈 감지: 강제로 RPS 10, Worker 2로 하향 조정합니다.")
```
stored_xss는 verify 단계에서 추가 요청·대기(동시 마커 검증 등)가 있어 동시성·부하가 커질 수 있음
RPS 10 / Worker 2로 고정해 세션·타깃 부하·경쟁 조건을 완화
### `modules/stored_xss/verify_urls.py`
collect_verify_candidate_urls(...)
앱별 하드코딩 없이 검증용 GET 후보 URL 수집
주입 응답의 최종 URL·Location/Refresh
응답 HTML/JSON에서 상세·목록 링크 패턴 (file_upload/path_discovery 재사용)
폼 action / source_url / Referer 및 상위 경로 휴리스틱
특정 보드 경로만 보는 전용 로직 제거 → 팀/커스텀 앱에도 같은 파이프라인 적용
### `modules/stored_xss/module.py`
verify에서 위 **collect_verify_candidate_urls**로 후보 URL 목록 생성 후 순회
2차 검증 GET
응답이 2xx만 마커·실행 컨텍스트 판정에 사용 (5xx 에러 페이지의 마커 반사 제거)
is_acceptable_verify_response: 마커 주변 에러/스택 트레이스 휴리스틱으로 오탐 추가 완화
### `modules/stored_xss/analyzer.py`
1차 분석(analyze_stored_xss)
응답 URL에 ?가 있고(쿼리 주입) + HTTP 5xx면 hit 처리 생략 → 에러 페이지 반사로 인한 불필요한 verify 진입·부하 감소
(POST 5xx 등은 그대로 두어, 저장 후 200 페이지에서 verify 하는 케이스 유지)
## 🧪 테스트 결과 (Testing & Verification)
<img width="781" height="131" alt="image" src="https://github.com/user-attachments/assets/1be8a266-05b3-4d7c-bb7a-0ef4adb9e221" />

```
http://43.201.78.91:3000/board/write
parameter: content
http://43.201.78.91:3000/board/write
parameter: title
http://43.201.78.91:3000/books
parameter: category
```