### PR TITLE
[feat] 더미 값을 갖는 페이로드의 발송을 생략하는 기능 추가

### DIFF
--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -7,7 +7,7 @@ from inspect import isawaitable
 from typing import Any, Awaitable, Callable, Iterable, Protocol
 
 import aiohttp
-from fuzzer.request_builder import send_baseline_request
+from fuzzer.request_builder import send_baseline_request, FuzzerResponse
 
 try:
     from core.models import AttackSurface  # type: ignore
@@ -74,8 +74,7 @@ class AttackModule(Protocol):
         elapsed_time: float,
         original_res: Any | None = None,
         requester: Callable[[str], Awaitable[Any]] | None = None,
-    ) -> tuple[bool, list[str], Any] | Awaitable[tuple[bool, list[str], Any]]: ...
-    #또는) -> bool | Awaitable[bool]: 
+    ) -> tuple[bool, list[str], Any] | Awaitable[tuple[bool, list[str], Any]] | bool | Awaitable[bool]: ...
 
 
 class FuzzerEngine:
@@ -490,24 +489,39 @@ class FuzzerEngine:
                 return
 
             response: Any
-            try:
-                async with self._semaphore:
-                    response = await request_sender(
-                        session=session,
-                        surface=surface,
-                        parameter=parameter,
-                        payload=payload,
-                        allow_redirects=allow_redir,
-                    )
-            except Exception as exc:
-                async with self._stats_lock:
-                    self._stats.failures += 1
-                print(f"[worker:{worker_id}][{module.name}] request failed: {exc}")
-                return
+            
+            payload_value = str(getattr(payload, "value", payload))
+            is_serial = getattr(payload, "_is_serial", False)
 
-            if self.delay > 0:
-                # Sleep outside semaphore so slots are not blocked by throttle waits.
-                await asyncio.sleep(self.delay)
+            if payload_value == "1" and is_serial:
+                # 더미 요청 발송을 생략하고 비어있는 FuzzerResponse 객체 생성
+                response = FuzzerResponse(
+                    status=0,
+                    text="",
+                    headers={},
+                    elapsed_time=0.0,
+                    url=surface.url,
+                    error="Skipped dummy request"
+                )
+            else:
+                try:
+                    async with self._semaphore:
+                        response = await request_sender(
+                            session=session,
+                            surface=surface,
+                            parameter=parameter,
+                            payload=payload,
+                            allow_redirects=allow_redir,
+                        )
+                except Exception as exc:
+                    async with self._stats_lock:
+                        self._stats.failures += 1
+                    print(f"[worker:{worker_id}][{module.name}] request failed: {exc}")
+                    return
+
+                if self.delay > 0:
+                    # Sleep outside semaphore so slots are not blocked by throttle waits.
+                    await asyncio.sleep(self.delay)
 
             elapsed_time = float(
                 getattr(response, "elapsed_time", getattr(response, "elapsed", 0.0))


### PR DESCRIPTION
## 📌 PR 목적 (What)
 더미 값 "1"을 페이로드로 하는 불필요한 요청 발송 제거.
## 🛠️ 주요 변경 사항 (How)
- fuzzer\engine.py :  페이로드 값이 1 이고 직렬 처리가 필요한 것이었을 경우 발송을 생략하고 빈 응답을 반환하도록 수정.
## 🧪 테스트 결과 (Testing & Verification)
 - 시간 페이로드 문제없이 동작함.
## 💡 리뷰어 참고 사항
 @김진우:  일반 페이로드 개수 예측을 통한 장벽 해제가 제대로 동작하지 않는 문제가 발견되었습니다.
 
## ✅ 다음 작업 (Next Step)
- 일반 페이로드 개수 예측 로직 수정