### PR TITLE
[feat] 모듈별 redirect 설정 추가, 엔진 수정

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -104,5 +104,5 @@ async def run_scan(args, *, base_url: str, surfaces) -> None:
     reporter.export_to_json(args.output)
 
 
-async def _request_sender(session, surface, parameter, payload):
-    return await build_and_send_request(session, surface, parameter, payload)
+async def _request_sender(session, surface, parameter, payload, allow_redirects=True):
+    return await build_and_send_request(session, surface, parameter, payload, allow_redirects=allow_redirects)

--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -54,6 +54,7 @@ class AsyncRequestSender(Protocol):
         surface: AttackSurface,
         parameter: str,
         payload: Any,
+        allow_redirects: bool = True,
     ) -> Any: ...
 
 
@@ -483,6 +484,7 @@ class FuzzerEngine:
         on_finding: ResultCallback | None,
     ) -> None:
         stop_event = self._module_stop_events.get(module.name)
+        allow_redir = getattr(module, "allow_redirects", True)
         try:
             if stop_event is not None and stop_event.is_set():
                 return
@@ -495,6 +497,7 @@ class FuzzerEngine:
                         surface=surface,
                         parameter=parameter,
                         payload=payload,
+                        allow_redirects=allow_redir,
                     )
             except Exception as exc:
                 async with self._stats_lock:
@@ -518,6 +521,7 @@ class FuzzerEngine:
                         surface=surface,
                         parameter=parameter,
                         payload=mutated_payload,
+                        allow_redirects=allow_redir,
                     )
 
             verdict = module.analyze(

--- a/fuzzer/request_builder.py
+++ b/fuzzer/request_builder.py
@@ -220,10 +220,11 @@ async def _send_prepared_request(
     method: str,
     url: str,
     request_kwargs: dict[str, Any],
+    allow_redirects: bool = True,
 ) -> FuzzerResponse:
     start_time = time.monotonic()
     try:
-        async with session.request(method, url, **request_kwargs) as response:
+        async with session.request(method, url, allow_redirects=allow_redirects, **request_kwargs) as response:
             text = await response.text(errors="replace")
             elapsed = time.monotonic() - start_time
             return FuzzerResponse(
@@ -316,6 +317,7 @@ async def build_and_send_request(
     surface: AttackSurface,
     parameter: str,
     payload: Any,
+    allow_redirects: bool = True
 ) -> FuzzerResponse:
     """
     Clone attack surface data, inject one payload, and send the HTTP request.
@@ -411,6 +413,7 @@ async def build_and_send_request(
             method=method,
             url=url,
             request_kwargs=request_kwargs,
+            allow_redirects=allow_redirects,
         )
 
     lock_key = _dynamic_lock_key(cookies)

--- a/modules/osci/module.py
+++ b/modules/osci/module.py
@@ -32,7 +32,8 @@ class OSCiModule(BaseModule):
             self.target_os = "all"
         else:
             self.target_os = "Unix"
-        
+            
+        self.allow_redirects = False
         self.evasion_level = kwargs.get('evasion_level', 0)
         self.include_time_based = kwargs.get('include_time_based', False)
         self.max_time_payloads = kwargs.get('max_time_payloads', 0)

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -22,6 +22,7 @@ class SQLiInternalPayload(Payload):
 class SQLiModule(BaseModule):
     def __init__(self, **kwargs):
         super().__init__("SQL Injection")
+        self.allow_redirects = False
         self.exploit_signatures = self._load_json("exploit_errors.json")
         self.syntax_signatures = self._load_json("syntax_errors.json")
         self.mismatch_signatures = self._load_json("mismatch_errors.json")


### PR DESCRIPTION
## 📌 PR 목적 (What)
 모듈에서 redirect 여부를 설정할 수 있도록 인자 추가
## 🛠️ 주요 변경 사항 (How)
 - cli\runner.py, fuzzer\engine.py, fuzzer\request_builder.py: 각 모듈에서 기본값이 true로 설정된 allow_redirect 값을 받아와서 적용하도록 수정.
 - module\osci\module.py, module\sqli.py:  allow_redirect = false 로 초기화 하도록 수정. 
## 🧪 테스트 결과 (Testing & Verification)
 - 크롤러 수정으로 추가된 attack surface 에서도 잘 동작하는 것 확인.
## 💡 리뷰어 참고 사항
 @김진우:  allow_redirect 가 없는 모듈에서는 기존과 동일하게 redirect 허용으로 실행되도록 구현했습니다.
## ✅ 다음 작업 (Next Step)
- 추가된 attack surface 에서의 sqli 모듈과 osci 모듈의 오탐, 미탐 수정.
