### PR TITLE
[feat] sqli 모듈과 osci 모듈 상태 코드 0 방어, 일반 페이로드로 전환 시 딜레이 추가, 일반 페이로드 개수 예측 수정

### DIFF
--- a/modules/osci/analyzer.py
+++ b/modules/osci/analyzer.py
@@ -46,11 +46,28 @@ def _analyze_marker_context(text: str, marker: str) -> str:
             return "reflection_error"
     return "execution_output"
 
-def detect_osci(response, payload, elapsed_time, original_res=None):
+async def detect_osci(response, payload, elapsed_time, original_res=None, requester=None):
     evidences = []
     attack_type = getattr(payload, "attack_type", "").lower()
     payload_value = getattr(payload, "value", "")
     is_time_based = "time-based" in attack_type or "time" in attack_type
+    
+    # Status 0면 최대 2회 재요청
+    if not is_time_based and requester:
+        current_status = getattr(response, "status", getattr(response, "status_code", 0)) or 0 if response else 0
+        
+        retry_count = 0
+        while current_status == 0 and retry_count < 2:
+            await asyncio.sleep(1.5)
+            try:
+                retry_res = await requester(payload_value)
+                if retry_res is not None:
+                    current_status = getattr(retry_res, "status", getattr(retry_res, "status_code", 0)) or 0
+                    elapsed_time = getattr(retry_res, "elapsed_time", getattr(retry_res, "elapsed", elapsed_time))
+                    response = retry_res
+            except Exception:
+                pass
+            retry_count += 1
 
     marker = "SVSDAAAA"
     arithmetic_sum = 100
