### PR TITLE
[feat] OOB 모듈을 CLI로 실행 시 증거 회수를 위한 폴링 추가

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import os
+import aiohttp
 
 from cli.output import print_scan_configuration, progress_printer
-from fuzzer import FuzzerEngine
+from fuzzer import FuzzerEngine, Finding
 from fuzzer.auth_provider import merge_scan_cookies, scan_auth_lifecycle
-from fuzzer.request_builder import build_and_send_request
+from fuzzer.request_builder import build_and_send_request, FuzzerResponse
 from fuzzer.setup import count_module_payloads, estimate_total_requests, select_modules
 from reporter import ReportGenerator
-
+from core.models import Payload 
 
 def prepare_scan_context(args, surfaces):
     if args.type == "stored_xss":
@@ -47,6 +48,89 @@ def prepare_scan_context(args, surfaces):
         "queue_workers": queue_workers,
         "total_requests": total_requests,
     }
+
+async def poll_oob_results(modules: list, oob_domain: str) -> list[Finding]:
+    """
+    모든 스캔이 종료된 후, OOB 모듈들이 발급했던 토큰을 모아
+    콜백 서버에 결과를 폴링. (URL Too Long 방지를 위해 청크 분할 전송)
+    """
+    oob_findings = []
+    
+    # 1. 모든 OOB 모듈에서 생성했던 CLI용 토큰들을 수집
+    tokens_to_poll = []
+    token_map = {}
+    for module in modules:
+        if hasattr(module, "generated_tokens") and module.generated_tokens:
+            for item in module.generated_tokens:
+                tokens_to_poll.append(item["token"])
+                token_map[item["token"]] = item
+
+    if not tokens_to_poll:
+        return oob_findings
+
+    print("\n[*] Waiting 10 seconds for delayed OOB callbacks...")
+    await asyncio.sleep(10.0)
+    
+    # 콜백 서버 폴링 API 주소
+    api_url = f"http://{oob_domain}:8001/api/poll"
+    
+    # URL Too Long (414/400) 에러를 막기 위해 최대 500개씩 청크 분할
+    CHUNK_SIZE = 500
+    token_chunks = [tokens_to_poll[i:i + CHUNK_SIZE] for i in range(0, len(tokens_to_poll), CHUNK_SIZE)]
+    
+    try:
+        async with aiohttp.ClientSession() as session:
+            for i, chunk in enumerate(token_chunks):
+                # 2. API 호출 (청크 단위로 발송)
+                params = {"tokens": ",".join(chunk)}
+                
+                async with session.get(api_url, params=params, timeout=10.0) as res:
+                    if res.status == 200:
+                        data = await res.json()
+                        hits = data.get("hits", [])
+                        
+                        # 3. 받아온 결과를 스캐너의 Finding 객체로 변환
+                        for hit in hits:
+                            hit_token = hit.get("token")
+                            if hit_token in token_map:
+                                matched_info = token_map[hit_token]
+                                target_url = matched_info.get("target", {}).get("url", "Unknown URL")
+                                param_name = matched_info.get("target", {}).get("parameter", "Unknown")
+                                protocol = hit.get("protocol", "Unknown")
+                                client_ip = hit.get("source_ip", "Unknown")
+                                
+                                print(f"[+] [OOB Hit] Vulnerability Verified on {target_url} (Param: {param_name}) via {protocol}")
+                                dummy_response = FuzzerResponse(
+                                    status=0, text="", headers={}, elapsed_time=0.0, url=target_url, error="OOB Callback (No Response)"
+                                )
+
+                                attack_info = matched_info.get("attack_info", {})
+
+                                reconstructed_payload = Payload(
+                                    value=attack_info.get("payload_value", ""),
+                                    attack_type=attack_info.get("type", "OOB"),
+                                    risk_level=attack_info.get("risk_level", "High")
+                                )
+
+                                oob_findings.append(Finding(
+                                    surface=matched_info["surface_obj"],
+                                    parameter=param_name,
+                                    payload=reconstructed_payload,
+                                    response=dummy_response,
+                                    module_name=matched_info.get("module_name", "OOB Module"),
+                                    evidences=[f"[Verified] OOB Execution detected via {protocol} from Target IP: {client_ip}"]
+                                ))
+                    else:
+                        print(f"[-] OOB Polling failed for chunk {i+1} with status {res.status}")
+                        
+                # 서버 부하 방지를 위해 청크 간 짧은 대기
+                if i < len(token_chunks) - 1:
+                    await asyncio.sleep(0.5)
+
+    except Exception as e:
+        print(f"[-] OOB Polling Network Error: {e}")
+        
+    return oob_findings
 
 
 async def run_scan(args, *, base_url: str, surfaces) -> None:
