### PR TITLE
[feat] SPA 동적 크롤러 기능 개선

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -5,8 +5,7 @@ import os
 
 from cli.output import print_scan_configuration, progress_printer
 from fuzzer import FuzzerEngine
-from cli.options import parse_cookies
-from fuzzer.auth_provider import scan_auth_lifecycle
+from fuzzer.auth_provider import merge_scan_cookies, scan_auth_lifecycle
 from fuzzer.request_builder import build_and_send_request
 from fuzzer.setup import count_module_payloads, estimate_total_requests, select_modules
 from reporter import ReportGenerator
@@ -89,8 +88,8 @@ async def run_scan(args, *, base_url: str, surfaces) -> None:
         delay=context["delay"],
     )
 
-    scan_cookies = parse_cookies(args.cookie) if getattr(args, "cookie", "") else {}
-    async with scan_auth_lifecycle(args, base_cookies=scan_cookies):
+    scan_cookies = merge_scan_cookies(args, surfaces)
+    async with scan_auth_lifecycle(args, base_cookies=scan_cookies, surfaces=surfaces):
         scan_task = asyncio.create_task(
             engine.run_with_attack_modules(
                 surfaces=surfaces,

--- a/core/models.py
+++ b/core/models.py
@@ -136,6 +136,8 @@ class AttackSurface:
     description: str | None = None
     depth: int = 0
     content_type: str | None = None
+    request_content_type: str | None = None
+    file_field_names: tuple[str, ...] = field(default_factory=tuple)
     graphql_arg_types: Dict[str, str] = field(default_factory=dict)
     parameter_confidence: Dict[str, str] = field(default_factory=dict)
 
@@ -160,6 +162,8 @@ class AttackSurface:
             'description': self.description,
             'depth': self.depth,
             'content_type': self.content_type,
+            'request_content_type': self.request_content_type,
+            'file_field_names': list(self.file_field_names),
             'graphql_arg_types': self.graphql_arg_types,
             'parameter_confidence': self.parameter_confidence,
         }
@@ -179,6 +183,8 @@ class AttackSurface:
             description=data.get('description'),
             depth=data.get('depth', 0),
             content_type=data.get('content_type'),
+            request_content_type=data.get('request_content_type'),
+            file_field_names=tuple(data.get('file_field_names') or ()),
             graphql_arg_types=_normalize_graphql_arg_types(data.get('graphql_arg_types', {})),
             parameter_confidence=_normalize_parameter_confidence(data.get('parameter_confidence', {})),
         )

--- a/crawler/session_manager.py
+++ b/crawler/session_manager.py
@@ -4,11 +4,12 @@ import asyncio
 import json
 import re
 from typing import Optional, Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import aiohttp
 from bs4 import BeautifulSoup
 
+from parsers.login_url_inference import iter_login_post_urls
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -265,16 +266,45 @@ class SessionManager:
         key, token = extracted
         return {key: token}
 
+    @staticmethod
+    def _auth_config_for_url(auth_config: AuthConfig, login_url: str) -> AuthConfig:
+        return AuthConfig(
+            login_url=login_url,
+            username=auth_config.username,
+            password=auth_config.password,
+            username_field=auth_config.username_field,
+            password_field=auth_config.password_field,
+            extra_fields=dict(auth_config.extra_fields or {}),
+            success_indicator=auth_config.success_indicator,
+            failure_indicator=auth_config.failure_indicator,
+            csrf_token_name=auth_config.csrf_token_name,
+            submit_field=auth_config.submit_field,
+            login_body_format=auth_config.login_body_format,
+        )
+
+    @staticmethod
+    def _api_login_path(url: str) -> bool:
+        return "/api/" in (urlparse(url).path or "").lower()
+
     async def login(self, auth_config: AuthConfig) -> bool:
         if self._session is None:
             await self.create_session()
 
+        candidates = iter_login_post_urls(auth_config.login_url)
+        for candidate_url in candidates:
+            trial = self._auth_config_for_url(auth_config, candidate_url)
+            if await self._login_once(trial):
+                return True
+        return False
+
+    async def _login_once(self, auth_config: AuthConfig) -> bool:
         forced_json = auth_config.login_body_format == "json"
+        api_login = self._api_login_path(auth_config.login_url)
         logger.info("로그인 시도: %s", auth_config.login_url)
         login_page = await self.get(auth_config.login_url)
 
         if not login_page:
-            if forced_json:
+            if forced_json or api_login:
                 logger.info(
                     "JSON 로그인: 로그인 URL GET 실패 — API 직접 POST만 시도합니다: %s",
                     auth_config.login_url,
@@ -289,7 +319,10 @@ class SessionManager:
         else:
             html = login_page.get("text", "")
 
-        body_format = self._resolve_login_body_format(auth_config, html)
+        if forced_json or api_login:
+            body_format = "json"
+        else:
+            body_format = self._resolve_login_body_format(auth_config, html)
         csrf_token = None
         if body_format != "json" and auth_config.csrf_token_name:
             csrf_token = self._extract_csrf_token(html, auth_config.csrf_token_name)

--- a/crawler/spa/browser.py
+++ b/crawler/spa/browser.py
@@ -446,73 +446,92 @@ async def playwright_json_login(engine, page, context) -> bool:
     pre_login_cookie_names = set(cookies_as_dict(engine.cookies).keys())
     login_data = SessionManager.build_login_payload(cfg)
     login_post_data = json.dumps(login_data, ensure_ascii=False)
-    try:
-        resp = await context.request.post(
-            cfg.login_url,
-            data=login_post_data,
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
-        )
-        json_body = None
+
+    from parsers.login_url_inference import iter_login_post_urls
+
+    for post_url in iter_login_post_urls(cfg.login_url):
         try:
-            json_body = await resp.json()
-        except Exception as exc:
-            logger.debug("[SPA Crawler] JSON login response was not JSON on %s: %s", cfg.login_url, exc)
+            resp = await context.request.post(
+                post_url,
+                data=login_post_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+            )
+            json_body = None
+            try:
+                json_body = await resp.json()
+            except Exception as exc:
+                logger.debug(
+                    "[SPA Crawler] JSON login response was not JSON on %s: %s",
+                    post_url,
+                    exc,
+                )
 
-        engine.record_seeded_api(
-            method="POST",
-            url=cfg.login_url,
-            post_data=login_post_data,
-            req_content_type="application/json",
-            status=resp.status,
-            content_type=resp.headers.get("content-type", ""),
-            source="auth-login-json",
-        )
-
-        engine.cookies = merge_playwright_cookies(
-            engine.cookies,
-            filter_cookies_for_target(engine, await context.cookies()),
-        )
-        for key, value in SessionManager.json_auth_for_local_storage(json_body).items():
-            engine.local_storage[key] = value
-        if engine.local_storage:
-            await page.evaluate(
-                """(items) => {
-                    for (const [k, v] of Object.entries(items || {})) {
-                        if (k != null && v != null) localStorage.setItem(String(k), String(v));
-                    }
-                }""",
-                dict(engine.local_storage),
+            engine.record_seeded_api(
+                method="POST",
+                url=post_url,
+                post_data=login_post_data,
+                req_content_type="application/json",
+                status=resp.status,
+                content_type=resp.headers.get("content-type", ""),
+                source="auth-login-json",
             )
 
-        await wait_for_page_settle(page, context_label="json login token apply")
-        await sync_storage_from_browser(engine, page)
-        engine.cookies = merge_playwright_cookies(
-            engine.cookies,
-            filter_cookies_for_target(engine, await context.cookies()),
-        )
+            if resp.status in (404, 405, 415):
+                logger.debug(
+                    "[SPA Crawler] JSON login skipped for %s (status=%s)",
+                    post_url,
+                    resp.status,
+                )
+                continue
 
-        if SessionManager._json_login_failed(json_body):
-            return False
-        if not (SessionManager._json_login_succeeded(json_body) or resp.ok):
-            return False
+            engine.cookies = merge_playwright_cookies(
+                engine.cookies,
+                filter_cookies_for_target(engine, await context.cookies()),
+            )
+            for key, value in SessionManager.json_auth_for_local_storage(json_body).items():
+                engine.local_storage[key] = value
+            if engine.local_storage:
+                await page.evaluate(
+                    """(items) => {
+                        for (const [k, v] of Object.entries(items || {})) {
+                            if (k != null && v != null) localStorage.setItem(String(k), String(v));
+                        }
+                    }""",
+                    dict(engine.local_storage),
+                )
 
-        if await verify_login_success(
-            page, cfg,
-            local_storage=engine.local_storage,
-            cookies=engine.cookies,
-            pre_login_cookie_names=pre_login_cookie_names,
-        ):
-            engine._login_verified = True
-            logger.info("[SPA Crawler] Playwright JSON login succeeded: %s", cfg.login_url)
-            return True
-        logger.warning("[SPA Crawler] Playwright JSON login not verified (2-of-3): %s", cfg.login_url)
-        return False
-    except Exception as e:
-        logger.warning("[SPA Crawler] Playwright JSON login failed on %s: %s", cfg.login_url, e)
-        return False
+            await wait_for_page_settle(page, context_label="json login token apply")
+            await sync_storage_from_browser(engine, page)
+            engine.cookies = merge_playwright_cookies(
+                engine.cookies,
+                filter_cookies_for_target(engine, await context.cookies()),
+            )
+
+            if SessionManager._json_login_failed(json_body):
+                continue
+            if not (SessionManager._json_login_succeeded(json_body) or resp.ok):
+                continue
+
+            if await verify_login_success(
+                page,
+                cfg,
+                local_storage=engine.local_storage,
+                cookies=engine.cookies,
+                pre_login_cookie_names=pre_login_cookie_names,
+            ):
+                engine._login_verified = True
+                logger.info("[SPA Crawler] Playwright JSON login succeeded: %s", post_url)
+                return True
+            logger.debug(
+                "[SPA Crawler] Playwright JSON login not verified on %s",
+                post_url,
+            )
+        except Exception as e:
+            logger.debug("[SPA Crawler] Playwright JSON login failed on %s: %s", post_url, e)
+    return False
 
 
 async def playwright_auth_login(engine, page, context) -> bool:

--- a/crawler/spa/capture_core.py
+++ b/crawler/spa/capture_core.py
@@ -71,6 +71,7 @@ _MULTIPART_NAME_RE = re.compile(
     r'content-disposition:\s*form-data;\s*name="([^"]+)"',
     re.IGNORECASE,
 )
+_MULTIPART_FILENAME_RE = re.compile(r"filename\s*=", re.IGNORECASE)
 
 # ---------------------------------------------------------------------------
 # URL normalization and API key helpers
@@ -349,6 +350,32 @@ def extract_multipart_boundary(body: str, content_type: str) -> str:
     return ""
 
 
+def parse_multipart_file_field_names(body: str, content_type: str) -> set[str]:
+    """Multipart parts that include a filename= attribute (file uploads)."""
+    if not body:
+        return set()
+    text = str(body)
+    ct = str(content_type or "").lower()
+    if "multipart/form-data" not in ct and not text.lstrip().startswith("--"):
+        return set()
+    boundary = extract_multipart_boundary(text, content_type)
+    if not boundary:
+        return set()
+    names: set[str] = set()
+    delimiter = f"--{boundary}"
+    for part in text.split(delimiter):
+        chunk = part.strip()
+        if not chunk or chunk == "--":
+            continue
+        header_block = chunk.split("\r\n\r\n", 1)[0] if "\r\n\r\n" in chunk else chunk.split("\n\n", 1)[0]
+        if not _MULTIPART_FILENAME_RE.search(header_block):
+            continue
+        name_match = _MULTIPART_NAME_RE.search(header_block)
+        if name_match:
+            names.add(str(name_match.group(1)).strip())
+    return names
+
+
 def parse_multipart_fields(body: str, content_type: str) -> dict[str, str]:
     if not body:
         return {}
@@ -409,7 +436,10 @@ def parse_payload_fields(post_data: str, content_type: str) -> dict[str, str]:
 def serialize_body_fields(fields: dict[str, str], content_type: str) -> tuple[str, str]:
     ct = str(content_type or "").lower().split(";", 1)[0].strip()
     clean = {str(k): str(v) for k, v in fields.items() if str(k).strip()}
-    if ct in ("application/x-www-form-urlencoded", "multipart/form-data"):
+    if ct == "multipart/form-data":
+        # Preserve observed field names; synthesized forms carry values separately.
+        return "", "multipart/form-data"
+    if ct == "application/x-www-form-urlencoded":
         return urlencode(clean, doseq=True), "application/x-www-form-urlencoded"
     return json.dumps(clean, ensure_ascii=False), "application/json"
 
@@ -441,9 +471,36 @@ def register_observed_query_keys(engine, url: str) -> None:
         store_observed_sample(samples, key_str, val)
 
 
+def register_observed_body_field_hints(
+    engine,
+    path_key: str,
+    field_names: set[str] | frozenset[str] | list[str],
+) -> None:
+    """XHR/DOM/JS 정적 분석에서 확인된 필드명을 path_key 샘플에 병합 (값은 빈 placeholder)."""
+    if not path_key or not field_names:
+        return
+    samples_map = getattr(engine, "observed_body_samples", None)
+    if samples_map is None:
+        engine.observed_body_samples = {}
+        samples_map = engine.observed_body_samples
+    bucket = samples_map.setdefault(path_key, {})
+    for raw_name in field_names:
+        key_str = str(raw_name).strip()
+        if not key_str:
+            continue
+        store_observed_sample(bucket, key_str, str(bucket.get(key_str) or ""))
+
+
+def _spa_path_keys_related(api_path_key: str, sample_key: str) -> bool:
+    from crawler.spa.path_family import spa_path_keys_related
+
+    return spa_path_keys_related(api_path_key, sample_key)
+
+
 def register_observed_body_keys(engine, url: str, post_data: str | None, content_type: str) -> None:
     fields = parse_payload_fields(post_data or "", content_type)
-    if not fields:
+    file_names = parse_multipart_file_field_names(post_data or "", content_type)
+    if not fields and not file_names:
         return
     path_key = path_key_from_url(url)
     names_map = getattr(engine, "observed_body_params", None)
@@ -459,6 +516,17 @@ def register_observed_body_keys(engine, url: str, post_data: str | None, content
     for key, val in fields.items():
         names.add(key)
         store_observed_sample(samples, key, val)
+    if file_names:
+        file_map = getattr(engine, "observed_body_file_fields", None)
+        if file_map is None:
+            engine.observed_body_file_fields = {}
+            file_map = engine.observed_body_file_fields
+        file_bucket = file_map.setdefault(path_key, set())
+        file_bucket.update(file_names)
+        names.update(file_names)
+        for key in file_names:
+            if key not in samples:
+                samples[key] = ""
     if content_type:
         ct_map = getattr(engine, "observed_body_content_types", None)
         if ct_map is None:
@@ -516,6 +584,17 @@ def drop_get_stubs_for_path(engine, path_key: str) -> None:
         del engine.api_endpoints[existing_hash]
 
 
+def _merge_api_file_fields(entry: dict, post_data: str | None, req_content_type: str) -> None:
+    discovered = parse_multipart_file_field_names(post_data or "", req_content_type or "")
+    if not discovered:
+        return
+    merged = set(entry.get("file_fields") or ())
+    merged.update(discovered)
+    entry["file_fields"] = sorted(merged)
+    if not entry.get("req_content_type") or "json" in str(entry.get("req_content_type")).lower():
+        entry["req_content_type"] = req_content_type or "multipart/form-data"
+
+
 def record_api_candidate(
     engine,
     *,
@@ -558,6 +637,7 @@ def record_api_candidate(
             existing["depth"] = int(getattr(engine, "current_route_depth", 0) or 0)
         if source and existing.get("source") == "js-static":
             existing["source"] = source
+        _merge_api_file_fields(existing, post_data, req_content_type)
         return api_hash, False
     if source == "js-static":
         # Snapshot items to avoid size-change errors while network callbacks update endpoints.
@@ -581,7 +661,9 @@ def record_api_candidate(
         "status": status,
         "content_type": content_type,
         "depth": int(getattr(engine, "current_route_depth", 0) or 0),
+        "file_fields": [],
     }
+    _merge_api_file_fields(engine.api_endpoints[api_hash], post_data, req_content_type)
     if str(method).upper() in _MUTATING_METHODS and post_data:
         drop_get_stubs_for_path(engine, path_key_from_url(url))
     return api_hash, True
@@ -774,10 +856,24 @@ def build_synthesized_html(engine, final_html: str, graphql_html: str) -> str:
         method = api["method"].upper()
         action = html.escape(api["url"], quote=True)
         fallback_ct = fallback_content_type_for_api(api)
-        ct = html.escape(fallback_ct or "application/json", quote=True)
+        req_ct_raw = str(api.get("req_content_type") or "").strip()
+        ct_base = (
+            req_ct_raw.split(";", 1)[0].strip().lower()
+            if req_ct_raw
+            else str(fallback_ct or "application/json").lower()
+        )
+        path_key = path_key_from_url(api["url"])
+        file_fields: set[str] = set(api.get("file_fields") or ())
+        observed_file_map = getattr(engine, "observed_body_file_fields", None) or {}
+        file_fields.update(observed_file_map.get(path_key) or ())
+        if file_fields:
+            ct_base = "multipart/form-data"
+        ct = html.escape(ct_base or "application/json", quote=True)
+        form_enctype_attr = (
+            ' enctype="multipart/form-data"' if ct_base == "multipart/form-data" else ""
+        )
         inputs = ""
         parsed = urlparse(api["url"])
-        path_key = path_key_from_url(api["url"])
         inferred_flag = False
         if method == "GET":
             query_params = dict(parse_qsl(parsed.query, keep_blank_values=True))
@@ -793,8 +889,30 @@ def build_synthesized_html(engine, final_html: str, graphql_html: str) -> str:
                 body_fields = parse_payload_fields(post_data, api.get("req_content_type") or "")
             if not body_fields:
                 body_fields = dict((observed_body or {}).get(path_key) or {})
+            from crawler.spa.capture_enrichment import resolve_mutating_body_fields
+
+            body_fields = resolve_mutating_body_fields(
+                engine,
+                path_key,
+                local_fields=body_fields,
+                source_url=str(api.get("source_url") or ""),
+                url=str(api.get("url") or ""),
+            )
+        rendered_names: set[str] = set()
         for key, val in body_fields.items():
-            inputs += f'  <input name="{html.escape(str(key), quote=True)}" value="{html.escape(str(val), quote=True)}">\n'
+            rendered_names.add(str(key))
+            if str(key) in file_fields:
+                inputs += f'  <input type="file" name="{html.escape(str(key), quote=True)}">\n'
+            else:
+                inputs += (
+                    f'  <input name="{html.escape(str(key), quote=True)}" '
+                    f'value="{html.escape(str(val), quote=True)}">\n'
+                )
+        for key in sorted(file_fields):
+            if key in rendered_names:
+                continue
+            rendered_names.add(key)
+            inputs += f'  <input type="file" name="{html.escape(str(key), quote=True)}">\n'
         if post_data and not body_fields:
             try:
                 post_json = json.loads(post_data)
@@ -828,7 +946,8 @@ def build_synthesized_html(engine, final_html: str, graphql_html: str) -> str:
         data_resp_ct = html.escape(str(fallback_ct or ""), quote=True)
         data_inferred = "true" if (method == "GET" and inferred_flag) else "false"
         synthesized += (
-            f'<form action="{action}" method="{html_method}" data-original-method="{method}" '
+            f'<form action="{action}" method="{html_method}"{form_enctype_attr} '
+            f'data-original-method="{method}" '
             f'data-content-type="{ct}" data-source-kind="{data_source}" '
             f'data-route-context="{data_route}" data-source-url="{data_source_url}" '
             f'data-depth="{data_depth}" data-response-headers="{data_resp_headers}" '

--- a/crawler/spa/capture_core.py
+++ b/crawler/spa/capture_core.py
@@ -484,9 +484,11 @@ def register_observed_body_field_hints(
         engine.observed_body_samples = {}
         samples_map = engine.observed_body_samples
     bucket = samples_map.setdefault(path_key, {})
+    from parsers.body_field_inference import is_plausible_field_name
+
     for raw_name in field_names:
         key_str = str(raw_name).strip()
-        if not key_str:
+        if not key_str or not is_plausible_field_name(key_str):
             continue
         store_observed_sample(bucket, key_str, str(bucket.get(key_str) or ""))
 

--- a/crawler/spa/capture_enrichment.py
+++ b/crawler/spa/capture_enrichment.py
@@ -6,6 +6,7 @@ import json
 import re
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
+from parsers.body_field_inference import merge_path_inferred_fields
 from parsers.http_method_inference import infer_body_params_from_path, infer_http_method_from_path
 
 from crawler.spa.capture_core import (
@@ -18,6 +19,7 @@ from crawler.spa.capture_core import (
     record_api_candidate,
     serialize_body_fields,
 )
+from crawler.spa.path_family import path_keys_share_body_field_family
 
 _DELETE_SEGMENT_RE = re.compile(r"^delete[a-z0-9_-]*$", re.IGNORECASE)
 _MUTATION_HINT_SEGMENTS = frozenset(
@@ -343,6 +345,61 @@ def enrich_source_urls(engine) -> int:
     return changed
 
 
+def merge_observed_body_fields_for_family(
+    engine,
+    path_key: str,
+    *,
+    local_fields: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """
+    같은 API 리소스 트리(예: /api/checkout/*)에서 관측된 body 필드를 합친다.
+    SPA는 confirm/process 등 형제 엔드포인트마다 XHR 본문이 달라 한 path_key만으로는 필드가 비는 경우가 많다.
+    """
+    samples = getattr(engine, "observed_body_samples", None) or {}
+    merged = dict(local_fields or {})
+    merged.update(dict(samples.get(path_key) or {}))
+
+    for sample_key, fields in samples.items():
+        if not fields or sample_key == path_key:
+            continue
+        if not path_keys_share_body_field_family(path_key, sample_key):
+            continue
+        for key, value in fields.items():
+            key_str = str(key).strip()
+            if not key_str:
+                continue
+            if key_str not in merged or not str(merged.get(key_str) or "").strip():
+                merged[key_str] = str(value)
+    return merged
+
+
+def resolve_mutating_body_fields(
+    engine,
+    path_key: str,
+    *,
+    local_fields: dict[str, str] | None = None,
+    source_url: str = "",
+    url: str = "",
+) -> dict[str, str]:
+    """
+    XHR/DOM 관측 + 리소스 family + source URL + 경로 세그먼트 힌트를 순서대로 병합.
+    관측값은 유지하고, 누락된 키만 보강한다 (범용 SPA surface 구축).
+    """
+    body_samples = getattr(engine, "observed_body_samples", None) or {}
+    seed = dict(local_fields or {})
+    if not seed:
+        seed = dict(body_samples.get(path_key) or {})
+    fields = merge_observed_body_fields_for_family(
+        engine,
+        path_key,
+        local_fields=seed,
+    )
+    if not fields and url:
+        fields = infer_body_params_from_path(url)
+    fields = hydrate_fields_from_source_context(fields, source_url)
+    return merge_path_inferred_fields(fields, path_key)
+
+
 def hydrate_fields_from_source_context(fields: dict[str, str], source_url: str) -> dict[str, str]:
     if not fields or not source_url:
         return fields
@@ -354,15 +411,12 @@ def hydrate_fields_from_source_context(fields: dict[str, str], source_url: str) 
     if not q:
         return fields
     hydrated = dict(fields)
-    if "post_type" in hydrated and not str(hydrated.get("post_type") or "").strip():
-        mapped = str(q.get("post_type") or q.get("type") or "").strip()
+    for key in list(hydrated.keys()):
+        if str(hydrated.get(key) or "").strip():
+            continue
+        mapped = str(q.get(key) or "").strip()
         if mapped:
-            hydrated["post_type"] = mapped
-    for key in ("order_id", "book_id", "id"):
-        if key in hydrated and not str(hydrated.get(key) or "").strip():
-            mapped = str(q.get(key) or "").strip()
-            if mapped:
-                hydrated[key] = mapped
+            hydrated[key] = mapped
     return hydrated
 
 
@@ -520,25 +574,35 @@ def normalize_mutating_path_endpoints(engine) -> int:
             continue
         path_key = path_key_from_url(url)
         source_url = best_source_url_for_path(engine, path_key) or str(entry.get("source_url") or "")
-        fields = dict(body_samples.get(path_key) or {})
-        if not fields:
-            fields = infer_body_params_from_path(url)
+        existing_fields = parse_payload_fields(
+            entry.get("post_data") or "", entry.get("req_content_type") or ""
+        )
+        fields = resolve_mutating_body_fields(
+            engine,
+            path_key,
+            local_fields=existing_fields,
+            source_url=source_url,
+            url=url,
+        )
         if not fields and promote_get_api:
-            # Generic fallback for API endpoints that look mutating but had no captured body.
-            # Keep conservative: single id key so modules can at least execute probe requests.
             fields = {"id": ""}
-        fields = hydrate_fields_from_source_context(fields, source_url)
         if not fields:
             continue
         content_type = body_cts.get(path_key, "application/json")
         post_data, req_ct = serialize_body_fields(fields, content_type)
+        file_map = getattr(engine, "observed_body_file_fields", None) or {}
+        path_file_fields = sorted(file_map.get(path_key) or ())
+        if path_file_fields:
+            req_ct = "multipart/form-data"
+            entry["file_fields"] = path_file_fields
 
-        if str(entry.get("method") or "GET").upper() != "POST" or not entry.get("post_data"):
-            entry["method"] = "POST"
-            entry["post_data"] = post_data
-            entry["req_content_type"] = req_ct
+        prior_post = entry.get("post_data")
+        entry["method"] = "POST"
+        entry["post_data"] = post_data
+        entry["req_content_type"] = req_ct
+        if prior_post != post_data:
             source = str(entry.get("source") or "")
-            if source in ("js-static", ""):
+            if source in ("js-static", "") and not existing_fields:
                 entry["source"] = "path-inferred"
             changed += 1
         if source_url and not str(entry.get("source_url") or "").strip():
@@ -558,6 +622,10 @@ def enrich_api_endpoints_from_observations(engine) -> int:
             continue
         content_type = body_cts.get(path_key, "application/json")
         post_data, req_content_type = serialize_body_fields(fields, content_type)
+        file_map = getattr(engine, "observed_body_file_fields", None) or {}
+        path_file_fields = sorted(file_map.get(path_key) or ())
+        if path_file_fields:
+            req_content_type = "multipart/form-data"
 
         for entry in list(engine.api_endpoints.values()):
             if path_key_from_url(entry.get("url") or "") != path_key:
@@ -565,9 +633,26 @@ def enrich_api_endpoints_from_observations(engine) -> int:
             if str(entry.get("method") or "GET").upper() not in _MUTATING_METHODS:
                 continue
             if entry.get("post_data"):
+                existing = parse_payload_fields(
+                    entry.get("post_data") or "", entry.get("req_content_type") or ""
+                )
+                merged = resolve_mutating_body_fields(
+                    engine,
+                    path_key,
+                    local_fields=existing,
+                    source_url=str(entry.get("source_url") or ""),
+                    url=str(entry.get("url") or ""),
+                )
+                merged_post, merged_ct = serialize_body_fields(merged, content_type)
+                if merged_post != entry.get("post_data"):
+                    entry["post_data"] = merged_post
+                    entry["req_content_type"] = merged_ct
+                    added += 1
                 continue
             entry["post_data"] = post_data
             entry["req_content_type"] = req_content_type
+            if path_file_fields:
+                entry["file_fields"] = path_file_fields
             if str(entry.get("source") or "") == "js-static":
                 entry["source"] = "observed-body"
 

--- a/crawler/spa/capture_enrichment.py
+++ b/crawler/spa/capture_enrichment.py
@@ -6,7 +6,11 @@ import json
 import re
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
-from parsers.body_field_inference import merge_path_inferred_fields
+from parsers.body_field_inference import (
+    is_plausible_field_name,
+    merge_path_inferred_fields,
+    sanitize_field_map,
+)
 from parsers.http_method_inference import infer_body_params_from_path, infer_http_method_from_path
 
 from crawler.spa.capture_core import (
@@ -356,20 +360,17 @@ def merge_observed_body_fields_for_family(
     SPA는 confirm/process 등 형제 엔드포인트마다 XHR 본문이 달라 한 path_key만으로는 필드가 비는 경우가 많다.
     """
     samples = getattr(engine, "observed_body_samples", None) or {}
-    merged = dict(local_fields or {})
-    merged.update(dict(samples.get(path_key) or {}))
+    merged = sanitize_field_map(local_fields)
+    merged.update(sanitize_field_map(samples.get(path_key) or {}))
 
     for sample_key, fields in samples.items():
         if not fields or sample_key == path_key:
             continue
         if not path_keys_share_body_field_family(path_key, sample_key):
             continue
-        for key, value in fields.items():
-            key_str = str(key).strip()
-            if not key_str:
-                continue
-            if key_str not in merged or not str(merged.get(key_str) or "").strip():
-                merged[key_str] = str(value)
+        for key, value in sanitize_field_map(fields).items():
+            if key not in merged or not str(merged.get(key) or "").strip():
+                merged[key] = str(value)
     return merged
 
 
@@ -397,7 +398,7 @@ def resolve_mutating_body_fields(
     if not fields and url:
         fields = infer_body_params_from_path(url)
     fields = hydrate_fields_from_source_context(fields, source_url)
-    return merge_path_inferred_fields(fields, path_key)
+    return merge_path_inferred_fields(sanitize_field_map(fields), path_key)
 
 
 def hydrate_fields_from_source_context(fields: dict[str, str], source_url: str) -> dict[str, str]:

--- a/crawler/spa/dom_form_capture.py
+++ b/crawler/spa/dom_form_capture.py
@@ -6,26 +6,53 @@ import logging
 from urllib.parse import urlparse
 
 from crawler.spa.capture_core import path_key_from_url, register_observed_body_field_hints
+from parsers.body_field_inference import sanitize_field_map
 
 logger = logging.getLogger(__name__)
 
 _COLLECT_FORM_FIELDS_JS = """() => {
     const fields = {};
+    const labels = {};
     const skipName = /^(csrf|_token|token|authenticity_token|submit|button|login|logout)$/i;
     const skipType = new Set(['submit', 'button', 'reset', 'image']);
     const idLike = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
     const dataAttrs = ['data-field', 'data-name', 'data-testid', 'data-test', 'data-cy'];
 
+    function looksLikeUrl(t) {
+        const s = String(t || '').trim().toLowerCase();
+        return s.startsWith('http://') || s.startsWith('https://') || s.startsWith('//')
+            || (s.includes('://') && s.length >= 10);
+    }
+
+    function inferFromSemanticLabel(text) {
+        const t = String(text || '').trim();
+        if (!t) return '';
+        if (looksLikeUrl(t)) return 'url';
+        if (/(?:external|remote|reference|fetch|proxy|webhook|callback|redirect|foreign|embed|avatar|image|logo|src|href|외부|참조|연동|링크|이미지)/i.test(t)
+            && /(?:url|uri|link|endpoint|주소|링크)/i.test(t)) {
+            return 'external_url';
+        }
+        if (/^(?:url|uri|link|href|src|endpoint)$/i.test(t)) return 'url';
+        if (/\\b(?:e-?mail|email)\\b/i.test(t)) return 'email';
+        if (/\\b(?:phone|mobile|tel|연락|전화)\\b/i.test(t)) return 'phone';
+        if (/\\b(?:password|passwd|비밀)\\b/i.test(t)) return 'password';
+        if (/\\b(?:username|user_name|아이디)\\b/i.test(t)) return 'username';
+        if (/\\b(?:attachment|upload|첨부|파일)\\b/i.test(t)) return 'attachment';
+        return '';
+    }
+
     function slugify(text) {
         const raw = String(text || '').trim().slice(0, 80);
-        if (!raw) return '';
+        if (!raw || looksLikeUrl(raw)) return '';
         const slug = raw
             .toLowerCase()
             .replace(/[^\\w\\s-]+/g, ' ')
             .replace(/[\\s-]+/g, '_')
             .replace(/^_+|_+$/g, '')
             .slice(0, 64);
-        return slug && /^[a-z][a-z0-9_]*$/.test(slug) ? slug : '';
+        if (!slug || !/^[a-z][a-z0-9_]*$/.test(slug)) return '';
+        if (/^(?:https?|http)_|_com_|example_com|localhost/.test(slug)) return '';
+        return slug;
     }
 
     function labelTextForControl(el) {
@@ -40,8 +67,6 @@ _COLLECT_FORM_FIELDS_JS = """() => {
         if (parentLabel && parentLabel.innerText) return parentLabel.innerText.trim();
         const aria = (el.getAttribute('aria-label') || '').trim();
         if (aria) return aria;
-        const placeholder = (el.getAttribute('placeholder') || '').trim();
-        if (placeholder) return placeholder;
         return '';
     }
 
@@ -55,6 +80,8 @@ _COLLECT_FORM_FIELDS_JS = """() => {
         for (const attr of dataAttrs) {
             const v = (el.getAttribute(attr) || '').trim();
             if (!v) continue;
+            const semantic = inferFromSemanticLabel(v);
+            if (semantic) return semantic;
             const fromData = slugify(v) || (idLike.test(v) ? v.replace(/-/g, '_') : '');
             if (fromData) return fromData;
         }
@@ -63,10 +90,17 @@ _COLLECT_FORM_FIELDS_JS = """() => {
         const typeHints = { email: 'email', password: 'password', search: 'q', tel: 'phone', url: 'url' };
         if (typeHints[type]) return typeHints[type];
 
-        return slugify(labelTextForControl(el));
+        const label = labelTextForControl(el);
+        const placeholder = (el.getAttribute('placeholder') || '').trim();
+        const fromLabel = inferFromSemanticLabel(label);
+        if (fromLabel) return fromLabel;
+        if (looksLikeUrl(placeholder)) {
+            return fromLabel || 'url';
+        }
+        return slugify(label) || slugify(placeholder);
     }
 
-    function addField(name, value, el) {
+    function addField(name, value, el, labelHint) {
         const key = String(name || '').trim();
         if (!key || skipName.test(key)) return;
         const type = (el && (el.getAttribute('type') || 'text').toLowerCase()) || 'text';
@@ -76,17 +110,46 @@ _COLLECT_FORM_FIELDS_JS = """() => {
         if (!(key in fields) || !String(fields[key] || '').trim()) {
             fields[key] = val;
         }
+        if (labelHint && !(key in labels)) {
+            labels[key] = String(labelHint).slice(0, 200);
+        }
     }
 
     document.querySelectorAll('input, textarea, select').forEach((el) => {
         const type = (el.getAttribute('type') || 'text').toLowerCase();
         if (type === 'hidden' || type === 'file') return;
+        const label = labelTextForControl(el);
+        const placeholder = (el.getAttribute('placeholder') || '').trim();
         const key = inferFieldName(el);
-        if (key) addField(key, el.value, el);
+        if (key) addField(key, el.value, el, label || placeholder);
     });
 
-    return fields;
+    return { fields, labels };
 }"""
+
+
+def _normalize_dom_capture(raw: object) -> tuple[dict[str, str], dict[str, str]]:
+    if not isinstance(raw, dict):
+        return {}, {}
+
+    if "fields" in raw or "labels" in raw:
+        field_map = raw.get("fields") if isinstance(raw.get("fields"), dict) else {}
+        label_map = raw.get("labels") if isinstance(raw.get("labels"), dict) else {}
+    else:
+        field_map = raw
+        label_map = {}
+
+    label_hints = {
+        str(k): str(v)
+        for k, v in label_map.items()
+        if str(k).strip()
+    }
+    values = {
+        str(k).strip(): str(v)[:500]
+        for k, v in field_map.items()
+        if str(k).strip()
+    }
+    return sanitize_field_map(values, label_hints=label_hints), label_hints
 
 
 async def extract_visible_form_fields(page) -> dict[str, str]:
@@ -95,13 +158,8 @@ async def extract_visible_form_fields(page) -> dict[str, str]:
     except Exception as exc:
         logger.debug("[SPA Crawler] DOM form field capture failed: %s", exc)
         return {}
-    if not isinstance(raw, dict):
-        return {}
-    return {
-        str(k).strip(): str(v)[:500]
-        for k, v in raw.items()
-        if str(k).strip()
-    }
+    fields, _ = _normalize_dom_capture(raw)
+    return fields
 
 
 def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]) -> int:
@@ -109,6 +167,7 @@ def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]
     현재 클라이언트 라우트의 input/textarea name을 관련 API path_key에 병합.
     React controlled form은 XHR 전까지 body 샘플이 비는 경우가 많다.
     """
+    fields = sanitize_field_map(fields)
     if not fields:
         return 0
 
@@ -134,7 +193,7 @@ def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]
             if key_str not in bucket or not str(bucket.get(key_str) or "").strip():
                 bucket[key_str] = str(value)
         if len(bucket) > before or (before == 0 and bucket):
-            samples_map[path_key] = bucket
+            samples_map[path_key] = sanitize_field_map(bucket)
             updated += 1
         register_observed_body_field_hints(engine, path_key, fields.keys())
 

--- a/crawler/spa/dom_form_capture.py
+++ b/crawler/spa/dom_form_capture.py
@@ -1,0 +1,181 @@
+"""SPA 라우트 방문 시 DOM 폼 필드명을 observed_body_samples에 반영."""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+from crawler.spa.capture_core import path_key_from_url, register_observed_body_field_hints
+
+logger = logging.getLogger(__name__)
+
+_COLLECT_FORM_FIELDS_JS = """() => {
+    const fields = {};
+    const skipName = /^(csrf|_token|token|authenticity_token|submit|button|login|logout)$/i;
+    const skipType = new Set(['submit', 'button', 'reset', 'image']);
+    const idLike = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+    const dataAttrs = ['data-field', 'data-name', 'data-testid', 'data-test', 'data-cy'];
+
+    function slugify(text) {
+        const raw = String(text || '').trim().slice(0, 80);
+        if (!raw) return '';
+        const slug = raw
+            .toLowerCase()
+            .replace(/[^\\w\\s-]+/g, ' ')
+            .replace(/[\\s-]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+            .slice(0, 64);
+        return slug && /^[a-z][a-z0-9_]*$/.test(slug) ? slug : '';
+    }
+
+    function labelTextForControl(el) {
+        const id = (el.getAttribute('id') || '').trim();
+        if (id) {
+            try {
+                const bound = document.querySelector(`label[for="${CSS.escape(id)}"]`);
+                if (bound && bound.innerText) return bound.innerText.trim();
+            } catch (e) {}
+        }
+        const parentLabel = el.closest('label');
+        if (parentLabel && parentLabel.innerText) return parentLabel.innerText.trim();
+        const aria = (el.getAttribute('aria-label') || '').trim();
+        if (aria) return aria;
+        const placeholder = (el.getAttribute('placeholder') || '').trim();
+        if (placeholder) return placeholder;
+        return '';
+    }
+
+    function inferFieldName(el) {
+        const explicit = (el.getAttribute('name') || '').trim();
+        if (explicit) return explicit;
+
+        const id = (el.getAttribute('id') || '').trim();
+        if (id && idLike.test(id)) return id.replace(/-/g, '_');
+
+        for (const attr of dataAttrs) {
+            const v = (el.getAttribute(attr) || '').trim();
+            if (!v) continue;
+            const fromData = slugify(v) || (idLike.test(v) ? v.replace(/-/g, '_') : '');
+            if (fromData) return fromData;
+        }
+
+        const type = (el.getAttribute('type') || 'text').toLowerCase();
+        const typeHints = { email: 'email', password: 'password', search: 'q', tel: 'phone', url: 'url' };
+        if (typeHints[type]) return typeHints[type];
+
+        return slugify(labelTextForControl(el));
+    }
+
+    function addField(name, value, el) {
+        const key = String(name || '').trim();
+        if (!key || skipName.test(key)) return;
+        const type = (el && (el.getAttribute('type') || 'text').toLowerCase()) || 'text';
+        if (skipType.has(type)) return;
+        if (el && (type === 'checkbox' || type === 'radio') && !el.checked) return;
+        const val = String(value || '').slice(0, 500);
+        if (!(key in fields) || !String(fields[key] || '').trim()) {
+            fields[key] = val;
+        }
+    }
+
+    document.querySelectorAll('input, textarea, select').forEach((el) => {
+        const type = (el.getAttribute('type') || 'text').toLowerCase();
+        if (type === 'hidden' || type === 'file') return;
+        const key = inferFieldName(el);
+        if (key) addField(key, el.value, el);
+    });
+
+    return fields;
+}"""
+
+
+async def extract_visible_form_fields(page) -> dict[str, str]:
+    try:
+        raw = await page.evaluate(_COLLECT_FORM_FIELDS_JS)
+    except Exception as exc:
+        logger.debug("[SPA Crawler] DOM form field capture failed: %s", exc)
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(k).strip(): str(v)[:500]
+        for k, v in raw.items()
+        if str(k).strip()
+    }
+
+
+def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]) -> int:
+    """
+    현재 클라이언트 라우트의 input/textarea name을 관련 API path_key에 병합.
+    React controlled form은 XHR 전까지 body 샘플이 비는 경우가 많다.
+    """
+    if not fields:
+        return 0
+
+    samples_map = getattr(engine, "observed_body_samples", None)
+    if samples_map is None:
+        engine.observed_body_samples = {}
+        samples_map = engine.observed_body_samples
+
+    route_key = path_key_from_url(route_url)
+    route_path = (urlparse(route_url).path or "").rstrip("/").lower()
+    updated = 0
+
+    def merge_into(path_key: str) -> None:
+        nonlocal updated
+        if not path_key:
+            return
+        bucket = dict(samples_map.get(path_key) or {})
+        before = len(bucket)
+        for key, value in fields.items():
+            key_str = str(key).strip()
+            if not key_str:
+                continue
+            if key_str not in bucket or not str(bucket.get(key_str) or "").strip():
+                bucket[key_str] = str(value)
+        if len(bucket) > before or (before == 0 and bucket):
+            samples_map[path_key] = bucket
+            updated += 1
+        register_observed_body_field_hints(engine, path_key, fields.keys())
+
+    merge_into(route_key)
+
+    for entry in getattr(engine, "api_endpoints", {}).values():
+        api_url = str(entry.get("url") or "")
+        api_key = path_key_from_url(api_url)
+        source_url = str(entry.get("source_url") or "")
+        source_key = path_key_from_url(source_url) if source_url.startswith("http") else source_url
+
+        related = False
+        if route_key and (route_key in api_key or api_key.endswith(route_key)):
+            related = True
+        if route_path and source_url:
+            src_path = (urlparse(source_url).path or "").rstrip("/").lower()
+            if src_path == route_path or route_path in src_path or src_path in route_path:
+                related = True
+        if route_key and source_key and (route_key in source_key or source_key in route_key):
+            related = True
+        if route_key.startswith("/api/") and route_key[4:] == api_key:
+            related = True
+        if api_key.startswith("/api/") and api_key[4:] == route_key:
+            related = True
+
+        if related:
+            merge_into(api_key)
+
+    return updated
+
+
+async def capture_and_register_dom_fields(engine, page) -> None:
+    fields = await extract_visible_form_fields(page)
+    if not fields:
+        return
+    route_url = str(getattr(page, "url", "") or getattr(engine, "current_route_url", "") or "")
+    count = register_dom_fields_for_route(engine, route_url, fields)
+    if count:
+        logger.debug(
+            "[SPA Crawler] DOM form fields (%s keys) linked to %s API path(s) on %s",
+            len(fields),
+            count,
+            route_url,
+        )

--- a/crawler/spa/engine.py
+++ b/crawler/spa/engine.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse, urlunparse
 from playwright.async_api import async_playwright
 
 from core.models import PageData
+from crawler.spa.dom_form_capture import capture_and_register_dom_fields
 from crawler.spa.browser import (
     build_auth_headers,
     build_playwright_cookies,
@@ -330,6 +331,7 @@ class SPACrawlerEngine:
                     self.current_route_depth = 0
                     self.route_depths[self.target_url] = 0
                     await wait_for_page_settle(page, context_label="base route load")
+                    await capture_and_register_dom_fields(self, page)
                     final_html = await page.content()
                 except Exception as e:
                     logger.debug("[SPA Crawler] Load timeout on base url: %s", e)
@@ -393,6 +395,7 @@ class SPACrawlerEngine:
                             timeout=self.route_timeout,
                         )
                         await wait_for_page_settle(page, context_label=f"route load:{route}")
+                        await capture_and_register_dom_fields(self, page)
                         await interact_and_submit(self, page)
                         await interact_and_submit(self, page)
                         await sync_storage_from_browser(self, page)

--- a/crawler/spa/js_analyzer.py
+++ b/crawler/spa/js_analyzer.py
@@ -10,7 +10,9 @@ from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
 
 from crawler.spa.capture import is_in_scope, record_api_candidate
+from crawler.spa.capture_core import path_key_from_url, register_observed_body_field_hints
 from parsers.http_method_inference import infer_http_method_from_path
+from parsers.body_field_inference import extract_body_field_names_near_url_literal
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +162,7 @@ def _infer_content_type(method: str, url: str) -> str:
 def _content_type_for_wrapper(wrapper: str) -> str:
     w = str(wrapper or "").lower()
     if w == "postform":
-        return "application/x-www-form-urlencoded"
+        return "multipart/form-data"
     if w in ("post", "put", "patch", "delete", "del"):
         return "application/json"
     return ""
@@ -352,6 +354,14 @@ async def seed_api_candidates_from_scripts(engine, page, context) -> int:
             )
             if created:
                 added += 1
+            if method.upper() in {"POST", "PUT", "PATCH", "DELETE"}:
+                near_fields = extract_body_field_names_near_url_literal(script_text, endpoint_url)
+                if near_fields:
+                    register_observed_body_field_hints(
+                        engine,
+                        path_key_from_url(urljoin(base_url, endpoint_url)),
+                        near_fields,
+                    )
         engine.metrics["js_scripts_scanned"] += 1
 
     timeout_ms = int(getattr(engine, "route_timeout", 5000) or 5000)
@@ -378,6 +388,14 @@ async def seed_api_candidates_from_scripts(engine, page, context) -> int:
             )
             if created:
                 added += 1
+            if method.upper() in {"POST", "PUT", "PATCH", "DELETE"}:
+                near_fields = extract_body_field_names_near_url_literal(script_text, endpoint_url)
+                if near_fields:
+                    register_observed_body_field_hints(
+                        engine,
+                        path_key_from_url(urljoin(script_url, endpoint_url)),
+                        near_fields,
+                    )
         engine.metrics["js_scripts_scanned"] += 1
 
     engine.metrics["js_endpoints_seeded"] += added

--- a/crawler/spa/path_family.py
+++ b/crawler/spa/path_family.py
@@ -1,0 +1,71 @@
+"""SPA/API path_key 간 body 필드 병합 범위 (범용 REST 리소스 트리)."""
+
+from __future__ import annotations
+
+
+def normalize_path_key(path: str) -> str:
+    p = (path or "").strip()
+    if not p.startswith("/"):
+        p = "/" + p
+    return p.rstrip("/").lower() or "/"
+
+
+def api_resource_family_root(path_key: str) -> str:
+    """
+    형제 엔드포인트(confirm/process 등)끼리만 body 필드를 공유하는 리소스 루트.
+    /api/checkout/confirm -> /api/checkout
+    /api/board/write -> /api/board
+    /profile/edit -> /profile
+    """
+    segments = [seg for seg in normalize_path_key(path_key).split("/") if seg]
+    if not segments:
+        return "/"
+    if segments[0] == "api" and len(segments) >= 2:
+        return f"/api/{segments[1]}"
+    return f"/{segments[0]}"
+
+
+def spa_path_keys_related(path_key: str, sample_key: str) -> bool:
+    """클라이언트 라우트(/board/write)와 API 경로(/api/board/write) 샘플 연결."""
+    if not path_key or not sample_key:
+        return False
+
+    api_norm = normalize_path_key(path_key)
+    sample_norm = normalize_path_key(sample_key)
+    if api_norm == sample_norm:
+        return True
+
+    if api_norm.startswith("/api/"):
+        without_api = api_norm[4:]
+        if without_api == sample_norm:
+            return True
+    if api_norm.endswith(sample_norm):
+        if len(api_norm) == len(sample_norm):
+            return True
+        return api_norm[-len(sample_norm) - 1] == "/"
+    return False
+
+
+def path_keys_share_body_field_family(path_key: str, sample_key: str) -> bool:
+    """
+    서로 다른 API 리소스(/api/board vs /api/checkout) 전역 병합을 막고,
+    같은 리소스 트리·SPA 라우트 쌍만 body 필드를 공유한다.
+    """
+    if spa_path_keys_related(path_key, sample_key):
+        return True
+
+    pk = normalize_path_key(path_key)
+    sk = normalize_path_key(sample_key)
+    if pk == sk:
+        return True
+
+    root_pk = api_resource_family_root(pk)
+    root_sk = api_resource_family_root(sk)
+    if root_pk != root_sk:
+        return False
+
+    if sk.startswith(pk + "/") or pk.startswith(sk + "/"):
+        return True
+    if pk == root_pk or sk == root_sk:
+        return True
+    return pk.startswith(root_pk + "/") and sk.startswith(root_sk + "/")

--- a/fuzzer/__init__.py
+++ b/fuzzer/__init__.py
@@ -1,5 +1,11 @@
 from .engine import AttackJob, AttackModule, EngineStats, Finding, FuzzerEngine
-from .auth_provider import ScanAuthProvider, create_scan_auth_provider, scan_auth_lifecycle
+from .auth_provider import (
+    ScanAuthProvider,
+    collect_cookies_from_surfaces,
+    create_scan_auth_provider,
+    merge_scan_cookies,
+    scan_auth_lifecycle,
+)
 from .request_builder import (
     FuzzerResponse,
     build_and_send_request,
@@ -18,7 +24,9 @@ __all__ = [
     "send_baseline_request",
     "FuzzerResponse",
     "ScanAuthProvider",
+    "collect_cookies_from_surfaces",
     "create_scan_auth_provider",
+    "merge_scan_cookies",
     "set_auth_provider",
     "get_auth_provider",
     "scan_auth_lifecycle",

--- a/fuzzer/auth_provider.py
+++ b/fuzzer/auth_provider.py
@@ -184,6 +184,37 @@ class ScanAuthProvider:
         self._cookies.update(self._session_manager.get_cookies())
 
 
+def collect_cookies_from_surfaces(surfaces: Any) -> dict[str, str]:
+    """크롤 surface에 실린 세션 쿠키를 퍼징 단계에 전달."""
+    merged: dict[str, str] = {}
+    if not surfaces:
+        return merged
+    for surface in surfaces:
+        raw = getattr(surface, "cookies", None) or {}
+        if isinstance(raw, dict):
+            for key, value in raw.items():
+                if value is None:
+                    continue
+                key_str = str(key).strip()
+                if key_str:
+                    merged[key_str] = str(value)
+    return merged
+
+
+def merge_scan_cookies(args: Any, surfaces: Any = None) -> dict[str, str]:
+    """CLI --cookie 와 크롤 surface 쿠키를 합친다 (surface 값 우선)."""
+    from cli.options import parse_cookies
+
+    cookies = parse_cookies(getattr(args, "cookie", "") or "")
+    for key, value in collect_cookies_from_surfaces(surfaces).items():
+        cookies[key] = value
+    return cookies
+
+
+def _has_session_cookie(cookies: dict[str, str]) -> bool:
+    return any(_is_auth_cookie_name(name) for name in cookies)
+
+
 def parse_local_storage_arg(raw: Any) -> dict[str, Any]:
     if isinstance(raw, dict):
         return dict(raw)
@@ -203,6 +234,7 @@ async def create_scan_auth_provider(
     args: Any,
     *,
     base_cookies: dict[str, str] | None = None,
+    surfaces: Any = None,
 ) -> ScanAuthProvider | None:
     """
     CLI/Web 인자로부터 퍼징용 AuthProvider 생성.
@@ -215,6 +247,11 @@ async def create_scan_auth_provider(
     auth_cookies = dict(base_cookies or {})
     for name, value in build_auth_cookies_from_storage(local_storage).items():
         auth_cookies.setdefault(name, value)
+    for name, value in collect_cookies_from_surfaces(surfaces).items():
+        auth_cookies[name] = value
+
+    crawl_mode = str(getattr(args, "crawl_mode", "hybrid") or "hybrid").lower()
+    has_crawl_session = _has_session_cookie(auth_cookies)
 
     login_url = (getattr(args, "login_url", "") or "").strip()
     username = (getattr(args, "username", "") or "").strip()
@@ -247,10 +284,16 @@ async def create_scan_auth_provider(
                 auth_cookies.update(sm.get_cookies())
                 print(f"[*] [Auth] fuzz-phase login succeeded: {login_url}")
             else:
-                print(
-                    f"[!] [Auth] fuzz-phase login failed: {login_url} "
-                    f"(refresh disabled; using static tokens only if any)"
-                )
+                if crawl_mode == "dynamic" and has_crawl_session:
+                    print(
+                        f"[*] [Auth] fuzz-phase login failed for {login_url}; "
+                        f"using crawl session cookie(s) from attack surfaces."
+                    )
+                else:
+                    print(
+                        f"[!] [Auth] fuzz-phase login failed: {login_url} "
+                        f"(refresh disabled; using static tokens only if any)"
+                    )
                 await sm.close()
         except Exception as exc:
             print(f"[!] [Auth] fuzz-phase login error: {exc}")
@@ -287,13 +330,18 @@ async def scan_auth_lifecycle(
     args: Any,
     *,
     base_cookies: dict[str, str] | None = None,
+    surfaces: Any = None,
 ) -> AsyncIterator[ScanAuthProvider | None]:
     """
     CLI·Web 공통: provider 생성 → set_auth_provider → finally 정리.
     """
     from fuzzer.request_builder import set_auth_provider
 
-    provider = await create_scan_auth_provider(args, base_cookies=base_cookies)
+    provider = await create_scan_auth_provider(
+        args,
+        base_cookies=base_cookies,
+        surfaces=surfaces,
+    )
     set_auth_provider(provider)
     try:
         yield provider

--- a/fuzzer/request_builder.py
+++ b/fuzzer/request_builder.py
@@ -15,6 +15,7 @@ import aiohttp
 from core.models import AttackSurface, ParamLocation
 
 from fuzzer.auth_provider import ScanAuthProvider
+from modules.file_upload.form_helpers import fill_upload_form_defaults
 
 _DYNAMIC_TOKEN_LOCKS: dict[str, asyncio.Lock] = {}
 _auth_provider: ScanAuthProvider | None = None
@@ -515,6 +516,89 @@ def _is_file_payload(payload: Any) -> bool:
     )
 
 
+_FILE_PARAM_HINTS = frozenset(
+    {
+        "attachment",
+        "attachments",
+        "file",
+        "files",
+        "uploaded",
+        "uploadfile",
+        "userfile",
+        "image",
+        "images",
+        "document",
+        "avatar",
+        "binary",
+        "blob",
+    }
+)
+
+_UPLOAD_URL_HINTS = ("upload", "attach", "attachment", "file", "media", "avatar")
+
+
+def _surface_file_field_names(surface: AttackSurface) -> frozenset[str]:
+    raw = getattr(surface, "file_field_names", None) or ()
+    return frozenset(str(name).strip() for name in raw if str(name).strip())
+
+
+def _parameter_looks_like_file_field(parameter: str) -> bool:
+    key = str(parameter or "").strip().lower()
+    if not key:
+        return False
+    if key in _FILE_PARAM_HINTS:
+        return True
+    return any(hint in key for hint in _FILE_PARAM_HINTS)
+
+
+def _surface_suggests_file_upload(surface: AttackSurface) -> bool:
+    blob = f"{surface.url} {getattr(surface, 'source_url', '') or ''}".lower()
+    return any(hint in blob for hint in _UPLOAD_URL_HINTS)
+
+
+def _should_use_multipart_upload(
+    surface: AttackSurface,
+    parameter: str,
+    *,
+    is_file_payload: bool,
+) -> bool:
+    """SPA API surfaces may be BODY_JSON while the live client sends multipart."""
+    if not is_file_payload:
+        return False
+    if surface.param_location == ParamLocation.BODY_FORM:
+        return True
+    if surface.param_location != ParamLocation.BODY_JSON:
+        return False
+    req_ct = str(getattr(surface, "request_content_type", "") or "").lower()
+    if "multipart/form-data" in req_ct:
+        return True
+    file_fields = _surface_file_field_names(surface)
+    if file_fields:
+        return parameter in file_fields or _parameter_looks_like_file_field(parameter)
+    return _parameter_looks_like_file_field(parameter) or _surface_suggests_file_upload(surface)
+
+
+def _build_multipart_request_kwargs(
+    req_params: dict[str, Any],
+    *,
+    parameter: str,
+    payload: Any,
+) -> dict[str, Any]:
+    fill_upload_form_defaults(req_params, parameter)
+    form = aiohttp.FormData()
+    for key, value in req_params.items():
+        if key == parameter:
+            continue
+        form.add_field(str(key), str(value))
+    form.add_field(
+        parameter,
+        payload.content,
+        filename=str(payload.filename),
+        content_type=str(payload.content_type),
+    )
+    return {"data": form}
+
+
 def _inject_path_payload(url: str, parameter: str, payload: str) -> str:
     """
     Replace a path placeholder with encoded payload.
@@ -577,6 +661,9 @@ async def build_and_send_request(
     request_kwargs: dict[str, Any] = {}
     payload_value = _resolve_payload_value(payload)
     is_file_payload = _is_file_payload(payload)
+    use_multipart_upload = _should_use_multipart_upload(
+        surface, parameter, is_file_payload=is_file_payload
+    )
     is_lfi_payload = type(payload).__name__ == "LFIPayload"
     headers = _sanitize_headers_for_request(headers)
 
@@ -585,19 +672,12 @@ async def build_and_send_request(
         if not is_lfi_payload:
             request_kwargs["params"] = req_params
     elif surface.param_location == ParamLocation.BODY_FORM:
-        if is_file_payload:
-            form = aiohttp.FormData()
-            for key, value in req_params.items():
-                if key == parameter:
-                    continue
-                form.add_field(str(key), str(value))
-            form.add_field(
-                parameter,
-                payload.content,
-                filename=str(payload.filename),
-                content_type=str(payload.content_type),
+        if use_multipart_upload:
+            request_kwargs.update(
+                _build_multipart_request_kwargs(
+                    req_params, parameter=parameter, payload=payload
+                )
             )
-            request_kwargs["data"] = form
         else:
             req_params[parameter] = payload_value
             _hydrate_empty_supporting_params(req_params, attack_parameter=parameter)
@@ -605,27 +685,38 @@ async def build_and_send_request(
 
     #  JSON 및 GraphQL 직렬화 + Safe Mode 방어 (일반 요청)
     elif surface.param_location == ParamLocation.BODY_JSON:
-        req_params[parameter] = payload_value
-        _hydrate_empty_supporting_params(req_params, attack_parameter=parameter)
+        if use_multipart_upload:
+            _hydrate_empty_supporting_params(req_params, attack_parameter=parameter)
+            request_kwargs.update(
+                _build_multipart_request_kwargs(
+                    req_params, parameter=parameter, payload=payload
+                )
+            )
+        else:
+            req_params[parameter] = payload_value
+            _hydrate_empty_supporting_params(req_params, attack_parameter=parameter)
 
         gql_meta = _parse_graphql_surface(surface)
-        if gql_meta is not None:
-            gql_type, op_name = gql_meta
-            if _should_skip_graphql_mutation(gql_type):
-                print(f"[Safe Mode] 스킵된 GraphQL Mutation: {op_name} (URL: {url})")
-                return FuzzerResponse(
-                    status=0, text="", headers={}, elapsed_time=0.0, url=url,
-                    error="Skipped by Safe Mode (GraphQL Mutation)"
+        if use_multipart_upload:
+            gql_meta = None
+        if not use_multipart_upload:
+            if gql_meta is not None:
+                gql_type, op_name = gql_meta
+                if _should_skip_graphql_mutation(gql_type):
+                    print(f"[Safe Mode] 스킵된 GraphQL Mutation: {op_name} (URL: {url})")
+                    return FuzzerResponse(
+                        status=0, text="", headers={}, elapsed_time=0.0, url=url,
+                        error="Skipped by Safe Mode (GraphQL Mutation)"
+                    )
+                query_str = _build_graphql_operation_query(
+                    gql_type, op_name, req_params,
+                    attack_parameter=parameter,
+                    attack_value=payload_value,
+                    arg_types=getattr(surface, "graphql_arg_types", None) or {},
                 )
-            query_str = _build_graphql_operation_query(
-                gql_type, op_name, req_params,
-                attack_parameter=parameter,
-                attack_value=payload_value,
-                arg_types=getattr(surface, "graphql_arg_types", None) or {},
-            )
-            request_kwargs["json"] = {"query": query_str}
-        else:
-            request_kwargs["json"] = req_params
+                request_kwargs["json"] = {"query": query_str}
+            else:
+                request_kwargs["json"] = req_params
 
     elif surface.param_location == ParamLocation.HEADER:
         headers[parameter] = payload_value
@@ -688,42 +779,42 @@ async def build_and_send_request(
             if not is_lfi_payload:
                 request_kwargs["params"] = req_params
         elif surface.param_location == ParamLocation.BODY_FORM:
-            if is_file_payload:
-                form = aiohttp.FormData()
-                for key, value in req_params.items():
-                    if key == parameter:
-                        continue
-                    form.add_field(str(key), str(value))
-                form.add_field(
-                    parameter,
-                    payload.content,
-                    filename=str(payload.filename),
-                    content_type=str(payload.content_type),
+            if use_multipart_upload:
+                request_kwargs.update(
+                    _build_multipart_request_kwargs(
+                        req_params, parameter=parameter, payload=payload
+                    )
                 )
-                request_kwargs["data"] = form
             else:
                 request_kwargs["data"] = req_params
 
         #  JSON 및 GraphQL 직렬화 + Safe Mode 방어 (Dynamic Token이 있는 경우)
         elif surface.param_location == ParamLocation.BODY_JSON:
-            gql_meta = _parse_graphql_surface(surface)
-            if gql_meta is not None:
-                gql_type, op_name = gql_meta
-                if _should_skip_graphql_mutation(gql_type):
-                    print(f"[Safe Mode] 스킵된 GraphQL Mutation: {op_name} (URL: {url})")
-                    return FuzzerResponse(
-                        status=0, text="", headers={}, elapsed_time=0.0, url=url,
-                        error="Skipped by Safe Mode (GraphQL Mutation)"
+            if use_multipart_upload:
+                request_kwargs.update(
+                    _build_multipart_request_kwargs(
+                        req_params, parameter=parameter, payload=payload
                     )
-                query_str = _build_graphql_operation_query(
-                    gql_type, op_name, req_params,
-                    attack_parameter=parameter,
-                    attack_value=payload_value,
-                    arg_types=getattr(surface, "graphql_arg_types", None) or {},
                 )
-                request_kwargs["json"] = {"query": query_str}
             else:
-                request_kwargs["json"] = req_params
+                gql_meta = _parse_graphql_surface(surface)
+                if gql_meta is not None:
+                    gql_type, op_name = gql_meta
+                    if _should_skip_graphql_mutation(gql_type):
+                        print(f"[Safe Mode] 스킵된 GraphQL Mutation: {op_name} (URL: {url})")
+                        return FuzzerResponse(
+                            status=0, text="", headers={}, elapsed_time=0.0, url=url,
+                            error="Skipped by Safe Mode (GraphQL Mutation)"
+                        )
+                    query_str = _build_graphql_operation_query(
+                        gql_type, op_name, req_params,
+                        attack_parameter=parameter,
+                        attack_value=payload_value,
+                        arg_types=getattr(surface, "graphql_arg_types", None) or {},
+                    )
+                    request_kwargs["json"] = {"query": query_str}
+                else:
+                    request_kwargs["json"] = req_params
 
         elif req_params:
             request_kwargs["params"] = req_params

--- a/parsers/body_field_inference.py
+++ b/parsers/body_field_inference.py
@@ -1,0 +1,174 @@
+"""HTTP POST body 필드명 추론 — 라벨 슬러그, 경로 형태, 번들 JS 정적 추출."""
+
+from __future__ import annotations
+
+import re
+
+from parsers.http_method_inference import _POST_ACTION_SEGMENTS
+
+__all__ = (
+    "infer_field_name_from_label_text",
+    "infer_semantic_body_fields_from_path",
+    "merge_path_inferred_fields",
+    "slugify_field_name",
+    "extract_body_field_names_from_script",
+    "extract_body_field_names_near_url_literal",
+)
+
+_NON_WORD_RE = re.compile(r"[^\w\s-]+", re.UNICODE)
+_MULTI_SEP_RE = re.compile(r"[\s-]+")
+_VALID_FIELD_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_NUMERIC_SEGMENT_RE = re.compile(r"^\d+$|^[0-9a-f]{8,}$", re.I)
+
+
+def slugify_field_name(text: str, *, max_len: int = 64) -> str:
+    """라벨·placeholder 등을 API 필드명 형태(snake_case)로 정규화."""
+    raw = str(text or "").strip()[:80]
+    if not raw:
+        return ""
+    slug = _MULTI_SEP_RE.sub("_", _NON_WORD_RE.sub(" ", raw.lower())).strip("_")[:max_len]
+    if slug and _VALID_FIELD_RE.match(slug):
+        return slug
+    return ""
+
+
+def infer_field_name_from_label_text(label_text: str) -> str:
+    """폼 라벨·aria-label·placeholder → 필드명 후보 (시맨틱 추측 없음)."""
+    return slugify_field_name(label_text)
+
+
+def _path_segments(path_key: str) -> tuple[str, ...]:
+    return tuple(seg for seg in (path_key or "").lower().split("/") if seg)
+
+
+def infer_semantic_body_fields_from_path(path_key: str) -> dict[str, str]:
+    """
+    XHR/폼 관측이 없을 때 경로 형태만으로 placeholder 필드명을 보강한다.
+    앱별 vocabulary(게시판·주문 등)는 사용하지 않는다.
+    """
+    segments = _path_segments(path_key)
+    if not segments:
+        return {}
+
+    fields: dict[str, str] = {}
+    if segments[-1] in _POST_ACTION_SEGMENTS:
+        fields.setdefault("id", "")
+    if any(_NUMERIC_SEGMENT_RE.match(seg) for seg in segments):
+        fields.setdefault("id", "")
+    return fields
+
+
+def merge_path_inferred_fields(
+    existing: dict[str, str] | None,
+    path_key: str,
+) -> dict[str, str]:
+    """관측·DOM·XHR 필드는 유지하고, 비어 있는 키만 경로 형태 힌트로 채운다."""
+    merged = dict(existing or {})
+    for key, value in infer_semantic_body_fields_from_path(path_key).items():
+        if key not in merged or not str(merged.get(key) or "").strip():
+            merged[key] = value
+    return merged
+
+
+# --- 번들/인라인 JS에서 request body 필드명 추출 ---
+
+_FORM_DATA_APPEND_RE = re.compile(
+    r"\.append\s*\(\s*['\"`](?P<field>[a-zA-Z_][a-zA-Z0-9_]*)['\"`]\s*,",
+    re.IGNORECASE,
+)
+
+_JSON_BODY_LITERAL_RE = re.compile(
+    r"(?:\bpost|\bput|\bpatch)\s*\(\s*[^,]{0,400}?,\s*\{([^}]{0,3000})\}",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_JSON_OBJECT_KEY_RE = re.compile(
+    r"(?:['\"`](?P<qfield>[a-zA-Z_][a-zA-Z0-9_]*)['\"`]|(?P<bare>[a-zA-Z_][a-zA-Z0-9_]*))\s*:",
+)
+
+_SKIP_FIELD_NAMES = frozenset(
+    {
+        "headers",
+        "method",
+        "body",
+        "credentials",
+        "mode",
+        "cache",
+        "redirect",
+        "signal",
+        "then",
+        "catch",
+    }
+)
+
+
+def extract_body_field_names_from_script(script_text: str) -> frozenset[str]:
+    """SPA 번들에서 관측 가능한 body 필드명 집합 (사이트 무관 패턴)."""
+    if not script_text:
+        return frozenset()
+
+    names: set[str] = set()
+    for match in _FORM_DATA_APPEND_RE.finditer(script_text):
+        field = str(match.group("field") or "").strip()
+        if field and field.lower() not in _SKIP_FIELD_NAMES:
+            names.add(field)
+
+    for block in _JSON_BODY_LITERAL_RE.finditer(script_text):
+        fragment = block.group(1) or ""
+        for key_match in _JSON_OBJECT_KEY_RE.finditer(fragment):
+            field = str(key_match.group("qfield") or key_match.group("bare") or "").strip()
+            if field and field.lower() not in _SKIP_FIELD_NAMES:
+                names.add(field)
+
+    return frozenset(names)
+
+
+def extract_body_field_names_near_url_literal(
+    script_text: str,
+    url_literal: str,
+    *,
+    window: int = 1400,
+) -> frozenset[str]:
+    """
+    번들 전역이 아니라 URL 리터럴 인접 구간에서만 필드명을 추출한다.
+    (한 chunk에 여러 feature가 있어도 엔드포인트별로 분리)
+    """
+    if not script_text or not url_literal:
+        return frozenset()
+
+    needle = str(url_literal).strip()
+    if not needle:
+        return frozenset()
+
+    positions: list[int] = []
+    start = 0
+    while True:
+        idx = script_text.find(needle, start)
+        if idx < 0:
+            break
+        positions.append(idx)
+        start = idx + max(1, len(needle))
+        if len(positions) >= 6:
+            break
+
+    if not positions:
+        path_only = needle.split("?", 1)[0].rstrip("/")
+        if path_only and path_only != needle:
+            return extract_body_field_names_near_url_literal(
+                script_text, path_only, window=window
+            )
+        return frozenset()
+
+    merged: set[str] = set()
+    half = max(200, window // 2)
+    for idx in positions:
+        start = max(0, idx - half)
+        end = min(len(script_text), idx + half)
+        fn_left = script_text.rfind("function ", 0, idx)
+        if fn_left >= 0 and fn_left > start:
+            start = fn_left
+        fn_right = script_text.find("function ", idx + 1)
+        if fn_right >= 0 and fn_right < end:
+            end = fn_right
+        merged.update(extract_body_field_names_from_script(script_text[start:end]))
+    return frozenset(merged)

--- a/parsers/body_field_inference.py
+++ b/parsers/body_field_inference.py
@@ -1,4 +1,4 @@
-"""HTTP POST body 필드명 추론 — 라벨 슬러그, 경로 형태, 번들 JS 정적 추출."""
+"""HTTP POST body 필드명 추론 — 라벨·경로·JS (앱 고유 vocabulary 없음)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,10 @@ __all__ = (
     "infer_semantic_body_fields_from_path",
     "merge_path_inferred_fields",
     "slugify_field_name",
+    "looks_like_url_value",
+    "is_plausible_field_name",
+    "refine_observed_field_key",
+    "sanitize_field_map",
     "extract_body_field_names_from_script",
     "extract_body_field_names_near_url_literal",
 )
@@ -20,21 +24,143 @@ _MULTI_SEP_RE = re.compile(r"[\s-]+")
 _VALID_FIELD_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 _NUMERIC_SEGMENT_RE = re.compile(r"^\d+$|^[0-9a-f]{8,}$", re.I)
 
+# placeholder를 slugify한 흔적 (http_example_com_… 등) — 필드명으로 부적절
+_MANGLED_URL_SLUG_RE = re.compile(
+    r"(?:^https?_|^http_|_https?_|_http_|(?:^|_)www(?:_|$)|"
+    r"example[_-]?com|localhost|\.com_|\.org_|\.net_|://)",
+    re.IGNORECASE,
+)
+
+# 라벨/aria/placeholder 텍스트 → 필드명 (HTTP·폼 표준 패턴, 앱명 미사용)
+_LABEL_SEMANTIC_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"(?:external|remote|upstream|outbound|foreign|reference|resource|fetch|"
+            r"proxy|webhook|callback|redirect|open|embed|avatar|image|logo|photo|"
+            r"banner|icon|thumbnail|cover|src|href|"
+            r"외부|참조|연동|링크|이미지|가져오)"
+            r".{0,40}"
+            r"(?:url|uri|link|endpoint|주소|링크)",
+            re.IGNORECASE,
+        ),
+        "external_url",
+    ),
+    (
+        re.compile(
+            r"(?:url|uri|link|endpoint|주소|링크)"
+            r".{0,40}"
+            r"(?:external|remote|reference|fetch|proxy|webhook|callback|foreign|외부|참조)",
+            re.IGNORECASE,
+        ),
+        "external_url",
+    ),
+    (re.compile(r"^(?:url|uri|link|href|src|endpoint|destination|target)$", re.I), "url"),
+    (re.compile(r"\b(?:e-?mail|email_address)\b", re.I), "email"),
+    (re.compile(r"\b(?:phone|mobile|tel|telephone|연락|전화)\b", re.I), "phone"),
+    (re.compile(r"\b(?:password|passwd|passphrase|비밀)\b", re.I), "password"),
+    (re.compile(r"\b(?:username|user_name|login_id|아이디)\b", re.I), "username"),
+    (re.compile(r"\b(?:keyword|search_query|검색)\b", re.I), "keyword"),
+    (re.compile(r"\b(?:attachment|upload|file_name|첨부|파일)\b", re.I), "attachment"),
+    (re.compile(r"\b(?:recipient|수령)\b", re.I), "recipient"),
+    (re.compile(r"\b(?:shipping|delivery|배송).{0,20}(?:address|주소)\b", re.I), "address"),
+)
+
+_URL_VALUE_RE = re.compile(
+    r"^(?:https?://|//|ftp://|file://)[^\s]+$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_url_value(text: str) -> bool:
+    t = str(text or "").strip()
+    if not t or len(t) < 8:
+        return False
+    return bool(_URL_VALUE_RE.match(t) or "://" in t[:24])
+
 
 def slugify_field_name(text: str, *, max_len: int = 64) -> str:
     """라벨·placeholder 등을 API 필드명 형태(snake_case)로 정규화."""
     raw = str(text or "").strip()[:80]
-    if not raw:
+    if not raw or looks_like_url_value(raw):
         return ""
     slug = _MULTI_SEP_RE.sub("_", _NON_WORD_RE.sub(" ", raw.lower())).strip("_")[:max_len]
-    if slug and _VALID_FIELD_RE.match(slug):
+    if slug and _VALID_FIELD_RE.match(slug) and is_plausible_field_name(slug):
         return slug
     return ""
 
 
 def infer_field_name_from_label_text(label_text: str) -> str:
-    """폼 라벨·aria-label·placeholder → 필드명 후보 (시맨틱 추측 없음)."""
-    return slugify_field_name(label_text)
+    """폼 라벨·aria-label·placeholder → 필드명 (HTTP/폼 시맨틱 우선, slug는 보조)."""
+    text = str(label_text or "").strip()
+    if not text:
+        return ""
+    if looks_like_url_value(text):
+        return "url"
+    for pattern, field_name in _LABEL_SEMANTIC_RULES:
+        if pattern.search(text):
+            return field_name
+    return slugify_field_name(text)
+
+
+def is_plausible_field_name(name: str) -> bool:
+    """API body 키로 쓸 수 있는지 (URL placeholder slug 등 제외)."""
+    key = str(name or "").strip().lower()
+    if not key or not _VALID_FIELD_RE.match(key):
+        return False
+    if _MANGLED_URL_SLUG_RE.search(key):
+        return False
+    if len(key) > 40 and key.count("_") >= 3 and ("http" in key or "www" in key):
+        return False
+    return True
+
+
+def refine_observed_field_key(
+    key: str,
+    value: str = "",
+    *,
+    label: str = "",
+) -> str:
+    """DOM/추론 키를 정제. 네트워크 관측의 정상 키는 그대로 통과."""
+    raw_key = str(key or "").strip()
+    if not raw_key:
+        return ""
+    if is_plausible_field_name(raw_key):
+        return raw_key
+
+    hint_parts = [str(label or "").strip()]
+    if looks_like_url_value(value):
+        hint_parts.append(str(value).strip())
+    hint = " ".join(p for p in hint_parts if p).strip()
+    inferred = infer_field_name_from_label_text(hint) if hint else ""
+    if inferred and is_plausible_field_name(inferred):
+        return inferred
+    if looks_like_url_value(value) or looks_like_url_value(label):
+        return "url"
+    return ""
+
+
+def sanitize_field_map(
+    fields: dict[str, str] | None,
+    *,
+    label_hints: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """관측 필드 맵에서 비정상 키를 제거·병합하고 시맨틱 키로 대체."""
+    if not fields:
+        return {}
+    hints = label_hints or {}
+    cleaned: dict[str, str] = {}
+    for raw_key, raw_val in fields.items():
+        val = str(raw_val or "")[:500]
+        refined = refine_observed_field_key(
+            str(raw_key),
+            val,
+            label=hints.get(str(raw_key), ""),
+        )
+        if not refined:
+            continue
+        if refined not in cleaned or (not cleaned[refined] and val):
+            cleaned[refined] = val
+    return cleaned
 
 
 def _path_segments(path_key: str) -> tuple[str, ...]:
@@ -42,10 +168,7 @@ def _path_segments(path_key: str) -> tuple[str, ...]:
 
 
 def infer_semantic_body_fields_from_path(path_key: str) -> dict[str, str]:
-    """
-    XHR/폼 관측이 없을 때 경로 형태만으로 placeholder 필드명을 보강한다.
-    앱별 vocabulary(게시판·주문 등)는 사용하지 않는다.
-    """
+    """경로 형태만으로 placeholder 보강 (앱 vocabulary 없음)."""
     segments = _path_segments(path_key)
     if not segments:
         return {}
@@ -62,15 +185,14 @@ def merge_path_inferred_fields(
     existing: dict[str, str] | None,
     path_key: str,
 ) -> dict[str, str]:
-    """관측·DOM·XHR 필드는 유지하고, 비어 있는 키만 경로 형태 힌트로 채운다."""
-    merged = dict(existing or {})
+    merged = sanitize_field_map(existing)
     for key, value in infer_semantic_body_fields_from_path(path_key).items():
         if key not in merged or not str(merged.get(key) or "").strip():
             merged[key] = value
     return merged
 
 
-# --- 번들/인라인 JS에서 request body 필드명 추출 ---
+# --- JS: FormData.append / JSON body 키 ---
 
 _FORM_DATA_APPEND_RE = re.compile(
     r"\.append\s*\(\s*['\"`](?P<field>[a-zA-Z_][a-zA-Z0-9_]*)['\"`]\s*,",
@@ -102,8 +224,11 @@ _SKIP_FIELD_NAMES = frozenset(
 )
 
 
+def _filter_script_field_names(names: set[str]) -> frozenset[str]:
+    return frozenset(n for n in names if is_plausible_field_name(n))
+
+
 def extract_body_field_names_from_script(script_text: str) -> frozenset[str]:
-    """SPA 번들에서 관측 가능한 body 필드명 집합 (사이트 무관 패턴)."""
     if not script_text:
         return frozenset()
 
@@ -120,7 +245,7 @@ def extract_body_field_names_from_script(script_text: str) -> frozenset[str]:
             if field and field.lower() not in _SKIP_FIELD_NAMES:
                 names.add(field)
 
-    return frozenset(names)
+    return _filter_script_field_names(names)
 
 
 def extract_body_field_names_near_url_literal(
@@ -129,10 +254,6 @@ def extract_body_field_names_near_url_literal(
     *,
     window: int = 1400,
 ) -> frozenset[str]:
-    """
-    번들 전역이 아니라 URL 리터럴 인접 구간에서만 필드명을 추출한다.
-    (한 chunk에 여러 feature가 있어도 엔드포인트별로 분리)
-    """
     if not script_text or not url_literal:
         return frozenset()
 
@@ -162,13 +283,13 @@ def extract_body_field_names_near_url_literal(
     merged: set[str] = set()
     half = max(200, window // 2)
     for idx in positions:
-        start = max(0, idx - half)
-        end = min(len(script_text), idx + half)
+        chunk_start = max(0, idx - half)
+        chunk_end = min(len(script_text), idx + half)
         fn_left = script_text.rfind("function ", 0, idx)
-        if fn_left >= 0 and fn_left > start:
-            start = fn_left
+        if fn_left >= 0 and fn_left > chunk_start:
+            chunk_start = fn_left
         fn_right = script_text.find("function ", idx + 1)
-        if fn_right >= 0 and fn_right < end:
-            end = fn_right
-        merged.update(extract_body_field_names_from_script(script_text[start:end]))
-    return frozenset(merged)
+        if fn_right >= 0 and fn_right < chunk_end:
+            chunk_end = fn_right
+        merged.update(extract_body_field_names_from_script(script_text[chunk_start:chunk_end]))
+    return _filter_script_field_names(merged)

--- a/parsers/form_extractor.py
+++ b/parsers/form_extractor.py
@@ -31,6 +31,7 @@ class FormInfo(TypedDict):
     raw_html: str
     csrf_token: NotRequired[Optional[CSRFTokenInfo]]
     is_file_upload: NotRequired[bool]
+    file_field_names: NotRequired[List[str]]
     risk_level: NotRequired[str]
     data_content_type: NotRequired[str]
     data_orig_method: NotRequired[str]
@@ -96,6 +97,7 @@ def extract_forms(
             # 2. 파라미터 수집
             params: Dict[str, Any] = {}
             has_file_input = False
+            file_field_names: List[str] = []
 
             for el in form.find_all(['input', 'textarea', 'select', 'button']):
                 name = _get_attr_str(el, 'name').strip()
@@ -115,6 +117,7 @@ def extract_forms(
                     val = _get_attr_str(el, 'value')
                 elif el_type == 'file':
                     has_file_input = True
+                    file_field_names.append(name)
                     val = ""
                 elif el_type in ('checkbox', 'radio'):
                     if el.has_attr('checked'):
@@ -176,6 +179,7 @@ def extract_forms(
                 'raw_html': _get_limited_raw_html(form),
                 'csrf_token': csrf_info,
                 'is_file_upload': has_file_input or (enctype in UPLOAD_ENCTYPES),
+                'file_field_names': file_field_names,
                 'risk_level': risk_level
             })
 

--- a/parsers/http_method_inference.py
+++ b/parsers/http_method_inference.py
@@ -20,6 +20,8 @@ _POST_ACTION_SEGMENTS = frozenset({
     "register",
     "logout",
     "confirm",
+    "process",
+    "form",
 })
 
 _DEFAULT_PLACEHOLDER = ""
@@ -36,8 +38,6 @@ def infer_http_method_from_path(url: str) -> str:
         return "GET"
     last = segments[-1]
     if last in _POST_ACTION_SEGMENTS:
-        return "POST"
-    if len(segments) >= 2 and segments[-2] in ("checkout", "board") and last in ("form", "write"):
         return "POST"
     return "GET"
 

--- a/parsers/login_url_inference.py
+++ b/parsers/login_url_inference.py
@@ -1,0 +1,52 @@
+"""SPA/REST 로그인 URL 추론 — 페이지 라우트(/login)와 API(/api/login) 분리."""
+
+from __future__ import annotations
+
+from urllib.parse import urljoin, urlparse, urlunparse
+
+
+def iter_login_post_urls(login_url: str) -> list[str]:
+    """
+    JSON/폼 로그인 POST에 시도할 URL 후보 (중복 제거, 페이지 URL 우선).
+
+    - ``/login`` 페이지 → ``/api/login`` API (Express·Vue·React SPA 공통)
+    - 이미 ``/api/login`` 이면 그대로
+  """
+    raw = (login_url or "").strip()
+    if not raw:
+        return []
+
+    parsed = urlparse(raw)
+    if not parsed.scheme or not parsed.netloc:
+        return [raw]
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def add(url: str) -> None:
+        u = (url or "").strip()
+        if u and u not in seen:
+            seen.add(u)
+            ordered.append(u)
+
+    add(raw)
+
+    path = (parsed.path or "").rstrip("/") or "/"
+    lower = path.lower()
+
+    if lower.endswith("/login") or lower == "/login":
+        stem = path[: -len("/login")] if lower.endswith("/login") else ""
+        api_path = f"{stem}/api/login" if stem else "/api/login"
+        add(urlunparse((parsed.scheme, parsed.netloc, api_path, "", "", "")))
+
+    if "/api/" not in lower and lower not in ("/login",):
+        add(urljoin(raw, "/api/login"))
+
+    signin_variants = ("/signin", "/sign-in", "/auth/login")
+    for suffix in signin_variants:
+        if lower.endswith(suffix):
+            base = path[: -len(suffix)]
+            add(urlunparse((parsed.scheme, parsed.netloc, f"{base}/api/login", "", "", "")))
+            break
+
+    return ordered

--- a/parsers/surface_builder.py
+++ b/parsers/surface_builder.py
@@ -263,10 +263,19 @@ class SurfaceBuilder:
         if method == HttpMethod.GET:
             return ParamLocation.QUERY
 
+        if form.get("is_file_upload"):
+            return ParamLocation.BODY_FORM
+
         content_type = str(form.get("data_content_type", "")).lower()
+        if "multipart/form-data" in content_type:
+            return ParamLocation.BODY_FORM
         if _is_json_content_type(content_type):
             return ParamLocation.BODY_JSON
         if _is_form_content_type(content_type):
+            return ParamLocation.BODY_FORM
+
+        enctype = str(form.get("enctype", "")).lower()
+        if "multipart" in enctype:
             return ParamLocation.BODY_FORM
 
         has_spa_metadata = bool(form.get("data_orig_method") or content_type)
@@ -368,6 +377,14 @@ class SurfaceBuilder:
             if not response_headers and response_content_type:
                 response_headers = {"content-type": response_content_type}
 
+            request_content_type = str(form.get("data_content_type") or "").strip()
+            if form.get("is_file_upload") and not request_content_type:
+                request_content_type = "multipart/form-data"
+            raw_file_names = form.get("file_field_names") or []
+            file_field_names = tuple(
+                str(name).strip() for name in raw_file_names if str(name).strip()
+            )
+
             surfaces.append(AttackSurface(
                 url=safe_url,
                 method=method,
@@ -381,6 +398,8 @@ class SurfaceBuilder:
                 description=desc,
                 depth=depth_hint or getattr(page_data, "depth", 0) or 0,
                 content_type=response_content_type or None,
+                request_content_type=request_content_type or None,
+                file_field_names=file_field_names,
                 graphql_arg_types=gql_arg_types,
                 parameter_confidence=confidence,
             ))

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -18,7 +18,7 @@ from cli.options import parse_bf_length, parse_cookies
 from cli.runner import prepare_scan_context
 from cli.surfaces import resolve_surfaces
 from fuzzer import FuzzerEngine
-from fuzzer.auth_provider import scan_auth_lifecycle
+from fuzzer.auth_provider import merge_scan_cookies, scan_auth_lifecycle
 from fuzzer.request_builder import build_and_send_request, set_graphql_safe_mode
 from reporter import ReportGenerator
 from modules.oob.client import DEFAULT_OAST_SERVER_URL, normalize_oast_server_url
@@ -471,7 +471,8 @@ async def _run_real_scan(scan_id: str, req: ScanRequest) -> None:
             SCAN_LOG_EVERY_COMPLETED_BF_TRUE_RANDOM if bf_true_random_milestone_logs else 0
         )
 
-        async with scan_auth_lifecycle(args, base_cookies=cookies):
+        scan_cookies = merge_scan_cookies(args, surfaces)
+        async with scan_auth_lifecycle(args, base_cookies=scan_cookies, surfaces=surfaces):
             scan_task = asyncio.create_task(
                 engine.run_with_attack_modules(
                     surfaces=surfaces,


### PR DESCRIPTION
## 📌 PR 목적 (What)
SPA 동적 크롤링 이후 진행되는 퍼징 단계에서 로그인 유연성, 세션 유지 안정성, POST Body 표면의 정밀도를 향상
단일 로그인 URL에 의존하지 않고 라우트와 API를 분리해 로그인 후보를 자동 확장하며, 크롤링 단계에서 확보한 세션 쿠키를 퍼징 단계로 인계
## 🛠️ 주요 변경 사항 (How)
### 1. SPA 로그인 URL 자동 추론 및 다중 시도
#### `parsers/login_url_inference.py` 추가 - 후보 자동 확장
사용자가 입력한 --login-url을 우선하되, /login → /api/login, /signin, /sign-in, /auth/login 등의 변형을 후보로 자동 추가 (페이지 URL 우선, 중복 제거).
#### `crawler/session_manager.py`
`crawler/session_manager.py`의 login()에서 후보 URL을 순차적으로 시도(_login_once()). 경로에 /api/가 포함되어 있다면 JSON POST 방식을 우선 시도.
##### `crawler/spa/browser.py`
`crawler/spa/browser.py`에서 JSON POST 요청을 순회하며, 404/405/415 에러 시 다음 후보로 스킵. JSON 방식 실패 시 UI 폼 기반 로그인으로 안전하게 폴백
### 2. Attack Surface 쿠키 기반 퍼징 세션 연동
#### 크롤링 세션 승계
`fuzzer/auth_provider.py`에서 `collect_cookies_from_surfaces()`를 통해 크롤링 중 확보한 각 `AttackSurface`의 세션성 쿠키를 수집.
#### 로그인 실패 방어 로직
`crawl_mode=dynamic`일 때, 퍼징 단계에서의 자체 로그인이 실패하더라도 확보된 Surface 쿠키가 있다면 인증 프로바이더를 유지시켜 스캔을 강행
#### 쿠키 병합 처리
CLI의 --cookie 옵션과 Surface에서 얻은 쿠키를 병합할 때, 실제 동적 환경에서 얻은 Surface 값을 우선하도록 적용.
### 3. Mutating API Body 필드 정밀도 보강
#### `crawler/spa/dom_form_capture.py`  추가 - DOM 기반 필드 수집
라우트 방문 시 화면에 보이는 input, textarea, select에서 name, id, data-*, 라벨, placeholder, type 힌트(예: tel → phone)를 추출하여 해당 라우트 관련 API의 Body 힌트로 등록.
#### `parsers/body_field_inference.py` 추가 - JS 및 URL 경로 추론 
번들 JS에서 FormData.append나 post({...}) 주변의 필드명을 추출하고, 동적 경로 세그먼트(예: 숫자 ID)에서 id 파라미터를 추론하여 보강.
#### `crawler/spa/path_family.py` 추가 - 리소스 Family 단위 병합:
전역 오염 방지를 위해 /api/checkout과 /api/board 등 리소스 트리 단위로만 Body 샘플을 공유
confirm/process 등 형제(sibling) API 경로 간에 관측된 필드를 안전하게 병합
#### 액션 세그먼트 인지
HTTP 메서드 추론기(parsers/http_method_inference.py)에 confirm, process, form 등을 POST 액션 키워드로 추가하여 누락되는 엔드포인트 방지.
## 💡 리뷰어 참고 사항
수정 후 공격 모듈 테스트 결과
sqli, osci, lfi, reflected_xss 테스트 성공
ssrf, stroed_xss, fil_upload 수정 필요
## ✅ 다음 작업 (Next Step)
- [ ] stored_xss 모듈 수정