@@ -162,10 +179,24 @@ async def verify_osci_logic(response, payload, original_res, requester, is_hit, 
     if "requires verification" in str(evidences):
         try:
             retry_res = await requester(payload_value)
+            r_status = getattr(retry_res, "status", getattr(retry_res, "status_code", 0)) or 0 if retry_res else 0
+            # Status 0면 최대 2회 재요청
+            retry_count = 0
+            while r_status == 0 and retry_count < 2:
+                await asyncio.sleep(1.5)
+                try:
+                    retry_res = await requester(payload_value)
+                    r_status = getattr(retry_res, "status", getattr(retry_res, "status_code", 0)) or 0 if retry_res else 0
+                except Exception:
+                    pass
+                retry_count += 1
+
+            if r_status == 0 or retry_res is None:
+                return False, evidences + ["[False Positive] Network dropped during re-verification"]
+
             retry_text = retry_res.text
             has_marker_in_raw = marker in retry_text
             scrubbed_retry = _remove_direct_reflection(retry_text, payload_value)
-            
 
             arith_pattern = re.compile(rf"{marker}\D*(\d+)\D*{marker}", re.I | re.DOTALL)
             arith_matches = arith_pattern.findall(scrubbed_retry)
@@ -173,14 +204,14 @@ async def verify_osci_logic(response, payload, original_res, requester, is_hit, 
                 for val in arith_matches:
                     if int(val) == arithmetic_sum:
                         return True, evidences + [f"[Verified] Arithmetic result ({val}) confirmed on retry"]
-                        
+
             clip_pattern = re.compile(rf"{marker}\D*({arithmetic_sum})", re.I | re.DOTALL)
             clip_match = clip_pattern.search(scrubbed_retry)
             if clip_match:
                 val = clip_match.group(1)
                 return True, evidences + [f"[Verified] Clipped output result ({val}) confirmed on retry"]
 
-        except Exception as e:
+        except Exception:
             return False, []
-
+            
     return False, []

--- a/modules/osci/module.py
+++ b/modules/osci/module.py
@@ -32,7 +32,7 @@ class OSCiModule(BaseModule):
             self.target_os = "all"
         else:
             self.target_os = "Unix"
-            
+
         self.allow_redirects = False
         self.evasion_level = kwargs.get('evasion_level', 0)
         self.include_time_based = kwargs.get('include_time_based', False)
@@ -40,11 +40,13 @@ class OSCiModule(BaseModule):
         self.random_seed = kwargs.get('random_seed', 37)
         
         self._global_time_lock = asyncio.Lock()
-        self._fast_per_param = 0
-        self._known_targets = set()
-        self._total_fast_expected = 0
-        self._global_fast_completed = 0
         self._counter_lock = asyncio.Lock()
+        
+        self._fast_per_param = 0
+        self._time_per_param = 0
+        
+        self._global_completed_payloads = 0  # 완료된 페이로드 카운트
+        self._current_param_index = 1        # 현재 진행 중인 파라미터 번호
         
         # 이벤트 기반 장벽을 통해 시간 페이로드 직렬 처리
         self._barrier_event = asyncio.Event()
@@ -56,17 +58,9 @@ class OSCiModule(BaseModule):
         return "time-based" in attack_type or "time" in attack_type
 
     def get_target_parameters(self, surface: Any, all_params: Iterable[str]) -> Iterable[str]:
-        if self._fast_per_param == 0:
+        if self._fast_per_param == 0 and self._time_per_param == 0:
             self.get_payload_count()
-        params = list(all_params)
-        url = getattr(surface, "url", "")
-        method = getattr(surface, "method", "GET")
-        for p in params:
-            tid = (method, url, p)
-            if tid not in self._known_targets:
-                self._known_targets.add(tid)
-                self._total_fast_expected += self._fast_per_param
-        return params
+        return list(all_params)
 
     def get_payload_count(self) -> int:
         all_raw = get_osci_payloads(self.target_os)
@@ -80,11 +74,15 @@ class OSCiModule(BaseModule):
             selected_time_count = min(limit, time_c)
         
         multiplier = self.evasion_level + 1
+        
+        # 각 파라미터당 할당될 일반/시간 페이로드 개수 저장
         self._fast_per_param = fast_c * multiplier
-        return self._fast_per_param + (selected_time_count * multiplier)
+        self._time_per_param = selected_time_count * multiplier
+        
+        return self._fast_per_param + self._time_per_param
 
     def get_payloads(self) -> Iterator[Payload]:
-        if self._fast_per_param == 0: 
+        if self._fast_per_param == 0 and self._time_per_param == 0: 
             self.get_payload_count()
 
         filtered = get_osci_payloads(self.target_os)
@@ -132,7 +130,6 @@ class OSCiModule(BaseModule):
             if t_os == "Unix":
                 value = value.replace(" ", "${IFS}")
             else:
-                # Windows CMD/PHP 환경에서는 쉼표(,) 우회 사용, PowerShell은 제외
                 if "PS" not in action_level:
                     value = value.replace(" ", ",")
         
@@ -164,11 +161,12 @@ class OSCiModule(BaseModule):
                 await asyncio.sleep(2.0)
 
             try:
-                is_hit, evidences = detect_osci(
+                is_hit, evidences = await detect_osci(
                     response=response,
                     payload=payload,
                     elapsed_time=elapsed_time,
-                    original_res=original_res
+                    original_res=original_res,
+                    requester=requester
                 )
                 
                 if is_hit:
@@ -180,8 +178,13 @@ class OSCiModule(BaseModule):
                 return is_hit, evidences, payload
             finally:
                 async with self._counter_lock:
-                    self._global_fast_completed += 1
-                    if self._global_fast_completed >= self._total_fast_expected and self._total_fast_expected > 0:
+                    self._global_completed_payloads += 1
+                    
+                    n = self._current_param_index
+                    # n * (일반 페이로드 개수) + (n-1) * (시간 페이로드 개수)
+                    target_count = (n * self._fast_per_param) + ((n - 1) * self._time_per_param)
+                    
+                    if self._global_completed_payloads >= target_count:
                         if not self._barrier_event.is_set():
                             self._barrier_event.set()
 
@@ -200,14 +203,13 @@ class OSCiModule(BaseModule):
                         try:
                             await asyncio.wait_for(self._barrier_event.wait(), timeout=10.0)
                         except asyncio.TimeoutError:
-                            current_completed = self._global_fast_completed
+                            current_completed = self._global_completed_payloads
                             
                             if current_completed == last_completed:
                                 stuck_count += 1
                             else:
                                 stuck_count = 0
                                 last_completed = current_completed
-                            
                             # 30초(10초 * 3) 동안 일반 페이로드 완료 없으면 강제 돌파
                             if stuck_count >= 3:
                                 self._barrier_event.set()
@@ -215,6 +217,7 @@ class OSCiModule(BaseModule):
                         
                 if not self._time_phase_active:
                     self._time_phase_active = True
+                    await asyncio.sleep(4.5)
 
                 # 2. 전역 직렬 실행 락
                 async with self._global_time_lock:
@@ -226,14 +229,14 @@ class OSCiModule(BaseModule):
                         real_res = await requester(real_val)
                         real_elapsed = asyncio.get_event_loop().time() - start_ts
                         
-                        # 서버 회복 대기
                         await asyncio.sleep(4.5)
 
-                        is_hit, evidences = detect_osci(
+                        is_hit, evidences = await detect_osci(
                             response=real_res,
                             payload=actual_payload,
                             elapsed_time=real_elapsed,
-                            original_res=original_res
+                            original_res=original_res,
+                            requester=requester
                         )
 
                         if is_hit and "[Time]" not in str(evidences):
@@ -243,20 +246,23 @@ class OSCiModule(BaseModule):
                         return is_hit, evidences, actual_payload
 
                     except asyncio.TimeoutError:
-                        is_hit, evidences = detect_osci(
+                        is_hit, evidences = await detect_osci(
                             response=None,
                             payload=actual_payload,
                             elapsed_time=15.0,
-                            original_res=original_res
+                            original_res=original_res,
+                            requester=requester
                         )
                         return True, evidences, actual_payload
             finally:
                 async with self._counter_lock:
+                    self._global_completed_payloads += 1
                     self._time_attack_in_flight -= 1
                     if self._time_attack_in_flight == 0:
                         if self._time_phase_active:
-                            
                             self._barrier_event.clear()
                             self._time_phase_active = False
+                            self._current_param_index += 1
+                            await asyncio.sleep(30.0)
 
         return False, [], payload

--- a/modules/sqli/analyzer.py
+++ b/modules/sqli/analyzer.py
@@ -40,14 +40,36 @@ def _remove_direct_reflection(text: str, payload_value: str) -> str:
         scrubbed = scrubbed.replace(variant, "[DIRECT_REFLECTION_REMOVED]")
     return scrubbed
 
-def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None):
+async def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_signatures, mismatch_signatures, original_res=None, requester=None):
     evidences = []
-    res_text = response.text
+    attack_type = payload.attack_type.lower()
+    payload_value = payload.value
+    
+    is_time_related = "time" in attack_type or "stacked" in attack_type
+
+    # Status 0면 최대 2회 재요청
+    if not is_time_related and requester:
+        current_status = 0
+        if response is not None:
+            current_status = getattr(response, "status", getattr(response, "status_code", 0)) or 0
+            
+        retry_count = 0
+        while current_status == 0 and retry_count < 2:
+            await asyncio.sleep(1.5)
+            try:
+                response = await requester(payload_value)
+                if response is not None:
+                    current_status = getattr(response, "status", getattr(response, "status_code", 0)) or 0
+                    elapsed_time = getattr(response, "elapsed_time", getattr(response, "elapsed", elapsed_time))
+            except Exception:
+                pass
+            retry_count += 1
+            
+    res_text = response.text if response else ""
+    current_status = getattr(response, "status", getattr(response, "status_code", 0)) or 0 if response else 0
     
     orig_elapsed = getattr(original_res, "elapsed_time", getattr(getattr(original_res, "elapsed", object()), "total_seconds", lambda: 0.0)()) if original_res else 0.0
 
-    attack_type = payload.attack_type.lower()
-    payload_value = payload.value
     marker_start = "SVSDAAAA"
     marker_stop = "VASDAAAA"
     dynamic_marker_pattern = re.compile(f"{marker_start}(.*?){marker_stop}", re.I | re.DOTALL)
@@ -55,8 +77,6 @@ def detect_sqli(response, payload, elapsed_time, exploit_signatures, syntax_sign
     has_syntax_error = False
     has_execution_error = False
 
-    is_time_related = "time" in attack_type or "stacked" in attack_type
-    
     # [1] 시간 페이로드 타임아웃 탐지
     if is_time_related:
         if response is None and elapsed_time >= 4.5:
@@ -128,7 +148,6 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
     
     # 3. 논리 구조가 있으면 T!=F 대조 시도
     if has_logic or is_vuln_1st:
-        
         true_logic = ""
         false_logic = ""
         
@@ -177,7 +196,7 @@ async def verify_sqli_logic(response, payload, original_res, requester, is_vuln_
                         
                         r_t_status = getattr(retry_t_res, "status", getattr(retry_t_res, "status_code", 0)) or 0
                         r_f_status = getattr(retry_f_res, "status", getattr(retry_f_res, "status_code", 0)) or 0
-                        
+
                         if r_t_status == 0 or r_f_status == 0:
                             continue
                         

--- a/modules/sqli/module.py
+++ b/modules/sqli/module.py
@@ -22,6 +22,7 @@ class SQLiInternalPayload(Payload):
 class SQLiModule(BaseModule):
     def __init__(self, **kwargs):
         super().__init__("SQL Injection")
+        self.allow_redirects = False
         self.exploit_signatures = self._load_json("exploit_errors.json")
         self.syntax_signatures = self._load_json("syntax_errors.json")
         self.mismatch_signatures = self._load_json("mismatch_errors.json")
@@ -42,11 +43,14 @@ class SQLiModule(BaseModule):
         self.random_seed = kwargs.get('random_seed', 37)
         
         self._global_time_lock = asyncio.Lock()
-        self._fast_per_param = 0
-        self._known_targets = set()
-        self._total_fast_expected = 0
-        self._global_fast_completed = 0
         self._counter_lock = asyncio.Lock()
+        
+        self._fast_per_param = 0
+        self._time_per_param = 0
+        
+        self._global_completed_payloads = 0  # 완료된 페이로드 카운트
+        self._current_param_index = 1        # 현재 진행 중인 파라미터 번호
+        self._known_targets = set()
         
         # 이벤트 기반 장벽을 통해 시간 페이로드 직렬 처리
         self._barrier_event = asyncio.Event()
@@ -68,17 +72,9 @@ class SQLiModule(BaseModule):
         return "time" in attack_type or "stacked" in attack_type
 
     def get_target_parameters(self, surface: Any, all_params: Iterable[str]) -> Iterable[str]:
-        if self._fast_per_param == 0:
+        if self._fast_per_param == 0 and self._time_per_param == 0:
             self.get_payload_count()
-        params = list(all_params)
-        url = getattr(surface, "url", "")
-        method = getattr(surface, "method", "GET")
-        for p in params:
-            tid = (method, url, p)
-            if tid not in self._known_targets:
-                self._known_targets.add(tid)
-                self._total_fast_expected += self._fast_per_param
-        return params
+        return list(all_params)
 
     def get_payload_count(self) -> int:
         filtered = get_sqli_payloads(self.target_dbms)
@@ -92,11 +88,15 @@ class SQLiModule(BaseModule):
             selected_time_count = min(limit, time_c)
         
         multiplier = self.evasion_level + 1
+        
+        # 각 파라미터당 할당될 일반/시간 페이로드 개수 저장
         self._fast_per_param = fast_c * multiplier
-        return self._fast_per_param + (selected_time_count * multiplier)
+        self._time_per_param = selected_time_count * multiplier
+        
+        return self._fast_per_param + self._time_per_param
 
     def get_payloads(self) -> Iterator[Payload]:
-        if self._fast_per_param == 0: 
+        if self._fast_per_param == 0 and self._time_per_param == 0: 
             self.get_payload_count()
 
         # payload.py 에서 필터링된 페이로드 리스트 로드
@@ -156,12 +156,13 @@ class SQLiModule(BaseModule):
                 await asyncio.sleep(2.0)
 
             try:
-                is_hit, evidences, has_syntax_error = detect_sqli(
+                is_hit, evidences, has_syntax_error = await detect_sqli(
                     response=response, payload=payload, elapsed_time=elapsed_time,
                     exploit_signatures=self.exploit_signatures,
                     syntax_signatures=self.syntax_signatures,
                     mismatch_signatures=self.mismatch_signatures,
-                    original_res=original_res
+                    original_res=original_res,
+                    requester=requester
                 )
                 final_hit, final_evidences = await verify_sqli_logic(
                     response, payload, original_res, requester, is_hit, evidences, has_syntax_error, self.syntax_signatures
@@ -169,8 +170,13 @@ class SQLiModule(BaseModule):
                 return final_hit, final_evidences, payload
             finally:
                 async with self._counter_lock:
-                    self._global_fast_completed += 1
-                    if self._global_fast_completed >= self._total_fast_expected and self._total_fast_expected > 0:
+                    self._global_completed_payloads += 1
+                    
+                    n = self._current_param_index
+                    # n * (일반 페이로드 개수) + (n-1) * (시간 페이로드 개수)
+                    target_count = (n * self._fast_per_param) + ((n - 1) * self._time_per_param)
+                    
+                    if self._global_completed_payloads >= target_count:
                         if not self._barrier_event.is_set():
                             self._barrier_event.set()
 
@@ -189,22 +195,21 @@ class SQLiModule(BaseModule):
                         try:
                             await asyncio.wait_for(self._barrier_event.wait(), timeout=10.0)
                         except asyncio.TimeoutError:
-                            current_completed = self._global_fast_completed
+                            current_completed = self._global_completed_payloads
                             
                             if current_completed == last_completed:
                                 stuck_count += 1
                             else:
                                 stuck_count = 0
                                 last_completed = current_completed
-                            
                             # 30초(10초 * 3) 동안 일반 페이로드 완료 없으면 강제 돌파
                             if stuck_count >= 3:
-                                if not self._time_phase_active:
                                 self._barrier_event.set()
                                 break
                     
                 if not self._time_phase_active:
                     self._time_phase_active = True
+                    await asyncio.sleep(4.5)
 
                 # 2. 전역 직렬 실행 락
                 async with self._global_time_lock:
@@ -216,15 +221,15 @@ class SQLiModule(BaseModule):
                         real_res = await requester(real_val)
                         real_elapsed = asyncio.get_event_loop().time() - start_ts
                         
-                        # 서버 회복 대기
                         await asyncio.sleep(4.5)
 
-                        is_hit, evidences, has_syntax_error = detect_sqli(
+                        is_hit, evidences, has_syntax_error = await detect_sqli(
                             response=real_res, payload=actual_payload, elapsed_time=real_elapsed,
                             exploit_signatures=self.exploit_signatures,
                             syntax_signatures=self.syntax_signatures,
                             mismatch_signatures=self.mismatch_signatures,
-                            original_res=original_res
+                            original_res=original_res,
+                            requester=requester
                         )
 
                         if is_hit and not any(tag in str(evidences) for tag in ["[Time]", "[Error]", "[Reflection]"]):
@@ -234,20 +239,24 @@ class SQLiModule(BaseModule):
                         return is_hit, evidences, actual_payload
 
                     except asyncio.TimeoutError:
-                        is_hit, evidences, _ = detect_sqli(
+                        is_hit, evidences, has_syntax_error = await detect_sqli(
                             response=None, payload=actual_payload, elapsed_time=15.0,
                             exploit_signatures=self.exploit_signatures,
                             syntax_signatures=self.syntax_signatures,
                             mismatch_signatures=self.mismatch_signatures,
-                            original_res=original_res
+                            original_res=original_res,
+                            requester=requester
                         )
                         return True, evidences, actual_payload
             finally:
                 async with self._counter_lock:
+                    self._global_completed_payloads += 1
                     self._time_attack_in_flight -= 1
                     if self._time_attack_in_flight == 0:
                         if self._time_phase_active:
                             self._barrier_event.clear()
                             self._time_phase_active = False
+                            self._current_param_index += 1
+                            await asyncio.sleep(30.0)
 
         return False, [], payload


### PR DESCRIPTION
## 📌 PR 목적 (What)
 sqli 모듈과 osci 모듈의 서버 불안정 등의 예외 처리와 time-based 페이로드 포함 시 안정적인 동작을 위한 수정
## 🛠️ 주요 변경 사항 (How)
- 공통: 
  - 파라미터별로 일반 페이로드 개수 계산
  - time-based 페이로드에서 일반 페이로드로 전환 시 30초 딜레이 추가
- sqli 모듈: detect_sqli 에 status 0 방어 추가
- osci 모듈:  verify_osci 의 재검증과 detect_osci 에 status 0 방어 추가
## 🧪 테스트 결과 (Testing & Verification)
 두 모듈 모두 time-based 페이로드 포함 시에도 일반 페이로드의 결과에 간섭 없이 잘 동작하는 것 확인
## 💡 리뷰어 참고 사항
@김진우:  일반 페이로드로 전환 시 딜레이를 20초로 하면 일반 페이로드 결과에 간섭이 생겨서 30초로 설정했습니다.
## ✅ 다음 작업 (Next Step)
- 콜백 서버 구축