@@ -105,7 +189,17 @@ async def run_scan(args, *, base_url: str, surfaces) -> None:
         stats = await scan_task
         await progress_task
 
-    reporter = ReportGenerator(stats=stats, findings=engine.findings)
+    # 스캔 완료 직후 리포트 생성 전에 OOB 폴링 수행
+    oob_domain = getattr(args, "oob_domain", "oob.snowden.kr")
+    oob_findings = await poll_oob_results(context["modules"], oob_domain)
+
+    final_findings = engine.findings
+    
+    if oob_findings:
+        final_findings.extend(oob_findings)
+        stats.findings += len(oob_findings)
+
+    reporter = ReportGenerator(stats=stats, findings=final_findings)
     reporter.print_cli_report()
     reporter.export_to_json(args.output)
 

--- a/cli/runner.py
+++ b/cli/runner.py
@@ -52,7 +52,7 @@ def prepare_scan_context(args, surfaces):
 async def poll_oob_results(modules: list, oob_domain: str) -> list[Finding]:
     """
     모든 스캔이 종료된 후, OOB 모듈들이 발급했던 토큰을 모아
-    콜백 서버에 결과를 폴링. (URL Too Long 방지를 위해 청크 분할 전송)
+    콜백 서버에 결과를 폴링. (URL Too Long 방지 청크 분할 및 네트워크 재시도 적용)
     """
     oob_findings = []
     
@@ -77,58 +77,71 @@ async def poll_oob_results(modules: list, oob_domain: str) -> list[Finding]:
     # URL Too Long (414/400) 에러를 막기 위해 최대 500개씩 청크 분할
     CHUNK_SIZE = 500
     token_chunks = [tokens_to_poll[i:i + CHUNK_SIZE] for i in range(0, len(tokens_to_poll), CHUNK_SIZE)]
+    max_retries = 3
     
-    try:
-        async with aiohttp.ClientSession() as session:
-            for i, chunk in enumerate(token_chunks):
-                # 2. API 호출 (청크 단위로 발송)
-                params = {"tokens": ",".join(chunk)}
+    async with aiohttp.ClientSession() as session:
+        for i, chunk in enumerate(token_chunks):
+            params = {"tokens": ",".join(chunk)}
+            chunk_success = False
+            
+            # 네트워크 에러 및 타임아웃 방어용 재시도 루프
+            for attempt in range(1, max_retries + 1):
+                try:
+                    async with session.get(api_url, params=params, timeout=10.0) as res:
+                        if res.status == 200:
+                            data = await res.json()
+                            hits = data.get("hits", [])
+                            
+                            # 3. 받아온 결과를 스캐너의 Finding 객체로 변환
+                            for hit in hits:
+                                hit_token = hit.get("token")
+                                if hit_token in token_map:
+                                    matched_info = token_map[hit_token]
+                                    target_url = matched_info.get("target", {}).get("url", "Unknown URL")
+                                    param_name = matched_info.get("target", {}).get("parameter", "Unknown")
+                                    protocol = hit.get("protocol", "Unknown")
+                                    client_ip = hit.get("source_ip", "Unknown")
+                                    
+                                    dummy_response = FuzzerResponse(
+                                        status=0, text="", headers={}, elapsed_time=0.0, url=target_url, error="OOB Callback (No Response)"
+                                    )
+
+                                    attack_info = matched_info.get("attack_info", {})
+
+                                    reconstructed_payload = Payload(
+                                        value=attack_info.get("payload_value", ""),
+                                        attack_type=attack_info.get("type", "OOB"),
+                                        risk_level=attack_info.get("risk_level", "High")
+                                    )
+
+                                    oob_findings.append(Finding(
+                                        surface=matched_info["surface_obj"],
+                                        parameter=param_name,
+                                        payload=reconstructed_payload,
+                                        response=dummy_response,
+                                        module_name=matched_info.get("module_name", "OOB Module"),
+                                        evidences=[f"[Verified] OOB Execution detected via {protocol} from Target IP: {client_ip}"]
+                                    ))
+                            
+                            chunk_success = True
+                            break
+                        else:
+                            print(f"[-] OOB Polling failed for chunk {i+1} with status {res.status}. Attempt {attempt}/{max_retries}")
+                            
+                except Exception as e:
+                    print(f"[-] OOB Polling Network Error for chunk {i+1}: {e}. Attempt {attempt}/{max_retries}")
                 
-                async with session.get(api_url, params=params, timeout=10.0) as res:
-                    if res.status == 200:
-                        data = await res.json()
-                        hits = data.get("hits", [])
-                        
-                        # 3. 받아온 결과를 스캐너의 Finding 객체로 변환
-                        for hit in hits:
-                            hit_token = hit.get("token")
-                            if hit_token in token_map:
-                                matched_info = token_map[hit_token]
-                                target_url = matched_info.get("target", {}).get("url", "Unknown URL")
-                                param_name = matched_info.get("target", {}).get("parameter", "Unknown")
-                                protocol = hit.get("protocol", "Unknown")
-                                client_ip = hit.get("source_ip", "Unknown")
-                                
-                                dummy_response = FuzzerResponse(
-                                    status=0, text="", headers={}, elapsed_time=0.0, url=target_url, error="OOB Callback (No Response)"
-                                )
-
-                                attack_info = matched_info.get("attack_info", {})
-
-                                reconstructed_payload = Payload(
-                                    value=attack_info.get("payload_value", ""),
-                                    attack_type=attack_info.get("type", "OOB"),
-                                    risk_level=attack_info.get("risk_level", "High")
-                                )
-
-                                oob_findings.append(Finding(
-                                    surface=matched_info["surface_obj"],
-                                    parameter=param_name,
-                                    payload=reconstructed_payload,
-                                    response=dummy_response,
-                                    module_name=matched_info.get("module_name", "OOB Module"),
-                                    evidences=[f"[Verified] OOB Execution detected via {protocol} from Target IP: {client_ip}"]
-                                ))
-                    else:
-                        print(f"[-] OOB Polling failed for chunk {i+1} with status {res.status}")
-                        
-                # 서버 부하 방지를 위해 청크 간 짧은 대기
-                if i < len(token_chunks) - 1:
-                    await asyncio.sleep(0.5)
-
-    except Exception as e:
-        print(f"[-] OOB Polling Network Error: {e}")
-        
+                # 실패 시 2초 대기 후 재시도
+                if attempt < max_retries:
+                    await asyncio.sleep(2.0)
+            
+            if not chunk_success:
+                print(f"[-] OOB Polling completely failed for chunk {i+1} after {max_retries} attempts. Some findings might be lost.")
+                    
+            # 서버 부하 방지를 위해 청크 간 짧은 대기 (마지막 청크 제외)
+            if i < len(token_chunks) - 1:
+                await asyncio.sleep(0.5)
+                
     return oob_findings
 
 

--- a/cli/runner.py
+++ b/cli/runner.py
@@ -99,7 +99,6 @@ async def poll_oob_results(modules: list, oob_domain: str) -> list[Finding]:
                                 protocol = hit.get("protocol", "Unknown")
                                 client_ip = hit.get("source_ip", "Unknown")
                                 
-                                print(f"[+] [OOB Hit] Vulnerability Verified on {target_url} (Param: {param_name}) via {protocol}")
                                 dummy_response = FuzzerResponse(
                                     status=0, text="", headers={}, elapsed_time=0.0, url=target_url, error="OOB Callback (No Response)"
                                 )

--- a/fuzzer/setup.py
+++ b/fuzzer/setup.py
@@ -16,10 +16,15 @@ from modules.oob.module import OOBModule
 from modules.oob_osci.module import OOB_OSCiModule
 from modules.oob_sqli.module import OOB_SQLiModule
 
+import os
+
 def select_modules(args) -> list:
     selected = []
 
     current_scan_id = getattr(args, "scan_id", "ERROR_SCAN_ID_NOT_PASSED")
+
+    is_saas_mode = os.getenv("CELERY_WORKER") == "1"
+    current_oob_mode = "webhook" if is_saas_mode else "polling"
 
     if args.type in ("sqli", "all"):
         sqli_module = SQLiModule(
@@ -37,6 +42,7 @@ def select_modules(args) -> list:
             scan_id=current_scan_id,
             oob_domain=getattr(args, "oob_domain", "oob.snowden.kr"),
             redis_url=getattr(args, "redis_url", "redis://localhost:6379/0"),
+            oob_mode=current_oob_mode
         )
         selected.append(oob_sqli_module)
 
@@ -56,6 +62,7 @@ def select_modules(args) -> list:
             scan_id=current_scan_id,
             oob_domain=getattr(args, "oob_domain", "oob.snowden.kr"),
             redis_url=getattr(args, "redis_url", "redis://localhost:6379/0"),
+            oob_mode=current_oob_mode
         )
         selected.append(oob_osci_module)
 

--- a/modules/base_oob_module.py
+++ b/modules/base_oob_module.py
@@ -24,6 +24,12 @@ class BaseOOBModule(BaseModule):
         # Scan ID 저장
         self.scan_id = kwargs.get("scan_id", "UNKNOWN_SCAN_ID")
         
+        # 자동으로 감지된 모드
+        self.oob_mode = kwargs.get("oob_mode", "polling").lower()
+        
+        # CLI(polling) 모드일 때 토큰과 타겟 매핑 정보를 저장할 리스트
+        self.generated_tokens = []
+
         # Redis 커넥션 풀 (지연 할당)
         self._redis = None
 
@@ -37,9 +43,13 @@ class BaseOOBModule(BaseModule):
         """
         엔진 훅: 워커가 HTTP 요청을 보내기 직전에 호출.
         """
-        # 1. 8자리 고유 토큰 생성
-        token = uuid.uuid4().hex[:8]
-        
+        # 1. 1바이트 Prefix 포함한 9바이트 토큰 생성
+        raw_token = uuid.uuid4().hex[:8]
+        if self.oob_mode == "webhook":
+            token = f"w{raw_token}"  # SaaS 모드: w (웹훅)
+        else:
+            token = f"c{raw_token}"  # CLI 모드: c (폴링)
+            
         # 실제 타겟에 주입될 도메인
         oob_host = f"{token}.{self.oob_domain}"
         
@@ -49,9 +59,8 @@ class BaseOOBModule(BaseModule):
         method_raw = getattr(surface, "method", "GET")
         method_str = getattr(method_raw, "value", str(method_raw))
         
-        # 2. 메인 스캐너의 Webhook 리시버가 참조할 수 있도록 Redis에 매핑 데이터 저장
-        r = await self._get_redis()
         meta_data = {
+            "token": token,  # 메모리 대조를 위해 토큰값 포함
             "scan_id": self.scan_id,
             "module_name": self.name,
             "target": {
@@ -67,8 +76,16 @@ class BaseOOBModule(BaseModule):
             }
         }
         
-        # 토큰을 키로 하여 TTL(24시간)과 함께 저장 (Fire & Forget)
-        await r.setex(f"oob_map:{token}", self.oob_ttl, json.dumps(meta_data))
+        # 2. 모드에 따른 매핑 데이터 분기 저장
+        if self.oob_mode == "webhook":
+            # SaaS: 메인 서버 Celery가 처리할 수 있도록 Redis에 저장
+            r = await self._get_redis()
+            await r.setex(f"oob_map:{token}", self.oob_ttl, json.dumps(meta_data))
+        else:
+            # CLI: Redis 없이 메모리에만 저장
+            memory_data = meta_data.copy()
+            memory_data["surface_obj"] = surface
+            self.generated_tokens.append(memory_data)
 
         # 3. Payload 객체의 value 치환 후 복제본 반환
         new_value = payload.value.replace("[OOB_HOST]", oob_host)


### PR DESCRIPTION
## 📌 PR 목적 (What)
- CI/CD 파이프라인(CLI 단독 실행) 환경 지원을 위한 OOB Two-Track 아키텍처 도입 및 폴링 시스템 구축.
- SaaS 환경(Redis/Webhook)과 CLI 환경(Memory/Polling)을 자동 감지하여 OOM 방지.

## 🛠️ 주요 변경 사항 (How)
-  fuzzer/setup.py
   - CELERY_WORKER 환경 변수를 통해 스캐너가 현재 SaaS 모드인지 CLI 모드인지 감지
- module/base_oob_module.py
  - 토큰 Prefix 라우팅: 구동 모드에 따라 토큰 앞에 w(Webhook/SaaS) 또는 c(CLI/Polling) 추가.
  - 저장소 분기: SaaS 모드일 경우 기존처럼 Redis에 매핑 정보를 저장하고, CLI 모드일 경우 Redis 의존성 없이 내부 메모리에 저장하도록 분리.
- cli/runner.py
  - poll_oob_results: 모든 페이로드 발송이 완료된 후, OOB 콜백 지연 시간을 고려하여 일정 시간 대기.
  - 대기 후 콜백 서버의 /api/poll 을 호출하여 수신된 증거를 회수.
  - 회수된 데이터를 Finding 객체로 변환하여 리포트에 병합.

## 🧪 테스트 결과 (Testing & Verification)
- CLI 모드 실행 시 Redis 연결 시도를 하지 않고 내부 메모리에 c 접두사가 붙은 토큰이 정상 저장됨을 확인.
- 스캔 100% 완료 후 10초간 정상적으로 대기하며, 이후 폴링 API를 통해 회수한 취약점이 리포트에 추가됨을 확인.

## ✅ 다음 작업 (Next Step)
- [ ] CI/CD 파이프라인 구현