### PR TITLE
[feat] spa 환경에서 modules 취약점 탐지를 위한 2차 검증 로직 개선

### DIFF
--- a/crawler/spa/dom_form_capture.py
+++ b/crawler/spa/dom_form_capture.py
@@ -67,6 +67,29 @@ _COLLECT_FORM_FIELDS_JS = """() => {
         if (parentLabel && parentLabel.innerText) return parentLabel.innerText.trim();
         const aria = (el.getAttribute('aria-label') || '').trim();
         if (aria) return aria;
+        // React/Vue 등: <label>텍스트</label><input> 형태의 형제 라벨
+        let prev = el.previousElementSibling;
+        if (prev && prev.tagName === 'LABEL' && prev.innerText) {
+            return prev.innerText.trim();
+        }
+        // 같은 field-group 컨테이너 안의 첫 label (div > label + input 패턴)
+        const group = el.closest('div, fieldset, section, li, p');
+        if (group) {
+            const labels = group.querySelectorAll(':scope > label');
+            if (labels.length === 1 && labels[0].innerText) {
+                return labels[0].innerText.trim();
+            }
+            for (const lbl of labels) {
+                if (!lbl.innerText) continue;
+                let node = lbl.nextElementSibling;
+                while (node) {
+                    if (node === el || node.contains(el)) {
+                        return lbl.innerText.trim();
+                    }
+                    node = node.nextElementSibling;
+                }
+            }
+        }
         return '';
     }
 
@@ -86,16 +109,18 @@ _COLLECT_FORM_FIELDS_JS = """() => {
             if (fromData) return fromData;
         }
 
-        const type = (el.getAttribute('type') || 'text').toLowerCase();
-        const typeHints = { email: 'email', password: 'password', search: 'q', tel: 'phone', url: 'url' };
-        if (typeHints[type]) return typeHints[type];
-
         const label = labelTextForControl(el);
         const placeholder = (el.getAttribute('placeholder') || '').trim();
         const fromLabel = inferFromSemanticLabel(label);
         if (fromLabel) return fromLabel;
+
+        const type = (el.getAttribute('type') || 'text').toLowerCase();
+        const typeHints = { email: 'email', password: 'password', search: 'q', tel: 'phone', url: 'url' };
+        if (typeHints[type]) return typeHints[type];
+
+        // placeholder의 예시 URL(http://…)은 필드명이 아님 — 라벨 slug만 사용
         if (looksLikeUrl(placeholder)) {
-            return fromLabel || 'url';
+            return slugify(label) || '';
         }
         return slugify(label) || slugify(placeholder);
     }
@@ -152,22 +177,27 @@ def _normalize_dom_capture(raw: object) -> tuple[dict[str, str], dict[str, str]]
     return sanitize_field_map(values, label_hints=label_hints), label_hints
 
 
-async def extract_visible_form_fields(page) -> dict[str, str]:
+async def extract_visible_form_fields(page) -> tuple[dict[str, str], dict[str, str]]:
     try:
         raw = await page.evaluate(_COLLECT_FORM_FIELDS_JS)
     except Exception as exc:
         logger.debug("[SPA Crawler] DOM form field capture failed: %s", exc)
-        return {}
-    fields, _ = _normalize_dom_capture(raw)
-    return fields
+        return {}, {}
+    return _normalize_dom_capture(raw)
 
 
-def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]) -> int:
+def register_dom_fields_for_route(
+    engine,
+    route_url: str,
+    fields: dict[str, str],
+    *,
+    label_hints: dict[str, str] | None = None,
+) -> int:
     """
     현재 클라이언트 라우트의 input/textarea name을 관련 API path_key에 병합.
     React controlled form은 XHR 전까지 body 샘플이 비는 경우가 많다.
     """
-    fields = sanitize_field_map(fields)
+    fields = sanitize_field_map(fields, label_hints=label_hints)
     if not fields:
         return 0
 
@@ -193,7 +223,7 @@ def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]
             if key_str not in bucket or not str(bucket.get(key_str) or "").strip():
                 bucket[key_str] = str(value)
         if len(bucket) > before or (before == 0 and bucket):
-            samples_map[path_key] = sanitize_field_map(bucket)
+            samples_map[path_key] = sanitize_field_map(bucket, label_hints=label_hints)
             updated += 1
         register_observed_body_field_hints(engine, path_key, fields.keys())
 
@@ -226,11 +256,11 @@ def register_dom_fields_for_route(engine, route_url: str, fields: dict[str, str]
 
 
 async def capture_and_register_dom_fields(engine, page) -> None:
-    fields = await extract_visible_form_fields(page)
+    fields, label_hints = await extract_visible_form_fields(page)
     if not fields:
         return
     route_url = str(getattr(page, "url", "") or getattr(engine, "current_route_url", "") or "")
-    count = register_dom_fields_for_route(engine, route_url, fields)
+    count = register_dom_fields_for_route(engine, route_url, fields, label_hints=label_hints)
     if count:
         logger.debug(
             "[SPA Crawler] DOM form fields (%s keys) linked to %s API path(s) on %s",

--- a/crawler/spa/engine.py
+++ b/crawler/spa/engine.py
@@ -332,14 +332,13 @@ class SPACrawlerEngine:
                     self.route_depths[self.target_url] = 0
                     await wait_for_page_settle(page, context_label="base route load")
                     await capture_and_register_dom_fields(self, page)
+                    try:
+                        await seed_api_candidates_from_scripts(self, page, context)
+                    except Exception as exc:
+                        logger.debug("[SPA Crawler] JS endpoint seeding failed on base route: %s", exc)
                     final_html = await page.content()
                 except Exception as e:
                     logger.debug("[SPA Crawler] Load timeout on base url: %s", e)
-
-                try:
-                    await seed_api_candidates_from_scripts(self, page, context)
-                except Exception as exc:
-                    logger.debug("[SPA Crawler] JS endpoint seeding failed: %s", exc)
 
                 await interact_and_submit(self, page)
                 await interact_and_submit(self, page)
@@ -396,6 +395,14 @@ class SPACrawlerEngine:
                         )
                         await wait_for_page_settle(page, context_label=f"route load:{route}")
                         await capture_and_register_dom_fields(self, page)
+                        try:
+                            await seed_api_candidates_from_scripts(self, page, context)
+                        except Exception as exc:
+                            logger.debug(
+                                "[SPA Crawler] JS endpoint seeding failed on %s: %s",
+                                route,
+                                exc,
+                            )
                         await interact_and_submit(self, page)
                         await interact_and_submit(self, page)
                         await sync_storage_from_browser(self, page)

--- a/crawler/spa/js_analyzer.py
+++ b/crawler/spa/js_analyzer.py
@@ -329,6 +329,23 @@ async def _fetch_script_text(context, script_url: str, timeout_ms: int) -> str:
     return body.decode("utf-8", errors="ignore")
 
 
+def _scanned_js_script_urls(engine) -> set[str]:
+    scanned = getattr(engine, "_js_scanned_script_urls", None)
+    if scanned is None:
+        engine._js_scanned_script_urls = set()
+        scanned = engine._js_scanned_script_urls
+    return scanned
+
+
+def _resolve_endpoint_path_key(base_url: str, endpoint_url: str) -> str:
+    """절대/상대 API 경로를 path_key로 정규화 (번들 URL 기준 join 오류 방지)."""
+    raw = str(endpoint_url or "").strip()
+    if raw.startswith(("http://", "https://", "//")):
+        return path_key_from_url(raw)
+    joined = urljoin(base_url, raw)
+    return path_key_from_url(joined)
+
+
 async def seed_api_candidates_from_scripts(engine, page, context) -> int:
     try:
         html_text = await page.content()
@@ -338,6 +355,7 @@ async def seed_api_candidates_from_scripts(engine, page, context) -> int:
 
     page_url = page.url or getattr(engine, "target_url", "")
     script_urls, inline_scripts = _extract_scripts_from_html(html_text, page_url)
+    scanned_scripts = _scanned_js_script_urls(engine)
     added = 0
 
     for base_url, script_text in inline_scripts:
@@ -359,13 +377,15 @@ async def seed_api_candidates_from_scripts(engine, page, context) -> int:
                 if near_fields:
                     register_observed_body_field_hints(
                         engine,
-                        path_key_from_url(urljoin(base_url, endpoint_url)),
+                        _resolve_endpoint_path_key(base_url, endpoint_url),
                         near_fields,
                     )
         engine.metrics["js_scripts_scanned"] += 1
 
     timeout_ms = int(getattr(engine, "route_timeout", 5000) or 5000)
     for script_url in script_urls:
+        if script_url in scanned_scripts:
+            continue
         if not is_in_scope(engine, script_url):
             continue
         try:
@@ -375,6 +395,7 @@ async def seed_api_candidates_from_scripts(engine, page, context) -> int:
             continue
         if not script_text:
             continue
+        scanned_scripts.add(script_url)
         for method, endpoint_url, content_type in _extract_from_script_text(script_text, base_url=script_url):
             if not is_in_scope(engine, endpoint_url):
                 continue
@@ -393,7 +414,7 @@ async def seed_api_candidates_from_scripts(engine, page, context) -> int:
                 if near_fields:
                     register_observed_body_field_hints(
                         engine,
-                        path_key_from_url(urljoin(script_url, endpoint_url)),
+                        _resolve_endpoint_path_key(page_url, endpoint_url),
                         near_fields,
                     )
         engine.metrics["js_scripts_scanned"] += 1

--- a/fuzzer/engine.py
+++ b/fuzzer/engine.py
@@ -549,13 +549,17 @@ class FuzzerEngine:
                         allow_redirects=allow_redir,
                     )
 
-            verdict = module.analyze(
-                response=response,
-                payload=payload,
-                elapsed_time=elapsed_time,
-                original_res=baseline_response,
-                requester=module_requester
-            )
+            analyze_kwargs = {
+                "response": response,
+                "payload": payload,
+                "elapsed_time": elapsed_time,
+                "original_res": baseline_response,
+                "requester": module_requester,
+            }
+            try:
+                verdict = module.analyze(**analyze_kwargs, surface=surface)
+            except TypeError:
+                verdict = module.analyze(**analyze_kwargs)
 
             if isawaitable(verdict):
                 verdict = await verdict

--- a/modules/file_upload/analyzer.py
+++ b/modules/file_upload/analyzer.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
 import re
 
 from modules.file_upload.payloads import FilePayload
+from modules.stored_xss.analyzer import (
+    _redirect_implies_auth_failure,
+    looks_like_successful_store_api_response,
+)
 
 SUCCESS_SIGNATURES = [
     r"succes+fully uploaded",
@@ -29,6 +34,74 @@ def _response_indicates_upload_failure(res_lower: str) -> bool:
     return any(phrase in res_lower for phrase in ERROR_PHRASES)
 
 
+_JSON_UPLOAD_PATH_KEYS = frozenset(
+    {
+        "url",
+        "path",
+        "file",
+        "filename",
+        "fileurl",
+        "file_url",
+        "filepath",
+        "file_path",
+        "attachment",
+        "attachment_url",
+        "location",
+        "src",
+        "href",
+        "download",
+        "link",
+        "redirect",
+    }
+)
+
+_LISTING_PAGE_HINTS = (
+    "board-table",
+    "/view?id=",
+    "/view/",
+    "/detail?",
+    "/detail/",
+    "/posts/",
+    "/articles/",
+)
+
+
+def _json_indicates_upload_success(body: str, filename: str) -> tuple[bool, list[str]]:
+    """SPA/REST mutation 응답(JSON)에서 업로드 성공 신호 추출."""
+    text = (body or "").strip()
+    if not text.startswith("{"):
+        return False, []
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return False, []
+    if not isinstance(data, dict):
+        return False, []
+
+    evidences: list[str] = []
+    if data.get("error"):
+        return False, evidences
+
+    filename_lower = filename.lower()
+    basename = filename_lower.rsplit("/", 1)[-1]
+
+    for key, value in data.items():
+        key_lower = str(key).lower()
+        if key_lower in _JSON_UPLOAD_PATH_KEYS and isinstance(value, str) and value.strip():
+            value_lower = value.lower()
+            if "upload" in value_lower or basename in value_lower:
+                evidences.append(f"[JsonUploadPath] {key}={value[:120]}")
+
+    redirect = data.get("redirect")
+    if redirect and not _redirect_implies_auth_failure(str(redirect)):
+        evidences.append(f"[JsonRedirect] {redirect}")
+
+    if data.get("success") is True or data.get("ok") is True:
+        evidences.append("[JsonSuccessFlag] mutation accepted")
+
+    return (len(evidences) > 0), evidences
+
+
 def detect_file_upload(response, payload) -> tuple[bool, list[str]]:
     """
     Stage-1: probable upload success (WAF bypass / storage), before active verification.
@@ -44,10 +117,16 @@ def detect_file_upload(response, payload) -> tuple[bool, list[str]]:
         return False, evidences
 
     response_url = str(getattr(response, "url", "") or "").lower()
-    if "/board" in response_url and (
-        "board-table" in res_lower or "/board/view?id=" in res_lower
-    ):
-        evidences.append(f"[BoardRedirect] post-submit listing ({response_url})")
+
+    if looks_like_successful_store_api_response(response, res_text):
+        evidences.append("[StoreApiSuccess] mutation accepted (JSON)")
+
+    json_hit, json_evidences = _json_indicates_upload_success(res_text, payload.filename)
+    if json_hit:
+        evidences.extend(json_evidences)
+
+    if any(hint in res_lower for hint in _LISTING_PAGE_HINTS):
+        evidences.append(f"[ListingRedirect] post-submit listing ({response_url})")
 
     for pattern in SUCCESS_SIGNATURES:
         if re.search(pattern, res_lower, re.IGNORECASE):

--- a/modules/file_upload/markers.py
+++ b/modules/file_upload/markers.py
@@ -11,6 +11,12 @@ VERIFY_RCE = "rce"
 VERIFY_STATIC = "static"
 VERIFY_TEMPLATE = "template"
 
+# 2차 검증 결과 분류 
+CATEGORY_STATIC_MALICIOUS_FILE = "static_malicious_file"
+CATEGORY_UNRESTRICTED_UPLOAD = "unrestricted_upload"
+CATEGORY_RCE = "rce"
+CATEGORY_TEMPLATE_RCE = "template_rce"
+
 # If any of these appear alongside the marker, the response is source — not execution.
 PHP_SHELL_TAGS = ("<?php", "<?=", "<?", "&lt;?php", "&lt;?=")
 NODE_TEMPLATE_TAGS = ("<%=", "<%", "&lt;%=", "&lt;%")

--- a/modules/file_upload/module.py
+++ b/modules/file_upload/module.py
@@ -8,7 +8,11 @@ from modules.file_upload.form_helpers import select_upload_target_parameters
 from modules.file_upload.markers import VERIFY_TEMPLATE
 from modules.file_upload.payloads import FilePayload, get_file_upload_payloads
 from modules.file_upload.path_discovery import discover_verify_urls
-from modules.file_upload.verifier import build_verify_url_list, verify_upload_response
+from modules.file_upload.verifier import (
+    build_verify_url_list,
+    is_direct_upload_file_url,
+    verify_upload_response,
+)
 
 
 class FileUploadModule(BaseModule):
@@ -45,7 +49,7 @@ class FileUploadModule(BaseModule):
         """
         Stage-2 active verification:
         - RCE: marker present, interpreter tags stripped (PHP/JSP/…)
-        - Static: malicious content served verbatim (Stored XSS on static hosts)
+        - Static: malicious file content served verbatim from upload URL
         - Template: marker rendered on app routes (Node EJS overwrite)
         """
         if not isinstance(payload, FilePayload):
@@ -68,6 +72,8 @@ class FileUploadModule(BaseModule):
             payload=payload,
             headers=headers,
             cookies=cookies,
+            surface=surface,
+            upload_response=response,
         )
 
         if not verify_urls and (payload.verify_mode or "").lower() == VERIFY_TEMPLATE:
@@ -95,7 +101,8 @@ class FileUploadModule(BaseModule):
             except Exception:
                 continue
 
-            result = verify_upload_response(body, payload)
+            direct_file = is_direct_upload_file_url(verify_url, payload.filename)
+            result = verify_upload_response(body, payload, direct_file=direct_file)
             if result.verified:
                 return True
 

--- a/modules/file_upload/path_discovery.py
+++ b/modules/file_upload/path_discovery.py
@@ -341,6 +341,62 @@ async def _fetch_text(
         return None
 
 
+class _UploadInjectionResponse:
+    """stored_xss verify_urls.collect_verify_candidate_urls용 응답 shim."""
+
+    def __init__(
+        self,
+        *,
+        url: str = "",
+        text: str = "",
+        headers: dict[str, Any] | None = None,
+    ) -> None:
+        self.url = url
+        self.text = text
+        self.headers = headers or {}
+
+
+class _UploadSurfaceShim:
+    """collect_verify_candidate_urls에 넘길 최소 surface."""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        source_url: str | None = None,
+        headers: dict[str, Any] | None = None,
+        request_content_type: str | None = None,
+        content_type: str | None = None,
+    ) -> None:
+        self.url = url
+        self.source_url = source_url
+        self.headers = headers or {}
+        self.request_content_type = request_content_type
+        self.content_type = content_type
+
+
+def _surface_shim_from_upload(
+    *,
+    surface: Any | None,
+    surface_url: str,
+    source_url: str | None,
+    headers: dict[str, Any] | None,
+) -> _UploadSurfaceShim:
+    if surface is not None:
+        return _UploadSurfaceShim(
+            url=str(getattr(surface, "url", "") or surface_url),
+            source_url=str(getattr(surface, "source_url", "") or "") or source_url,
+            headers=getattr(surface, "headers", None) or headers,
+            request_content_type=getattr(surface, "request_content_type", None),
+            content_type=getattr(surface, "content_type", None),
+        )
+    return _UploadSurfaceShim(
+        url=surface_url,
+        source_url=source_url,
+        headers=headers,
+    )
+
+
 async def discover_verify_urls(
     session: Any,
     *,
@@ -352,24 +408,36 @@ async def discover_verify_urls(
     payload: Any,
     headers: dict[str, Any] | None = None,
     cookies: dict[str, Any] | None = None,
+    surface: Any | None = None,
+    upload_response: Any | None = None,
 ) -> list[str]:
     """
     Run all discovery strategies and return absolute URLs to probe.
 
-    Priority order:
-    1. Parse upload response text directly (JSON / HTML / regex)
-    2a. If upload response is a post listing, follow newest post detail pages
-        and extract file links from them  (stored_xss-style post tracking)
-    2b. GET related pages (form source / parent routes) and parse for filename
-    3. Common upload directory wordlist (fallback)
+    stored_xss ``verify_urls`` 후보 수집 + 파일 경로 추출 + 업로드 디렉터리 fallback.
     """
+    from modules.stored_xss.analyzer import surface_expects_json_api
+    from modules.stored_xss.verify_urls import (
+        collect_verify_candidate_urls,
+        expand_detail_urls_from_list_bodies,
+        infer_list_poll_urls,
+    )
+
     discovered_file_urls: list[str] = []
-    seen_file_urls: set[str] = set()
+    page_probe_urls: list[str] = []
+    seen_urls: set[str] = set()
+
+    def add_probe(url: str) -> None:
+        normalized = _normalize_to_url(base_url, url)
+        if normalized and normalized not in seen_urls:
+            seen_urls.add(normalized)
+            page_probe_urls.append(normalized)
 
     def add_file_url(url: str) -> None:
-        if url and url not in seen_file_urls:
-            seen_file_urls.add(url)
-            discovered_file_urls.append(url)
+        normalized = _normalize_to_url(base_url, url)
+        if normalized and normalized not in seen_urls:
+            seen_urls.add(normalized)
+            discovered_file_urls.append(normalized)
 
     request_kwargs: dict[str, Any] = {}
     if headers:
@@ -377,51 +445,114 @@ async def discover_verify_urls(
     if cookies:
         request_kwargs["cookies"] = cookies
 
+    final_upload_url = str(getattr(upload_response, "url", "") or surface_url or "")
+    upload_headers = getattr(upload_response, "headers", None) or {}
+    injection_res = _UploadInjectionResponse(
+        url=final_upload_url,
+        text=upload_response_text,
+        headers=upload_headers,
+    )
+    surface_shim = _surface_shim_from_upload(
+        surface=surface,
+        surface_url=surface_url,
+        source_url=source_url,
+        headers=headers,
+    )
+
+    # --- Strategy 0: stored_xss verify_urls (redirect, API read, listing, related) ---
+    for candidate in collect_verify_candidate_urls(
+        base_url=base_url,
+        surface=surface_shim,
+        injection_res=injection_res,
+        max_urls=12,
+    ):
+        add_probe(candidate)
+
+    prefers_json = surface_expects_json_api(surface_shim)
+    if prefers_json:
+        list_bodies: list[tuple[str, str]] = []
+        for list_url in infer_list_poll_urls(
+            surface_shim, base_url, upload_response_text
+        )[:3]:
+            list_text = await _fetch_text(session, list_url, request_kwargs)
+            if list_text:
+                list_bodies.append((list_url, list_text))
+        for detail_url in expand_detail_urls_from_list_bodies(
+            list_bodies,
+            base_url=base_url,
+            surface=surface_shim,
+            injection_body=upload_response_text,
+            surface_url=str(surface_shim.url or surface_url),
+            max_items=5,
+        ):
+            add_probe(detail_url)
+
     # --- Strategy 1: parse upload response directly ---
     for path in extract_paths_from_text(upload_response_text, filename):
         add_file_url(_normalize_to_url(base_url, path))
 
-    # --- Strategy 2a: post listing → detail page → file link ---
-    # The upload response is often a redirect to a board/listing page.
-    # Replicate stored_xss logic: find newest post links, visit each,
-    # and look for the uploaded filename inside.
-    post_detail_urls = extract_post_detail_urls(upload_response_text, base_url)
+    # --- Strategy 2: probe pages → detail → file link ---
+    fetch_cache: dict[str, str] = {}
 
-    for detail_url in post_detail_urls:
-        detail_text = await _fetch_text(session, detail_url, request_kwargs)
-        if not detail_text:
+    async def fetch_page(url: str) -> str | None:
+        if url in fetch_cache:
+            return fetch_cache[url]
+        text = await _fetch_text(session, url, request_kwargs)
+        if text is not None:
+            fetch_cache[url] = text
+        return text
+
+    ordered_pages = list(page_probe_urls)
+    ordered_pages.extend(
+        extract_post_detail_urls(upload_response_text, base_url)
+    )
+    for page_url in iter_related_crawl_urls(
+        surface_url=surface_url, source_url=source_url
+    ):
+        if page_url not in seen_urls:
+            ordered_pages.append(page_url)
+
+    for page_url in ordered_pages:
+        page_text = await fetch_page(page_url)
+        if not page_text:
             continue
-        for url in extract_file_links_from_page(detail_text, base_url, filename):
-            add_file_url(url)
-        if discovered_file_urls:
-            # Filename found in a post → stop scanning more posts
-            break
-
-    # --- Strategy 2b: related pages (source, parent routes) ---
-    if not discovered_file_urls:
-        for page_url in iter_related_crawl_urls(
-            surface_url=surface_url, source_url=source_url
-        ):
-            page_text = await _fetch_text(session, page_url, request_kwargs)
-            if not page_text:
+        for path in extract_paths_from_text(page_text, filename):
+            add_file_url(_normalize_to_url(base_url, path))
+        for file_url in extract_file_links_from_page(page_text, base_url, filename):
+            add_file_url(file_url)
+        for detail_url in extract_post_detail_urls(page_text, base_url):
+            detail_text = await fetch_page(detail_url)
+            if not detail_text:
                 continue
-            for path in extract_paths_from_text(page_text, filename):
-                add_file_url(_normalize_to_url(base_url, path))
+            for file_url in extract_file_links_from_page(detail_text, base_url, filename):
+                add_file_url(file_url)
 
-            # This page itself might be a listing — follow its post detail links too
-            for detail_url in extract_post_detail_urls(page_text, base_url):
-                detail_text = await _fetch_text(session, detail_url, request_kwargs)
-                if not detail_text:
-                    continue
-                for url in extract_file_links_from_page(detail_text, base_url, filename):
-                    add_file_url(url)
+    # --- Strategy 3: direct file URLs first, then page probes, then fallback ---
+    ordered: list[str] = []
+    merge_seen: set[str] = set()
 
-    # --- Strategy 3: common directory fallback ---
-    return merge_verify_urls(
+    def append_unique(url: str) -> None:
+        if url and url not in merge_seen:
+            merge_seen.add(url)
+            ordered.append(url)
+
+    for url in discovered_file_urls:
+        append_unique(url)
+
+    for url in build_fallback_urls(base_url, filename):
+        append_unique(url)
+
+    for url in page_probe_urls:
+        append_unique(url)
+
+    for url in merge_verify_urls(
         base_url=base_url,
         filename=filename,
-        discovered_paths=discovered_file_urls,
+        discovered_paths=[],
         payload=payload,
         surface_url=surface_url,
-        include_fallback=True,
-    )
+        include_fallback=False,
+    ):
+        append_unique(url)
+
+    return ordered

--- a/modules/file_upload/verifier.py
+++ b/modules/file_upload/verifier.py
@@ -8,6 +8,10 @@ from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlsplit
 
 from modules.file_upload.markers import (
+    CATEGORY_RCE,
+    CATEGORY_STATIC_MALICIOUS_FILE,
+    CATEGORY_TEMPLATE_RCE,
+    CATEGORY_UNRESTRICTED_UPLOAD,
     DEFAULT_SHELL_TAGS_BY_MODE,
     NODE_TEMPLATE_TAGS,
     PHP_SHELL_TAGS,
@@ -78,6 +82,14 @@ def extract_dynamic_verify_urls(base_url: str, response_text: str, filename: str
     )
 
 
+def is_direct_upload_file_url(url: str, filename: str) -> bool:
+    """URL path에 업로드 파일명(베이스네임)이 포함되면 직접 파일 서빙으로 간주."""
+    basename = (filename or "").rsplit("/", 1)[-1].strip().lower()
+    if not basename:
+        return False
+    return basename in (urlsplit(url).path or "").lower()
+
+
 def _body_contains_any(body: str, needles: tuple[str, ...]) -> bool:
     lower = body.lower()
     return any(needle.lower() in lower for needle in needles if needle)
@@ -89,9 +101,15 @@ def _shell_tags_for_payload(payload: FilePayload) -> tuple[str, ...]:
     return DEFAULT_SHELL_TAGS_BY_MODE.get(payload.verify_mode, PHP_SHELL_TAGS)
 
 
-def verify_upload_response(body: str, payload: FilePayload) -> VerificationResult:
+def verify_upload_response(
+    body: str,
+    payload: FilePayload,
+    *,
+    direct_file: bool = False,
+) -> VerificationResult:
     """
-    Active verification: distinguish executed code (RCE) vs static reflection (XSS).
+    Active verification: distinguish executed code (RCE) vs static file serve.
+    ``direct_file=True`` — 업로드된 파일 URL 자체를 GET한 경우 (PHP가 Node에서 미실행 등).
     """
     evidences: list[str] = []
     mode = (payload.verify_mode or VERIFY_RCE).lower()
@@ -101,27 +119,32 @@ def verify_upload_response(body: str, payload: FilePayload) -> VerificationResul
         if not probe:
             return VerificationResult(False, "static", "high", evidences)
         if probe not in body:
-            return VerificationResult(False, "stored_xss", "high", evidences)
+            return VerificationResult(False, CATEGORY_STATIC_MALICIOUS_FILE, "high", evidences)
         evidences.append(f"[StaticServe] probe reflected: {probe[:80]}")
-        return VerificationResult(True, "stored_xss", "high", evidences)
+        return VerificationResult(True, CATEGORY_STATIC_MALICIOUS_FILE, "high", evidences)
 
     if mode == VERIFY_TEMPLATE:
         marker = payload.marker
         if marker not in body:
-            return VerificationResult(False, "template_rce", "critical", evidences)
+            return VerificationResult(False, CATEGORY_TEMPLATE_RCE, "critical", evidences)
         if _body_contains_any(body, _shell_tags_for_payload(payload) or NODE_TEMPLATE_TAGS):
-            return VerificationResult(False, "template_rce", "critical", evidences)
+            return VerificationResult(False, CATEGORY_TEMPLATE_RCE, "critical", evidences)
         evidences.append(f"[TemplateRCE] marker rendered without template tags: {marker}")
-        return VerificationResult(True, "template_rce", "critical", evidences)
+        return VerificationResult(True, CATEGORY_TEMPLATE_RCE, "critical", evidences)
 
     # VERIFY_RCE — marker must appear and interpreter tags must be stripped.
     marker = payload.marker
     if marker not in body:
-        return VerificationResult(False, "rce", "critical", evidences)
+        return VerificationResult(False, CATEGORY_RCE, "critical", evidences)
     if _body_contains_any(body, _shell_tags_for_payload(payload)):
-        return VerificationResult(False, "rce", "critical", evidences)
+        if direct_file:
+            evidences.append(
+                f"[UnrestrictedUpload] marker in served file (interpreter not executed): {marker}"
+            )
+            return VerificationResult(True, CATEGORY_UNRESTRICTED_UPLOAD, "high", evidences)
+        return VerificationResult(False, CATEGORY_RCE, "critical", evidences)
     evidences.append(f"[RCE] marker executed (shell tags absent): {marker}")
-    return VerificationResult(True, "rce", "critical", evidences)
+    return VerificationResult(True, CATEGORY_RCE, "critical", evidences)
 
 
 def build_verify_url_list(

--- a/modules/ssrf/analyzer.py
+++ b/modules/ssrf/analyzer.py
@@ -1,6 +1,8 @@
 ﻿from __future__ import annotations
 
 import re
+import uuid
+from typing import Any
 
 _CLOUD_TARGET_HINTS = (
     "169.254.169.254",
@@ -27,10 +29,14 @@ _CLOUD_ERROR_HINTS = (
 )
 _INTERNAL_NETWORK_ERROR_HINTS = (
     "connection refused",
+    "econnrefused",
     "no route to host",
     "name or service not known",
     "network is unreachable",
     "connection timed out",
+    "etimedout",
+    "ehostunreach",
+    "enotfound",
     "ssh-2.0",
     "redis_version",
 )
@@ -117,66 +123,201 @@ def _probe_url_echoed_in_body(res_text_lower: str, payload_value_lower: str) -> 
     return False
 
 
+def _match_signature_proof(
+    res_text: str,
+    res_text_lower: str,
+    *,
+    expected_signature: str | None,
+    payload_value_lower: str,
+    original_text_lower: str,
+) -> bool:
+    if not expected_signature:
+        return False
+    try:
+        m_current = re.search(expected_signature, res_text, re.IGNORECASE | re.DOTALL)
+        matched_original = bool(
+            original_text_lower
+            and re.search(expected_signature, original_text_lower, re.IGNORECASE | re.DOTALL)
+        )
+        if m_current and not matched_original:
+            hit = m_current.group(0).lower()
+            if hit and hit not in payload_value_lower:
+                return True
+    except re.error:
+        expected_lower = expected_signature.lower()
+        if (
+            expected_lower in res_text_lower
+            and expected_lower not in original_text_lower
+            and expected_lower not in payload_value_lower
+        ):
+            return True
+    return False
+
+
+def _match_cloud_proof(
+    res_text_lower: str,
+    *,
+    payload_value_lower: str,
+    original_text_lower: str,
+    status_code: int,
+) -> bool:
+    is_cloud_payload = any(hint in payload_value_lower for hint in _CLOUD_TARGET_HINTS)
+    if not is_cloud_payload:
+        return False
+    new_cloud_hints = [
+        hint
+        for hint in _CLOUD_SUCCESS_HINTS
+        if hint in res_text_lower
+        and hint not in original_text_lower
+        and hint not in payload_value_lower
+    ]
+    if status_code == 200 and new_cloud_hints:
+        return True
+    if status_code in (400, 401, 403) and any(
+        hint in res_text_lower for hint in _CLOUD_ERROR_HINTS
+    ):
+        return True
+    return False
+
+
+def _match_internal_network_proof(res_text_lower: str) -> bool:
+    return any(hint in res_text_lower for hint in _INTERNAL_NETWORK_ERROR_HINTS)
+
+
+def _match_time_proof(payload_value_lower: str, elapsed_time: float) -> bool:
+    return (
+        "10.255.255.255" in payload_value_lower or ":22" in payload_value_lower
+    ) and elapsed_time > 10.0
+
+
+def analyze_ssrf_content_proof(
+    response,
+    payload,
+    elapsed_time: float = 0.0,
+    original_res=None,
+) -> bool:
+    """
+    Direct SSRF evidence in the response body (signatures, cloud hints, fetch errors).
+    Excludes boolean-blind length/status deltas that cause MPA redirect false positives.
+    """
+    res_text = _extract_response_text(response)
+    res_text_lower = res_text.lower()
+    original_text = _extract_response_text(original_res) if original_res is not None else ""
+    original_text_lower = original_text.lower()
+    status_code = _extract_status_code(response)
+    payload_value = str(getattr(payload, "value", ""))
+    payload_value_lower = payload_value.lower()
+    expected_signature = getattr(payload, "expected_signature", None)
+
+    if _match_signature_proof(
+        res_text,
+        res_text_lower,
+        expected_signature=expected_signature,
+        payload_value_lower=payload_value_lower,
+        original_text_lower=original_text_lower,
+    ):
+        return True
+    if _match_cloud_proof(
+        res_text_lower,
+        payload_value_lower=payload_value_lower,
+        original_text_lower=original_text_lower,
+        status_code=status_code,
+    ):
+        return True
+    if _match_internal_network_proof(res_text_lower):
+        return True
+    if _match_time_proof(payload_value_lower, elapsed_time):
+        return True
+    return False
+
+
+def analyze_ssrf_readback_proof(res_text: str, payload) -> bool:
+    """SSRF proof in a read-back GET body (stored content, detail API, etc.)."""
+
+    class _ReadbackResponse:
+        def __init__(self, text: str) -> None:
+            self.text = text
+            self.status_code = 200
+
+    return analyze_ssrf_content_proof(_ReadbackResponse(res_text), payload)
+
+
+def build_ssrf_verify_probe() -> tuple[str, int, str]:
+    """
+    Unique localhost probe for 2nd-stage verification.
+    Port + path token tie read-back evidence to *this* injection only.
+    """
+    verify_id = uuid.uuid4().hex[:8]
+    probe_port = 40000 + (int(verify_id, 16) % 20000)
+    probe_url = f"http://127.0.0.1:{probe_port}/vfy-{verify_id}/"
+    return verify_id, probe_port, probe_url
+
+
+def readback_shows_new_verify_probe(
+    pre_body: str,
+    post_body: str,
+    *,
+    verify_id: str,
+    probe_port: int,
+) -> bool:
+    """
+    True when post_body contains SSRF side-effect markers from this verify probe
+    that were absent in pre_body (prevents cross-surface / prior-scan contamination).
+    """
+    pre_lower = (pre_body or "").lower()
+    post_lower = (post_body or "").lower()
+    if not post_lower or post_lower == pre_lower:
+        return False
+
+    token = verify_id.lower()
+    if token in post_lower and token not in pre_lower:
+        return True
+
+    port_needle = f":{probe_port}"
+    if port_needle in post_lower and port_needle not in pre_lower:
+        if any(hint in post_lower for hint in _INTERNAL_NETWORK_ERROR_HINTS):
+            return True
+    return False
+
+
+def should_defer_ssrf_verify(surface: Any, response: Any) -> bool:
+    """
+    Mutating write accepted but the inline response lacks SSRF proof (SPA JSON redirect, etc.).
+  Reuses stored_xss store-success heuristics; no app-specific URLs.
+    """
+    from modules.stored_xss.analyzer import (
+        injection_response_implies_failed_auth,
+        is_store_mutation_surface,
+        looks_like_successful_store_api_response,
+        looks_like_successful_store_redirect,
+    )
+
+    if surface is None or not is_store_mutation_surface(surface):
+        return False
+    if injection_response_implies_failed_auth(response):
+        return False
+    body = _extract_response_text(response)
+    if looks_like_successful_store_api_response(response, body):
+        return True
+    return looks_like_successful_store_redirect(response, body, surface)
+
+
 def analyze_ssrf(response, payload, elapsed_time: float, original_res=None) -> bool:
+    if analyze_ssrf_content_proof(response, payload, elapsed_time, original_res):
+        return True
+
     res_text = _extract_response_text(response)
     res_text_lower = res_text.lower()
     original_text = _extract_response_text(original_res) if original_res is not None else ""
     original_text_lower = original_text.lower()
     status_code = _extract_status_code(response)
     original_status_code = _extract_status_code(original_res) if original_res is not None else 0
-    expected_signature = getattr(payload, "expected_signature", None)
     payload_value = str(getattr(payload, "value", ""))
     payload_value_lower = payload_value.lower()
-
-    # 1) Strong signature match (best signal, keep highest priority)
-    if expected_signature:
-        try:
-            m_current = re.search(expected_signature, res_text, re.IGNORECASE | re.DOTALL)
-            matched_original = bool(
-                original_text and re.search(expected_signature, original_text, re.IGNORECASE | re.DOTALL)
-            )
-            if m_current and not matched_original:
-                # If the regex hit is only a substring of the injected URL echoed back
-                # (e.g. ssrf.txt signatures like (ami-id|instance-id|...) on reflected LFI),
-                # do not treat as SSRF proof.
-                hit = m_current.group(0).lower()
-                if not hit or hit not in payload_value_lower:
-                    return True
-        except re.error:
-            expected_lower = expected_signature.lower()
-            if (
-                expected_lower in res_text_lower
-                and expected_lower not in original_text_lower
-                and expected_lower not in payload_value_lower
-            ):
-                return True
-
-    # 2) Cloud metadata endpoint heuristics and cloud-specific errors
     is_cloud_payload = any(hint in payload_value_lower for hint in _CLOUD_TARGET_HINTS)
-    if is_cloud_payload:
-        # Do not treat success hints as evidence when they only appear because they are
-        # part of the injected URL (e.g. .../meta-data/ami-id reflected in HTML). Real
-        # IMDS ami-id responses are usually a single ami-... line without the literal "ami-id".
-        new_cloud_hints = [
-            hint for hint in _CLOUD_SUCCESS_HINTS
-            if hint in res_text_lower
-            and hint not in original_text_lower
-            and hint not in payload_value_lower
-        ]
-        if status_code == 200 and new_cloud_hints:
-            return True
-        if status_code in (400, 401, 403) and any(
-            hint in res_text_lower for hint in _CLOUD_ERROR_HINTS
-        ):
-            return True
-
-    # 3) Internal-network error fingerprints (port-scan style SSRF evidence)
-    if any(hint in res_text_lower for hint in _INTERNAL_NETWORK_ERROR_HINTS):
-        return True
 
     # 4) Boolean-blind style delta checks (host discovery, path brute-force, bypasses)
     is_blind_probe = _is_blind_probe_payload(payload_value_lower)
-    is_cloud_payload = any(hint in payload_value_lower for hint in _CLOUD_TARGET_HINTS)
     attack_type = str(getattr(payload, "attack_type", "")).lower()
     is_bypass_or_basic = ("bypass" in attack_type) or ("basic" in attack_type)
 
@@ -208,8 +349,4 @@ def analyze_ssrf(response, payload, elapsed_time: float, original_res=None) -> b
             if has_login_hints and not had_login_hints:
                 return True
 
-    # 5) Time-based blind hints for deliberate timeout/port probes
-    if ("10.255.255.255" in payload_value_lower or ":22" in payload_value_lower) and elapsed_time > 10.0:
-        return True
-
-    return False
+    return _match_time_proof(payload_value_lower, elapsed_time)

--- a/modules/ssrf/module.py
+++ b/modules/ssrf/module.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import re
+from typing import Any
+
+import aiohttp
 
 from core.models import Payload
 from modules.base_module import BaseModule
-from modules.ssrf.analyzer import analyze_ssrf
+from modules.ssrf.analyzer import (
+    analyze_ssrf,
+    analyze_ssrf_content_proof,
+    should_defer_ssrf_verify,
+)
 from modules.ssrf.payloads import SSRFPayload, get_ssrf_payloads
+from modules.ssrf.verify import verify_ssrf_readback
 
 # Default display name; keep in sync with ``__init__(name=...)`` default.
 SSRF_MODULE_REPORT_NAME = "Server-Side Request Forgery"
@@ -65,6 +73,7 @@ class SSRFModule(BaseModule):
             include_oob_templates=include_oob_templates,
             bypass_level=bypass_level,
         )
+        self._last_verify_evidence: str = ""
 
     def get_payloads(self) -> list[Payload]:
         return self._payloads
@@ -76,13 +85,33 @@ class SSRFModule(BaseModule):
         elapsed_time: float,
         original_res=None,
         requester=None,
+        surface: Any = None,
     ) -> bool:
-        return analyze_ssrf(
-            response=response,
+        if analyze_ssrf_content_proof(response, payload, elapsed_time, original_res):
+            return True
+        if surface is not None and should_defer_ssrf_verify(surface, response):
+            return True
+        return analyze_ssrf(response, payload, elapsed_time, original_res)
+
+    async def verify(
+        self,
+        session: aiohttp.ClientSession,
+        surface: Any,
+        parameter: str,
+        payload: Payload,
+        response: Any,
+        baseline_response: Any,
+    ) -> bool:
+        verified, evidence = await verify_ssrf_readback(
+            session,
+            surface=surface,
+            parameter=parameter,
             payload=payload,
-            elapsed_time=elapsed_time,
-            original_res=original_res,
+            response=response,
+            baseline_response=baseline_response,
         )
+        self._last_verify_evidence = evidence
+        return verified
 
     def get_target_parameters(self, surface, parameters: list[str]) -> list[str]:
         surface_params: dict = getattr(surface, "parameters", {}) or {}

--- a/modules/ssrf/verify.py
+++ b/modules/ssrf/verify.py
@@ -1,0 +1,202 @@
+"""
+SSRF 2차 검증: 저장·조회 분리형 앱(SPA API 등)에서 read-back GET으로 fetch 증거를 확인한다.
+
+교차 오염 방지: 고유 verify probe를 재주입하고, read-back 본문에 해당 probe의
+흔적이 *새로* 나타날 때만 확정한다 (다른 endpoint/이전 스캔의 SSRF 잔여물 제외).
+
+stored_xss.verify_urls 의 후보 URL 수집 로직을 재사용하며 앱별 URL 하드코딩은 없다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any
+
+import aiohttp
+
+from core.models import Payload
+from fuzzer.request_builder import build_and_send_request
+from modules.ssrf.analyzer import (
+    build_ssrf_verify_probe,
+    readback_shows_new_verify_probe,
+)
+from modules.ssrf.payloads import SSRFPayload
+from modules.stored_xss.analyzer import (
+    build_verify_request_headers,
+    injection_response_implies_failed_auth,
+    is_success_status,
+    surface_expects_json_api,
+)
+from modules.stored_xss.verify_urls import (
+    collect_verify_candidate_urls,
+    expand_detail_urls_from_list_bodies,
+    infer_list_poll_urls,
+)
+
+
+async def _collect_readback_urls(
+    session: aiohttp.ClientSession,
+    *,
+    surface: Any,
+    injection_res: Any,
+    base_url: str,
+    injection_body: str,
+    max_urls: int = 12,
+) -> list[str]:
+    candidate_urls = collect_verify_candidate_urls(
+        base_url=base_url,
+        surface=surface,
+        injection_res=injection_res,
+        max_urls=max_urls,
+    )
+
+    req_headers = getattr(surface, "headers", {}) or {}
+    req_cookies = getattr(surface, "cookies", None)
+    verify_headers_base = build_verify_request_headers(surface, base_url, req_headers)
+    list_bodies: list[tuple[str, str]] = []
+
+    for list_url in infer_list_poll_urls(surface, base_url, injection_body)[:3]:
+        try:
+            async with session.get(
+                list_url,
+                headers=verify_headers_base,
+                cookies=req_cookies,
+                timeout=15,
+            ) as list_res:
+                if is_success_status(list_res.status):
+                    list_bodies.append((list_url, await list_res.text()))
+        except Exception:
+            continue
+
+    surface_url = str(getattr(surface, "url", "") or "")
+    for detail_url in expand_detail_urls_from_list_bodies(
+        list_bodies,
+        base_url=base_url,
+        surface=surface,
+        injection_body=injection_body,
+        surface_url=surface_url,
+        max_items=5,
+    ):
+        if detail_url not in candidate_urls:
+            candidate_urls.insert(0, detail_url)
+
+    return candidate_urls
+
+
+async def _fetch_readback_bodies(
+    session: aiohttp.ClientSession,
+    *,
+    surface: Any,
+    urls: list[str],
+) -> dict[str, str]:
+    req_headers = getattr(surface, "headers", {}) or {}
+    req_cookies = getattr(surface, "cookies", None)
+    bodies: dict[str, str] = {}
+
+    for check_url in urls:
+        verify_headers = build_verify_request_headers(surface, check_url, req_headers)
+        try:
+            async with session.get(
+                check_url,
+                headers=verify_headers,
+                cookies=req_cookies,
+                timeout=15,
+            ) as verify_res:
+                if is_success_status(verify_res.status):
+                    bodies[check_url] = await verify_res.text()
+        except Exception:
+            continue
+    return bodies
+
+
+async def verify_ssrf_readback(
+    session: aiohttp.ClientSession,
+    *,
+    surface: Any,
+    parameter: str,
+    payload: Payload,
+    response: Any,
+    baseline_response: Any,
+) -> tuple[bool, str]:
+    """
+    Re-inject a unique verify probe, then confirm its SSRF side-effect appears newly
+    in read-back (or inline re-inject response), not in pre-injection snapshots.
+    """
+    _ = payload
+    _ = baseline_response
+
+    if injection_response_implies_failed_auth(response):
+        return False, ""
+
+    verify_id, probe_port, probe_url = build_ssrf_verify_probe()
+    probe_payload = SSRFPayload(
+        value=probe_url,
+        attack_type="verify_probe",
+        risk_level="info",
+    )
+
+    target_url = str(getattr(response, "url", "") or getattr(surface, "url", "") or "")
+    base_url = target_url
+    injection_body = getattr(response, "text", "") or ""
+    prefers_json = surface_expects_json_api(surface)
+
+    readback_urls = await _collect_readback_urls(
+        session,
+        surface=surface,
+        injection_res=response,
+        base_url=base_url,
+        injection_body=injection_body,
+    )
+
+    pre_bodies = await _fetch_readback_bodies(session, surface=surface, urls=readback_urls)
+
+    safe_surface = copy.deepcopy(surface)
+    try:
+        reinject_res = await build_and_send_request(
+            session,
+            safe_surface,
+            parameter,
+            probe_payload,
+        )
+    except Exception:
+        return False, ""
+
+    if injection_response_implies_failed_auth(reinject_res):
+        return False, ""
+
+    await asyncio.sleep(1.0 if prefers_json else 0.75)
+
+    reinject_body = getattr(reinject_res, "text", "") or ""
+    post_urls = await _collect_readback_urls(
+        session,
+        surface=surface,
+        injection_res=reinject_res,
+        base_url=str(getattr(reinject_res, "url", "") or base_url),
+        injection_body=reinject_body,
+    )
+    for url in readback_urls:
+        if url not in post_urls:
+            post_urls.append(url)
+
+    post_bodies = await _fetch_readback_bodies(session, surface=surface, urls=post_urls)
+
+    for check_url, post_text in post_bodies.items():
+        pre_text = pre_bodies.get(check_url, "")
+        if readback_shows_new_verify_probe(
+            pre_text,
+            post_text,
+            verify_id=verify_id,
+            probe_port=probe_port,
+        ):
+            return True, f"verify_probe={verify_id} readback at {check_url}"
+
+    if readback_shows_new_verify_probe(
+        injection_body,
+        reinject_body,
+        verify_id=verify_id,
+        probe_port=probe_port,
+    ):
+        return True, f"verify_probe={verify_id} inline_reinject_response"
+
+    return False, ""

--- a/modules/stored_xss/analyzer.py
+++ b/modules/stored_xss/analyzer.py
@@ -1,9 +1,11 @@
 import html
+import json
 import re
 import difflib
 import base64
 from html.parser import HTMLParser
-from typing import List, Optional, Any, Dict
+from typing import List, Optional, Any, Dict, Tuple
+from urllib.parse import urlsplit
 from bs4 import BeautifulSoup
 from core.models import Payload
 
@@ -160,6 +162,563 @@ def is_acceptable_verify_response(status: int, body: str, *, marker: str = "") -
         if looks_like_error_snippet(body[start:end]):
             return False
     return True
+
+
+_JSON_CONTENT_TYPES = frozenset(
+    {
+        "application/json",
+        "application/problem+json",
+        "application/vnd.api+json",
+    }
+)
+
+_STORE_API_SUCCESS_KEYS = frozenset(
+    {
+        "redirect",
+        "redirect_url",
+        "redirecturl",
+        "location",
+        "next",
+        "continue",
+        "id",
+        "post_id",
+        "item_id",
+        "success",
+        "ok",
+    }
+)
+
+_DOM_RENDER_FIELD_HINTS = frozenset(
+    {
+        "title",
+        "content",
+        "comment",
+        "comments",
+        "body",
+        "description",
+        "name",
+        "message",
+        "summary",
+        "text",
+        "html",
+        "snippet",
+        "bio",
+        "caption",
+    }
+)
+
+# JSON 필드에 <script>만 있어도 innerHTML/v-html 렌더링이 흔한 이름
+_SCRIPT_TAG_JSON_FIELD_HINTS = frozenset(
+    {
+        "title",
+        "content",
+        "html",
+        "body",
+        "description",
+        "summary",
+        "caption",
+        "bio",
+        "snippet",
+    }
+)
+
+# 2차 검증: 주입 파라미터와 JSON 필드 경로 매칭 (title 히트로 content 오탐 방지)
+_PARAM_JSON_FIELD_ALIASES: dict[str, frozenset[str]] = {
+    "content": frozenset({"content", "body", "message", "text", "html", "description"}),
+    "body": frozenset({"body", "content", "message", "text", "html"}),
+    "comment": frozenset({"comment", "content", "body", "message", "text"}),
+    "title": frozenset({"title", "name", "subject", "headline"}),
+    "name": frozenset({"name", "title", "username", "author"}),
+    "description": frozenset({"description", "desc", "summary", "content", "body"}),
+    "message": frozenset({"message", "content", "body", "text"}),
+}
+
+_CONTENT_SCRIPT_BLOCK_ANCESTORS = frozenset({"review", "reviews"})
+_CONTENT_SCRIPT_ALLOW_ANCESTORS = frozenset(
+    {
+        "post",
+        "posts",
+        "board",
+        "article",
+        "articles",
+        "comment",
+        "comments",
+        "thread",
+        "message",
+        "messages",
+    }
+)
+
+# GET 쿼리로 파일/경로를 읽는 엔드포인트 — 저장형이 아닌 반사·LFI 성격
+_READ_ONLY_QUERY_PARAM_NAMES = frozenset(
+    {
+        "file",
+        "filename",
+        "filepath",
+        "path",
+        "folder",
+        "dir",
+        "document",
+        "doc",
+        "template",
+        "page",
+        "include",
+        "require",
+        "log",
+        "logfile",
+        "lang",
+        "locale",
+    }
+)
+
+_JSON_ERROR_FIELD_SEGMENTS = frozenset(
+    {
+        "error",
+        "errors",
+        "err",
+        "errmsg",
+        "errormessage",
+        "error_message",
+        "message",
+        "detail",
+        "reason",
+        "exception",
+        "stack",
+        "stacktrace",
+        "trace",
+    }
+)
+
+_AUTH_FAILURE_PATH_HINTS = ("/login", "/signin", "/auth/login")
+
+_REFLECTED_ONLY_PARAM_NAMES = frozenset(
+    {
+        "keyword",
+        "q",
+        "query",
+        "term",
+        "searchtext",
+    }
+)
+
+_REFLECTED_ONLY_PATH_SEGMENTS = (
+    "/search",
+    "/login",
+    "/error",
+)
+
+_STORE_MUTATION_PATH_HINTS = (
+    "write",
+    "add",
+    "create",
+    "comment",
+    "edit",
+    "update",
+    "review",
+    "post",
+    "reply",
+    "submit",
+    "register",
+    "signup",
+)
+
+
+def _header_content_type(headers: Any) -> str:
+    if not headers:
+        return ""
+    if isinstance(headers, dict):
+        for key, value in headers.items():
+            if str(key).lower() == "content-type":
+                return str(value or "").lower()
+        return ""
+    try:
+        return str(headers.get("content-type", "") or headers.get("Content-Type", "")).lower()
+    except Exception:
+        return ""
+
+
+def looks_like_json_body(body: str, headers: Any = None) -> bool:
+    text = (body or "").strip()
+    if not text:
+        return False
+    header_ct = _header_content_type(headers).split(";", 1)[0].strip()
+    if header_ct in _JSON_CONTENT_TYPES or header_ct.endswith("+json"):
+        return True
+    if text[0] not in "{[":
+        return False
+    try:
+        json.loads(text)
+        return True
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+
+def _redirect_implies_auth_failure(raw_url: str) -> bool:
+    path = (raw_url or "").strip().lower()
+    if not path:
+        return False
+    return any(hint in path for hint in _AUTH_FAILURE_PATH_HINTS)
+
+
+def surface_expects_json_api(surface: Any) -> bool:
+    """SPA/REST API surface인지 (HTML MPA에는 /api/ URL 추론을 쓰지 않음)."""
+    for raw in (
+        str(getattr(surface, "url", "") or ""),
+        str(getattr(surface, "source_url", "") or ""),
+    ):
+        if "/api/" in raw.lower():
+            return True
+    for attr in ("request_content_type", "content_type"):
+        value = str(getattr(surface, attr, "") or "").lower()
+        if "application/json" in value:
+            return True
+    return False
+
+
+def is_reflected_only_param(parameter: str) -> bool:
+    return str(parameter or "").strip().lower() in _REFLECTED_ONLY_PARAM_NAMES
+
+
+def is_store_mutation_surface(surface: Any) -> bool:
+    path = (urlsplit(str(getattr(surface, "url", "") or "")).path or "").lower()
+    return any(hint in path for hint in _STORE_MUTATION_PATH_HINTS)
+
+
+def _path_suggests_reflected_only(url: str) -> bool:
+    path = (urlsplit(url or "").path or "").lower()
+    return any(seg in path for seg in _REFLECTED_ONLY_PATH_SEGMENTS)
+
+
+def is_immediate_reflection_only_hit(
+    surface: Any,
+    response: Any,
+    payload_value: str,
+    marker: Optional[str],
+) -> bool:
+    """
+    동일 응답에만 페이로드가 보이고 저장·리다이렉트 신호가 없으면 반사형으로 본다.
+    (GET 목록/검색, POST /search 등 — stored_xss verify 부하·오탐 방지)
+    """
+    body = getattr(response, "text", "") or ""
+    if payload_value not in body and not (marker and marker in body):
+        return False
+    if surface is not None and surface_method_is_get(surface):
+        return True
+    if surface is not None and not is_store_mutation_surface(surface):
+        return True
+    response_url = str(getattr(response, "url", "") or "")
+    if _path_suggests_reflected_only(response_url):
+        return True
+    return False
+
+
+def looks_like_successful_store_redirect(
+    response: Any,
+    body: str,
+    surface: Any,
+) -> bool:
+    """MPA HTML 폼: POST 저장 후 redirect, 본문에 페이로드가 없는 경우."""
+    if surface is None or not is_store_mutation_surface(surface):
+        return False
+    method = getattr(surface, "method", None)
+    raw = getattr(method, "value", method)
+    if str(raw or "").upper() not in {"POST", "PUT", "PATCH"}:
+        return False
+    if not is_success_status(response_status(response)):
+        return False
+    text = (body or "").strip()
+    if text.startswith("{"):
+        return False
+    final_url = str(getattr(response, "url", "") or "")
+    if _redirect_implies_auth_failure(final_url):
+        return False
+    surface_url = str(getattr(surface, "url", "") or "")
+    if not final_url or not surface_url:
+        return False
+    fin = urlsplit(final_url)
+    sur = urlsplit(surface_url)
+    if (fin.scheme, fin.netloc, fin.path) == (sur.scheme, sur.netloc, sur.path):
+        return False
+    return True
+
+
+def injection_response_implies_failed_auth(response: Any) -> bool:
+    final_url = str(getattr(response, "url", "") or "").lower()
+    return _redirect_implies_auth_failure(final_url)
+
+
+def looks_like_successful_store_api_response(response: Any, body: str) -> bool:
+    """
+  Mutating API가 저장을 수락했지만 본문에 페이로드가 없는 경우(SPA JSON redirect 등).
+  2차 GET 검증으로 넘기기 위한 1차 히트 신호.
+    """
+    if not is_success_status(response_status(response)):
+        return False
+    text = (body or "").strip()
+    if not text.startswith("{"):
+        return False
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    error_val = data.get("error")
+    if error_val is not None and str(error_val).strip():
+        return False
+    for key in _STORE_API_SUCCESS_KEYS:
+        if key not in data:
+            continue
+        value = data.get(key)
+        if value is None:
+            continue
+        if key in {"redirect", "redirect_url", "redirecturl", "location", "next", "continue"}:
+            raw = str(value).strip()
+            if raw and not _redirect_implies_auth_failure(raw):
+                return True
+            continue
+        if key in {"id", "post_id", "item_id"}:
+            if str(value).strip():
+                return True
+            continue
+        if key in {"success", "ok"}:
+            if value is True or str(value).strip().lower() in {"1", "true", "ok", "success", "yes"}:
+                return True
+    return False
+
+
+def _walk_json_marker_hits(
+    node: Any,
+    marker: str,
+    *,
+    path: str = "",
+    hits: Optional[List[Tuple[str, str]]] = None,
+    depth: int = 0,
+) -> List[Tuple[str, str]]:
+    if hits is None:
+        hits = []
+    if depth > 12 or not marker:
+        return hits
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            _walk_json_marker_hits(value, marker, path=child_path, hits=hits, depth=depth + 1)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            child_path = f"{path}[{index}]"
+            _walk_json_marker_hits(value, marker, path=child_path, hits=hits, depth=depth + 1)
+    elif isinstance(node, str) and marker in node:
+        hits.append((path or "value", node))
+    return hits
+
+
+def _json_value_suggests_dom_execution(
+    value: str,
+    marker: str,
+    *,
+    path: str = "",
+) -> bool:
+    """
+    JSON 문자열 필드만으로 판정할 때: <script> 단독은 React 텍스트 노드 등에서
+    실행되지 않는 경우가 많아, 이벤트 핸들러·svg/img 등 강한 신호를 우선한다.
+    title/html 등 innerHTML에 가까운 필드명은 <script> 단독도 허용한다.
+    """
+    if marker not in value:
+        return False
+    escaped_marker = html.escape(marker)
+    if escaped_marker != marker and escaped_marker in value and marker not in value:
+        return True
+    if "&lt;" in value and marker not in value:
+        return False
+    if not _check_executable_in_response(value, value, marker).get("executable"):
+        return False
+    if re.search(r"<script\b", value, re.I):
+        if _json_field_path_segments(path) & _SCRIPT_TAG_JSON_FIELD_HINTS:
+            return True
+        if _content_field_allows_script_tag(path):
+            return True
+        if re.search(r"\bon\w+\s*=", value, re.I):
+            return True
+        if re.search(r"<(?:svg|img|iframe|object|embed|math)\b", value, re.I):
+            return True
+        return False
+    return True
+
+
+def _json_string_stored_unescaped(value: str, marker: str, *, path: str = "") -> bool:
+    return _json_value_suggests_dom_execution(value, marker, path=path)
+
+
+def _content_field_allows_script_tag(path: str) -> bool:
+    segments = _json_field_path_segments(path)
+    if "content" not in segments:
+        return False
+    if segments & _CONTENT_SCRIPT_BLOCK_ANCESTORS:
+        return False
+    return bool(segments & _CONTENT_SCRIPT_ALLOW_ANCESTORS)
+
+
+def _json_field_path_segments(path: str) -> set[str]:
+    segments: set[str] = set()
+    for part in re.split(r"\.|\[|\]", path or ""):
+        part = str(part).strip().lower()
+        if part:
+            segments.add(part)
+    return segments
+
+
+def _normalize_verify_location(location: str) -> str:
+    raw = str(location or "")
+    for prefix in ("json_field_executable:", "json_field_html:"):
+        if raw.startswith(prefix):
+            return raw[len(prefix):]
+    return raw
+
+
+def verify_context_matches_parameter(parameter: str, location: str) -> bool:
+    """
+    SPA 목록 API는 title만 내려주고 content는 view API에만 있다.
+    주입 파라미터와 검증 위치(JSON 경로)가 맞는지 확인한다.
+    """
+    param = str(parameter or "").strip().lower()
+    if not param:
+        return True
+    loc = str(location or "")
+    if not loc or loc.startswith(("html_", "safe_", "script_", "attribute_", "reflected_only")):
+        return True
+    if not loc.startswith("json_field_"):
+        return True
+    path = _normalize_verify_location(loc)
+    segments = _json_field_path_segments(path)
+    allowed = _PARAM_JSON_FIELD_ALIASES.get(param, frozenset({param}))
+    return bool(segments & allowed)
+
+
+def _json_path_is_error_field(path: str) -> bool:
+    return bool(_json_field_path_segments(path) & _JSON_ERROR_FIELD_SEGMENTS)
+
+
+def _likely_dom_rendered_json_field(path: str) -> bool:
+    segments = _json_field_path_segments(path)
+    return bool(segments & _DOM_RENDER_FIELD_HINTS)
+
+
+def surface_method_is_get(surface: Any) -> bool:
+    method = getattr(surface, "method", None)
+    if method is None:
+        return False
+    raw = getattr(method, "value", method)
+    return str(raw).upper() == "GET"
+
+
+def is_read_only_query_param(parameter: str) -> bool:
+    return str(parameter or "").strip().lower() in _READ_ONLY_QUERY_PARAM_NAMES
+
+
+def is_get_read_only_surface(surface: Any, parameter: str) -> bool:
+    if not surface_method_is_get(surface):
+        return False
+    loc = getattr(surface, "param_location", None)
+    loc_raw = getattr(loc, "value", loc)
+    if str(loc_raw or "").lower() not in {"query", "url"}:
+        return False
+    return is_read_only_query_param(parameter)
+
+
+def verify_implies_persistent_storage(
+    surface: Any,
+    injection_url: str,
+    hit_url: str,
+) -> bool:
+    """
+    동일 GET 엔드포인트에 마커가 보이는 것만으로는 저장형으로 보지 않는다.
+  (파일명·경로 파라미터 반사 / LFI 오류 메시지 등)
+    """
+    if not surface_method_is_get(surface):
+        return True
+    inj = urlsplit(injection_url)
+    hit = urlsplit(hit_url)
+    if (inj.scheme, inj.netloc, inj.path) != (hit.scheme, hit.netloc, hit.path):
+        return True
+    return False
+
+
+def analyze_json_stored_context(
+    body: str,
+    payload_value: str,
+    marker: Optional[str] = None,
+) -> Dict[str, Any]:
+    """JSON API 응답에서 저장된 마커가 실행 가능한 HTML로 내려오는지 판정."""
+    search = marker or payload_value
+    if not search or search not in body:
+        return {"executable": False, "location": "not_reflected"}
+
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return _analyze_context_robust(body, payload_value, marker)
+
+    hits = _walk_json_marker_hits(data, search)
+    if not hits:
+        return {"executable": False, "location": "not_reflected"}
+
+    for path, value in hits:
+        if _json_path_is_error_field(path):
+            continue
+        if _is_safely_escaped(value, search):
+            continue
+        if _json_value_suggests_dom_execution(value, search, path=path):
+            exec_check = _check_executable_in_response(value, payload_value, marker)
+            location = (
+                f"json_field_executable:{path}"
+                if exec_check.get("executable")
+                else f"json_field_html:{path}"
+            )
+            return {
+                "executable": True,
+                "location": location,
+                "evidence": (exec_check.get("evidence") or value[:200]),
+            }
+
+    return {"executable": False, "location": "json_stored_safe"}
+
+
+def analyze_verify_response(
+    body: str,
+    payload_value: str,
+    marker: Optional[str] = None,
+    *,
+    headers: Any = None,
+) -> Dict[str, Any]:
+    """2차 검증 응답: JSON API vs HTML SSR 자동 분기."""
+    if looks_like_json_body(body, headers):
+        return analyze_json_stored_context(body, payload_value, marker)
+    return _analyze_context_robust(body, payload_value, marker)
+
+
+def build_verify_request_headers(
+    surface: Any,
+    check_url: str,
+    base_headers: Optional[dict[str, Any]] = None,
+) -> dict[str, str]:
+    """SPA read API는 JSON Accept를 우선한다 (MPA HTML은 기존 헤더 유지)."""
+    headers: dict[str, str] = {}
+    for key, value in (base_headers or {}).items():
+        if value is not None:
+            headers[str(key)] = str(value)
+    path = (check_url or "").lower()
+    surface_url = str(getattr(surface, "url", "") or "").lower()
+    source_url = str(getattr(surface, "source_url", "") or "").lower()
+    prefers_json = (
+        "/api/" in path
+        or path.endswith(".json")
+        or "/api/" in surface_url
+        or "application/json" in str(getattr(surface, "request_content_type", "") or "").lower()
+        or "application/json" in str(getattr(surface, "content_type", "") or "").lower()
+    )
+    if prefers_json and not source_url.endswith(".html"):
+        headers.setdefault("Accept", "application/json")
+    return headers
 
 
 def _is_waf_blocked(response: Any, original_res: Any, baseline_text: Optional[str] = None) -> bool:
@@ -513,6 +1072,7 @@ def analyze_stored_xss(
         original_res: Any = None,
         requester: Any = None,
         baseline: Optional[str] = None,
+        surface: Any = None,
 ) -> Dict[str, Any]:
     """
     [범용] Stored XSS 취약점 분석
@@ -564,8 +1124,20 @@ def analyze_stored_xss(
         result["evidence"] = "Payload was HTML-escaped"
         return result
 
+    response_headers = getattr(response, "headers", None)
+
     if payload_value in response_body or (marker and marker in response_body):
-        context_state = _analyze_context_robust(response_body, payload_value, marker)
+        if is_immediate_reflection_only_hit(surface, response, payload_value, marker):
+            result["context"] = "reflected_only_not_stored"
+            result["evidence"] = (
+                "Inline reflection on read/search surface; deferred to reflected_xss / skip stored verify"
+            )
+            return result
+
+        if looks_like_json_body(response_body, response_headers):
+            context_state = analyze_json_stored_context(response_body, payload_value, marker)
+        else:
+            context_state = _analyze_context_robust(response_body, payload_value, marker)
 
         result["context"] = context_state["location"]
 
@@ -590,6 +1162,24 @@ def analyze_stored_xss(
         result["is_vulnerable"] = True
         result["context"] = "obfuscated_reflection"
         result["evidence"] = "Payload fragments reflected in executable context"
+        return result
+
+    if looks_like_successful_store_api_response(response, response_body):
+        result["is_vulnerable"] = True
+        result["context"] = "stored_api_deferred_verify"
+        result["evidence"] = (
+            "Mutating API accepted request without inline reflection; "
+            "deferred to read-endpoint verification"
+        )
+        return result
+
+    if looks_like_successful_store_redirect(response, response_body, surface):
+        result["is_vulnerable"] = True
+        result["context"] = "stored_redirect_deferred_verify"
+        result["evidence"] = (
+            "Mutating form accepted request and redirected without inline reflection; "
+            "deferred to read-endpoint verification"
+        )
         return result
 
     result["context"] = "filtered_or_not_reflected"

--- a/modules/stored_xss/module.py
+++ b/modules/stored_xss/module.py
@@ -13,12 +13,24 @@ from core.models import Payload
 from modules.stored_xss.payloads import build_stored_xss_payloads, PayloadCategory, reload_payloads
 from modules.stored_xss.analyzer import (
     analyze_stored_xss,
-    _analyze_context_robust,
+    analyze_verify_response,
+    build_verify_request_headers,
     _extract_injected_marker,
+    injection_response_implies_failed_auth,
     is_acceptable_verify_response,
+    is_get_read_only_surface,
+    is_reflected_only_param,
     is_success_status,
+    surface_expects_json_api,
+    surface_method_is_get,
+    verify_context_matches_parameter,
+    verify_implies_persistent_storage,
 )
-from modules.stored_xss.verify_urls import collect_verify_candidate_urls
+from modules.stored_xss.verify_urls import (
+    collect_verify_candidate_urls,
+    expand_detail_urls_from_list_bodies,
+    infer_list_poll_urls,
+)
 from fuzzer.request_builder import build_and_send_request
 
 
@@ -89,6 +101,10 @@ class StoredXSSModule(BaseModule):
         reload_payloads()
 
     def get_target_parameters(self, surface, parameters: List[str]) -> List[str]:
+        # 저장형 XSS는 데이터 변경 엔드포인트(POST 등)가 대상. GET 목록·상세 조회는 반사형 영역.
+        if surface_method_is_get(surface):
+            return []
+
         destructive_keys = {"btnclear", "clear", "reset", "delete", "destroy", "remove"}
 
         if hasattr(surface, 'parameters') and isinstance(surface.parameters, dict):
@@ -113,17 +129,22 @@ class StoredXSSModule(BaseModule):
 
         skip_keys = {
             "submit", "action", "login", "logout", "cancel", "update", "btnsign", "search", "page",
-            "lang", "theme", "csrf_token", "user_token", "_token", "authenticity_token"
+            "lang", "theme", "csrf_token", "user_token", "_token", "authenticity_token",
+            "keyword", "q", "query", "term", "searchtext",
         }.union(destructive_keys)
 
         if self.target_params:
             for p in parameters:
                 if p in self.target_params and str(p).lower() not in skip_keys:
+                    if is_get_read_only_surface(surface, p) or is_reflected_only_param(p):
+                        continue
                     valid_targets.append(p)
             return valid_targets
 
         for p in parameters:
             if str(p).lower() not in skip_keys:
+                if is_get_read_only_surface(surface, p) or is_reflected_only_param(p):
+                    continue
                 valid_targets.append(p)
 
         return valid_targets
@@ -158,7 +179,13 @@ class StoredXSSModule(BaseModule):
         return sum(counts.values())
 
     def analyze(
-            self, response: Any, payload: Payload, elapsed_time: float, original_res: Any = None, requester: Any = None
+            self,
+            response: Any,
+            payload: Payload,
+            elapsed_time: float,
+            original_res: Any = None,
+            requester: Any = None,
+            surface: Any = None,
     ) -> bool:
         with self._stats_lock:
             self.stats.tested += 1
@@ -168,7 +195,13 @@ class StoredXSSModule(BaseModule):
                 baseline_text = original_res.text
 
             result = analyze_stored_xss(
-                response, payload, elapsed_time, original_res, requester, baseline_text
+                response,
+                payload,
+                elapsed_time,
+                original_res,
+                requester,
+                baseline_text,
+                surface=surface,
             )
             self._last_analysis_result = result
             is_hit = bool(result.get("is_vulnerable", False))
@@ -218,18 +251,58 @@ class StoredXSSModule(BaseModule):
                 session, safe_surface, parameter, MockPayload(verify_payload_value)
             )
 
+            if injection_response_implies_failed_auth(injection_res):
+                return False
+
             req_headers = getattr(surface, "headers", {}) or {}
+            prefers_json = surface_expects_json_api(safe_surface)
             candidate_urls = collect_verify_candidate_urls(
                 base_url=base_url,
                 surface=safe_surface,
                 injection_res=injection_res,
+                max_urls=8,
             )
 
-            await asyncio.sleep(2.5)
+            await asyncio.sleep(1.0 if prefers_json else 0.75)
+
+            injection_body = getattr(injection_res, "text", "") or ""
+            list_poll_urls = (
+                infer_list_poll_urls(safe_surface, base_url, injection_body)
+                if prefers_json
+                else []
+            )
+            list_bodies: list[tuple[str, str]] = []
+            verify_headers_base = build_verify_request_headers(
+                safe_surface, base_url, req_headers
+            )
+            # 목록 URL이 후보에 이미 있어도 id→view URL 생성을 위해 반드시 fetch한다.
+            for list_url in list_poll_urls[:3]:
+                try:
+                    async with session.get(
+                        list_url,
+                        headers=verify_headers_base,
+                        cookies=getattr(surface, "cookies", None),
+                        timeout=15,
+                    ) as list_res:
+                        if is_success_status(list_res.status):
+                            list_bodies.append((list_url, await list_res.text()))
+                except Exception:
+                    continue
+            for detail_url in expand_detail_urls_from_list_bodies(
+                list_bodies,
+                base_url=base_url,
+                surface=safe_surface,
+                injection_body=injection_body,
+                surface_url=str(getattr(safe_surface, "url", "") or ""),
+                max_items=4,
+            ):
+                if detail_url not in candidate_urls:
+                    candidate_urls.insert(0, detail_url)
 
             is_vulnerable = False
             verified_location = ""
             hit_url = ""
+            fetch_cache: Dict[str, Dict[str, Any]] = {}
 
             for check_url in candidate_urls:
                 if check_url not in self._target_locks:
@@ -237,40 +310,67 @@ class StoredXSSModule(BaseModule):
 
                 verify_body = ""
                 verify_status = 0
+                verify_response_headers: dict[str, str] = {}
+                verify_headers = build_verify_request_headers(
+                    safe_surface, check_url, req_headers
+                )
                 async with self._target_locks[check_url]:
-                    try:
-                        req_cookies = getattr(surface, 'cookies', None)
-                        async with session.get(check_url, headers=req_headers, cookies=req_cookies,
-                                               timeout=15) as verify_res:
-                            verify_status = verify_res.status
-                            if not is_success_status(verify_status):
-                                continue
-                            verify_body = await verify_res.text()
-                    except Exception:
-                        continue
+                    cached = fetch_cache.get(check_url)
+                    if cached is not None:
+                        verify_status = cached.get("status", 0)
+                        verify_body = cached.get("body", "")
+                        verify_response_headers = cached.get("headers", {})
+                    else:
+                        try:
+                            req_cookies = getattr(surface, 'cookies', None)
+                            async with session.get(
+                                check_url,
+                                headers=verify_headers,
+                                cookies=req_cookies,
+                                timeout=15,
+                            ) as verify_res:
+                                verify_status = verify_res.status
+                                if not is_success_status(verify_status):
+                                    continue
+                                verify_body = await verify_res.text()
+                                verify_response_headers = {
+                                    str(k): str(v) for k, v in verify_res.headers.items()
+                                }
+                                fetch_cache[check_url] = {
+                                    "status": verify_status,
+                                    "body": verify_body,
+                                    "headers": verify_response_headers,
+                                }
+                        except Exception:
+                            continue
 
                 if not is_acceptable_verify_response(
                     verify_status, verify_body, marker=verify_marker
                 ):
                     continue
 
-                if verify_marker in verify_body:
-                    marker_indices = [m.start() for m in re.finditer(re.escape(verify_marker), verify_body)]
+                if verify_marker not in verify_body:
+                    continue
 
-                    for idx in marker_indices:
-                        slice_start = max(0, idx - 2000)
-                        slice_end = min(len(verify_body), idx + 2000)
-                        body_slice = verify_body[slice_start:slice_end]
+                context_state = analyze_verify_response(
+                    verify_body,
+                    verify_marker,
+                    verify_marker,
+                    headers=verify_response_headers,
+                )
 
-                        context_state = _analyze_context_robust(body_slice, verify_marker, verify_marker)
-
-                        if context_state.get("executable"):
-                            is_vulnerable = True
-                            verified_location = context_state.get('location', 'unknown_location')
-                            hit_url = check_url
-                            break
-
-                if is_vulnerable:
+                if context_state.get("executable"):
+                    if not verify_context_matches_parameter(
+                        parameter, context_state.get("location", "")
+                    ):
+                        continue
+                    if not verify_implies_persistent_storage(
+                        safe_surface, target_url, check_url
+                    ):
+                        continue
+                    is_vulnerable = True
+                    verified_location = context_state.get('location', 'unknown_location')
+                    hit_url = check_url
                     break
 
             if is_vulnerable:

--- a/modules/stored_xss/verify_urls.py
+++ b/modules/stored_xss/verify_urls.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 import json
 import re
 from typing import Any
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 
 from modules.file_upload.path_discovery import (
     extract_post_detail_urls,
     iter_related_crawl_urls,
 )
+from modules.stored_xss.analyzer import surface_expects_json_api
 
 _JSON_URL_KEYS = frozenset(
     {
@@ -36,6 +37,66 @@ _JSON_URL_KEYS = frozenset(
 )
 
 _REFRESH_URL_RE = re.compile(r"url\s*=\s*['\"]?([^;'\"]+)", re.IGNORECASE)
+
+_MUTATION_PATH_SUFFIXES = (
+    "/write",
+    "/add",
+    "/create",
+    "/post",
+    "/comment",
+    "/edit",
+    "/update",
+    "/reply",
+    "/process",
+    "/confirm",
+    "/submit",
+    "/complete",
+)
+
+# 결제·주문류 mutation 후 상세 조회가 다른 컬렉션에 있는 SPA/REST 패턴
+_MUTATION_TO_READ_COLLECTIONS: dict[str, tuple[str, ...]] = {
+    "checkout": ("orders", "order"),
+    "payment": ("orders", "order", "payments"),
+    "cart": ("orders",),
+    "purchase": ("orders", "order"),
+}
+
+_COLLECTION_ARRAY_KEYS = frozenset(
+    {
+        "posts",
+        "orders",
+        "items",
+        "results",
+        "entries",
+        "articles",
+        "threads",
+        "comments",
+        "books",
+        "records",
+        "rows",
+        "data",
+    }
+)
+
+_READ_PATH_SUFFIXES = (
+    "/view",
+    "/detail",
+    "/show",
+    "/read",
+    "/get",
+)
+
+_ID_FIELD_NAMES = frozenset(
+    {
+        "id",
+        "post_id",
+        "item_id",
+        "book_id",
+        "article_id",
+        "thread_id",
+        "comment_id",
+    }
+)
 
 
 def _append_unique(ordered: list[str], seen: set[str], raw_url: str) -> None:
@@ -92,6 +153,435 @@ def _urls_from_json(node: Any, base_url: str, found: set[str], *, depth: int = 0
             _urls_from_json(item, base_url, found, depth=depth + 1)
 
 
+def _scheme_netloc(base_url: str) -> tuple[str, str]:
+    split = urlsplit(base_url or "")
+    if split.scheme and split.netloc:
+        return split.scheme, split.netloc
+    return "", ""
+
+
+def _client_route_to_api_url(route_url: str, base_url: str) -> str:
+    """`/board/view?id=1` -> `/api/board/view?id=1` (범용 SPA 라우트 매핑)."""
+    raw = (route_url or "").strip()
+    if not raw:
+        return ""
+    split = urlsplit(raw)
+    if not split.scheme or not split.netloc:
+        scheme, netloc = _scheme_netloc(base_url)
+        if not scheme or not netloc:
+            return ""
+        split = urlsplit(urljoin(f"{scheme}://{netloc}", raw))
+    path = split.path or ""
+    if "/api/" in path.lower():
+        return urlunsplit((split.scheme, split.netloc, path, split.query, ""))
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return ""
+    api_path = "/api/" + "/".join(parts)
+    return urlunsplit((split.scheme, split.netloc, api_path, split.query, ""))
+
+
+def _view_template_from_mutation_url(url: str) -> str | None:
+    split = urlsplit(url or "")
+    path = split.path or ""
+    lower = path.lower()
+    for suffix in _MUTATION_PATH_SUFFIXES:
+        if lower.endswith(suffix):
+            stem = path[: -len(suffix)]
+            if not stem:
+                return None
+            return urlunsplit((split.scheme, split.netloc, f"{stem}/view", "", ""))
+    return None
+
+
+def _list_template_from_mutation_url(url: str) -> str | None:
+    split = urlsplit(url or "")
+    path = split.path or ""
+    lower = path.lower()
+    for suffix in _MUTATION_PATH_SUFFIXES:
+        if lower.endswith(suffix):
+            stem = path[: -len(suffix)]
+            if not stem:
+                return None
+            return urlunsplit((split.scheme, split.netloc, stem, "", ""))
+    return None
+
+
+def _api_path_segments(url: str) -> list[str]:
+    path = (urlsplit(url or "").path or "").lower()
+    return [seg for seg in path.split("/") if seg and seg != "api"]
+
+
+def _infer_read_urls_for_collection(
+    base_url: str,
+    collection_name: str,
+    *,
+    query: str = "",
+) -> list[str]:
+    """``orders`` -> ``/api/orders``, ``/api/orders/view`` (+ optional query)."""
+    scheme, netloc = _scheme_netloc(base_url)
+    if not scheme or not netloc or not collection_name:
+        return []
+    stem = f"/api/{collection_name.strip('/')}"
+    list_path = stem
+    view_path = f"{stem}/view"
+    if query:
+        list_url = urlunsplit((scheme, netloc, list_path, query, ""))
+        view_url = urlunsplit((scheme, netloc, view_path, query, ""))
+    else:
+        list_url = urlunsplit((scheme, netloc, list_path, "", ""))
+        view_url = urlunsplit((scheme, netloc, view_path, "", ""))
+    return [list_url, view_url]
+
+
+def infer_related_read_api_urls(
+    surface: Any,
+    base_url: str,
+    injection_body: str = "",
+) -> list[str]:
+    """
+    mutation·redirect 맥락에서 '다른 컬렉션' read API를 추론 (checkout -> orders/view 등).
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str) -> None:
+        normalized = _normalize_absolute(base_url, raw)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            found.append(normalized)
+
+    for raw in (
+        str(getattr(surface, "url", "") or ""),
+        str(getattr(surface, "source_url", "") or ""),
+    ):
+        for seg in _api_path_segments(raw):
+            for collection in _MUTATION_TO_READ_COLLECTIONS.get(seg, ()):
+                for url in _infer_read_urls_for_collection(base_url, collection):
+                    add(url)
+
+    for redirect_url in extract_redirect_urls_from_json(injection_body, base_url):
+        split = urlsplit(redirect_url)
+        path = (split.path or "").rstrip("/")
+        if not path:
+            continue
+        query = split.query or ""
+        parts = [p for p in path.split("/") if p]
+        if not parts:
+            continue
+        last = parts[-1].lower()
+        read_suffixes = {s.lstrip("/") for s in _READ_PATH_SUFFIXES}
+        mutation_suffixes = {s.lstrip("/") for s in _MUTATION_PATH_SUFFIXES}
+        if last in read_suffixes or last in mutation_suffixes:
+            continue
+        collection = parts[-1]
+        for url in _infer_read_urls_for_collection(base_url, collection, query=query):
+            add(url)
+
+    return found
+
+
+def _infer_api_read_urls(surface: Any, base_url: str) -> list[str]:
+    """Write/comment API surface에서 대응 read API URL을 추론."""
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str) -> None:
+        normalized = _normalize_absolute(base_url, raw)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            found.append(normalized)
+
+    for raw in (
+        str(getattr(surface, "url", "") or ""),
+        str(getattr(surface, "source_url", "") or ""),
+    ):
+        if not raw:
+            continue
+        view_tpl = _view_template_from_mutation_url(raw)
+        if view_tpl:
+            add(view_tpl)
+        list_tpl = _list_template_from_mutation_url(raw)
+        if list_tpl:
+            add(list_tpl)
+        api_variant = _client_route_to_api_url(raw, base_url)
+        if api_variant:
+            add(api_variant)
+
+    return found
+
+
+def _detail_url_with_id(template_url: str, resource_id: str) -> str:
+    split = urlsplit(template_url)
+    params = dict(parse_qsl(split.query, keep_blank_values=True))
+    params["id"] = str(resource_id)
+    query = urlencode(params)
+    return urlunsplit((split.scheme, split.netloc, split.path, query, ""))
+
+
+def extract_json_resource_detail_urls(
+    body: str,
+    base_url: str,
+    *,
+    surface_url: str = "",
+    extra_view_templates: list[str] | None = None,
+    max_items: int = 5,
+) -> list[str]:
+    """
+    JSON 목록/단건 응답에서 id를 찾아 view URL 후보 생성.
+    """
+    text = (body or "").strip()
+    if not text or text[0] not in "{[":
+        return []
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+    templates: list[str] = []
+    for raw in (surface_url, base_url):
+        tpl = _view_template_from_mutation_url(raw)
+        if tpl and tpl not in templates:
+            templates.append(tpl)
+    if not templates:
+        split = urlsplit(surface_url or base_url)
+        if "/api/" in (split.path or "").lower():
+            path = split.path or ""
+            for read_suffix in _READ_PATH_SUFFIXES:
+                if read_suffix in path.lower():
+                    templates.append(urlunsplit((split.scheme, split.netloc, path, "", "")))
+                    break
+
+    for raw_tpl in extra_view_templates or []:
+        tpl = (raw_tpl or "").strip()
+        if tpl and tpl not in templates:
+            templates.append(tpl)
+
+    if not templates:
+        return []
+
+    ids: list[str] = []
+
+    def collect_ids(node: Any, depth: int = 0) -> None:
+        if depth > 8 or len(ids) >= max_items * 3:
+            return
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_lower = str(key).lower()
+                if key_lower in _COLLECTION_ARRAY_KEYS and isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict):
+                            raw_id = item.get("id")
+                            if raw_id is not None:
+                                id_str = str(raw_id).strip()
+                                if id_str.isdigit():
+                                    ids.append(id_str)
+                if key_lower in _ID_FIELD_NAMES and value is not None:
+                    id_str = str(value).strip()
+                    if id_str.isdigit():
+                        ids.append(id_str)
+                else:
+                    collect_ids(value, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                collect_ids(item, depth + 1)
+
+    collect_ids(data)
+
+    # newest/highest id first
+    unique_ids: list[str] = []
+    seen_ids: set[str] = set()
+    for id_str in sorted({int(i) for i in ids if i.isdigit()}, reverse=True):
+        key = str(id_str)
+        if key in seen_ids:
+            continue
+        seen_ids.add(key)
+        unique_ids.append(key)
+        if len(unique_ids) >= max_items:
+            break
+
+    urls: list[str] = []
+    seen_urls: set[str] = set()
+    for template in templates:
+        for resource_id in unique_ids:
+            url = _detail_url_with_id(template, resource_id)
+            url = _normalize_absolute(base_url, url)
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                urls.append(url)
+    return urls
+
+
+def extract_redirect_urls_from_json(body: str, base_url: str) -> list[str]:
+    """SPA mutating API의 redirect/location 필드에서 후속 GET 검증 URL 추출."""
+    text = (body or "").strip()
+    if not text or text[0] not in "{[":
+        return []
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str) -> None:
+        normalized = _normalize_absolute(base_url, raw)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            found.append(normalized)
+
+    def walk(node: Any, depth: int = 0) -> None:
+        if depth > 6:
+            return
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_lower = str(key).lower()
+                if key_lower in _JSON_URL_KEYS and isinstance(value, str) and value.strip():
+                    add(value)
+                else:
+                    walk(value, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(data)
+    expanded: list[str] = []
+    for raw in found:
+        expanded.append(raw)
+        api_url = _client_route_to_api_url(raw, base_url)
+        if api_url:
+            expanded.append(api_url)
+    return expanded
+
+
+def _list_url_with_query(list_url: str, query: str) -> str:
+    if not query:
+        return list_url
+    split = urlsplit(list_url)
+    return urlunsplit((split.scheme, split.netloc, split.path, query, ""))
+
+
+def infer_list_api_urls(surface: Any, base_url: str) -> list[str]:
+    """write/add 뮤테이션 surface에서 대응 목록(list) API URL 추론."""
+    return infer_list_poll_urls(surface, base_url, injection_body="")
+
+
+def infer_list_poll_urls(
+    surface: Any,
+    base_url: str,
+    injection_body: str = "",
+) -> list[str]:
+    """
+    2차 검증 전 목록 API GET용 URL (mutation list + redirect list + 관련 컬렉션).
+    redirect가 ``/board?type=general``이면 목록 API에도 동일 query를 붙인다.
+    """
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str) -> None:
+        normalized = _normalize_absolute(base_url, raw)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            ordered.append(normalized)
+
+    redirect_queries: list[str] = []
+    for redirect_url in extract_redirect_urls_from_json(injection_body, base_url):
+        q = urlsplit(redirect_url).query
+        if q and q not in redirect_queries:
+            redirect_queries.append(q)
+
+    for raw in (
+        str(getattr(surface, "url", "") or ""),
+        str(getattr(surface, "source_url", "") or ""),
+    ):
+        tpl = _list_template_from_mutation_url(raw)
+        if tpl:
+            add(_client_route_to_api_url(tpl, base_url) or tpl)
+            for q in redirect_queries:
+                api_list = _client_route_to_api_url(tpl, base_url) or tpl
+                add(_list_url_with_query(api_list, q))
+
+    for redirect_url in extract_redirect_urls_from_json(injection_body, base_url):
+        split = urlsplit(redirect_url)
+        path = split.path or ""
+        if not path or "/view" in path.lower():
+            continue
+        api_list = _client_route_to_api_url(redirect_url, base_url)
+        if api_list:
+            add(api_list)
+
+    for related in infer_related_read_api_urls(surface, base_url, injection_body):
+        split = urlsplit(related)
+        path_lower = (split.path or "").lower()
+        if path_lower.endswith("/view"):
+            continue
+        add(related)
+
+    return ordered
+
+
+def _view_templates_for_surface(
+    surface: Any,
+    base_url: str,
+    injection_body: str,
+    surface_url: str,
+) -> list[str]:
+    templates: list[str] = []
+    seen: set[str] = set()
+
+    def add_tpl(raw: str) -> None:
+        split = urlsplit((raw or "").strip())
+        if not split.path or not split.path.lower().endswith("/view"):
+            return
+        tpl = urlunsplit((split.scheme, split.netloc, split.path, "", ""))
+        if tpl and tpl not in seen:
+            seen.add(tpl)
+            templates.append(tpl)
+
+    for raw in (surface_url,):
+        tpl = _view_template_from_mutation_url(raw)
+        if tpl:
+            add_tpl(tpl)
+
+    if surface is not None:
+        for raw in infer_related_read_api_urls(surface, base_url, injection_body):
+            add_tpl(raw)
+        for raw in _infer_api_read_urls(surface, base_url):
+            add_tpl(raw)
+
+    return templates
+
+
+def expand_detail_urls_from_list_bodies(
+    list_bodies: list[tuple[str, str]],
+    *,
+    base_url: str,
+    surface: Any = None,
+    injection_body: str = "",
+    surface_url: str = "",
+    max_items: int = 5,
+) -> list[str]:
+    """목록 API 응답 JSON에서 최신 리소스 view URL을 추가 생성."""
+    urls: list[str] = []
+    seen: set[str] = set()
+    extra_templates = _view_templates_for_surface(
+        surface, base_url, injection_body, surface_url
+    )
+    for _list_url, body in list_bodies:
+        for detail in extract_json_resource_detail_urls(
+            body,
+            base_url,
+            surface_url=surface_url,
+            extra_view_templates=extra_templates,
+            max_items=max_items,
+        ):
+            if detail not in seen:
+                seen.add(detail)
+                urls.append(detail)
+    return urls
+
+
 def _urls_from_json_body(body: str, base_url: str) -> list[str]:
     text = (body or "").strip()
     if not text or text[0] not in "{[":
@@ -102,7 +592,13 @@ def _urls_from_json_body(body: str, base_url: str) -> list[str]:
         return []
     found: set[str] = set()
     _urls_from_json(data, base_url, found)
-    return list(found)
+    mapped: set[str] = set()
+    for raw in list(found):
+        mapped.add(raw)
+        api_url = _client_route_to_api_url(raw, base_url)
+        if api_url:
+            mapped.add(api_url)
+    return list(mapped)
 
 
 def collect_verify_candidate_urls(
@@ -111,6 +607,7 @@ def collect_verify_candidate_urls(
     surface: Any,
     injection_res: Any,
     max_detail_pages: int = 5,
+    max_urls: int = 12,
 ) -> list[str]:
     """
     저장형 XSS 재검증에 GET할 URL 후보 목록 (중복 제거, 삽입 순서 유지).
@@ -138,6 +635,16 @@ def collect_verify_candidate_urls(
         add(header_url)
 
     injection_body = getattr(injection_res, "text", "") or ""
+    surface_url = str(getattr(surface, "url", "") or "")
+    expects_json = surface_expects_json_api(surface)
+
+    if expects_json:
+        for api_read in _infer_api_read_urls(surface, resolve_base):
+            add(api_read)
+
+        for related_read in infer_related_read_api_urls(surface, resolve_base, injection_body):
+            add(related_read)
+
     if injection_body:
         for detail_url in extract_post_detail_urls(
             injection_body,
@@ -145,16 +652,33 @@ def collect_verify_candidate_urls(
             max_posts=max_detail_pages,
         ):
             add(detail_url)
-        for json_url in _urls_from_json_body(injection_body, resolve_base):
-            add(json_url)
+        if expects_json:
+            for json_url in _urls_from_json_body(injection_body, resolve_base):
+                add(json_url)
+            for redirect_url in extract_redirect_urls_from_json(injection_body, resolve_base):
+                add(redirect_url)
+            for resource_url in extract_json_resource_detail_urls(
+                injection_body,
+                resolve_base,
+                surface_url=surface_url,
+                max_items=max_detail_pages,
+            ):
+                add(resource_url)
 
-    surface_url = str(getattr(surface, "url", "") or "")
+    if expects_json:
+        for list_url in infer_list_poll_urls(surface, resolve_base, injection_body):
+            add(list_url)
+
     source_url = getattr(surface, "source_url", None)
     for related in iter_related_crawl_urls(
         surface_url=surface_url,
         source_url=str(source_url) if source_url else None,
     ):
         add(related)
+        if expects_json:
+            api_related = _client_route_to_api_url(related, resolve_base)
+            if api_related:
+                add(api_related)
 
     if surface_url:
         add(surface_url)
@@ -169,4 +693,6 @@ def collect_verify_candidate_urls(
     elif resolve_base and resolve_base not in seen:
         add(resolve_base)
 
+    if max_urls > 0 and len(ordered) > max_urls:
+        return ordered[:max_urls]
     return ordered

--- a/parsers/body_field_inference.py
+++ b/parsers/body_field_inference.py
@@ -19,6 +19,9 @@ __all__ = (
     "extract_body_field_names_near_url_literal",
 )
 
+# DOM/네트워크에서 흔한 일반 키 — 라벨 시맨틱으로 더 구체적인 필드명으로 정제 가능
+_GENERIC_REFINABLE_FIELD_KEYS = frozenset({"url"})
+
 _NON_WORD_RE = re.compile(r"[^\w\s-]+", re.UNICODE)
 _MULTI_SEP_RE = re.compile(r"[\s-]+")
 _VALID_FIELD_RE = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -89,7 +92,7 @@ def slugify_field_name(text: str, *, max_len: int = 64) -> str:
     return ""
 
 
-def infer_field_name_from_label_text(label_text: str) -> str:
+def infer_field_name_from_label_text(label_text: str, *, semantic_only: bool = False) -> str:
     """폼 라벨·aria-label·placeholder → 필드명 (HTTP/폼 시맨틱 우선, slug는 보조)."""
     text = str(label_text or "").strip()
     if not text:
@@ -99,6 +102,8 @@ def infer_field_name_from_label_text(label_text: str) -> str:
     for pattern, field_name in _LABEL_SEMANTIC_RULES:
         if pattern.search(text):
             return field_name
+    if semantic_only:
+        return ""
     return slugify_field_name(text)
 
 
@@ -125,6 +130,17 @@ def refine_observed_field_key(
     if not raw_key:
         return ""
     if is_plausible_field_name(raw_key):
+        lowered = raw_key.lower()
+        if lowered in _GENERIC_REFINABLE_FIELD_KEYS:
+            hint = str(label or "").strip()
+            if hint:
+                inferred = infer_field_name_from_label_text(hint, semantic_only=True)
+                if (
+                    inferred
+                    and inferred != lowered
+                    and is_plausible_field_name(inferred)
+                ):
+                    return inferred
         return raw_key
 
     hint_parts = [str(label or "").strip()]


### PR DESCRIPTION
## 📌 PR 목적 (What)
spa 타겟 페이지 대상 fuzzer 실행시 stored_xss, file_upload, ssrf 경우 취약점 탐지가 안되는데 이걸 가능하게 하기 위해 2차 검증 로직 수정 및 추가
## 🛠️ 주요 변경 사항 (How)
1. spa 동적 크롤러 개선
`crawler/spa/dom_form_capture.py` 수정
`crawler/spa/engine.py` 수정
`crawler/spa/js_analyzer.py` 수정
`fuzzer/engine.py` 수정
`parsers/body_field_inference.py`  - 수정
2.stored_xss 모듈 2차 검증 로직 수정
`stored_xss/verify_urls.py`  - 수정
`stored_xss/module.py`  - 수정
`stored_xss/analyzer.py`  - 수정
3.file_upload 모듈 2차 검증 로작 추가
`file_upload/analyzer.py `  - 수정
`file_upload/markers.py `  - 수정
`file_upload/module.py `  - 수정
`file_upload/path_discovery.py `  - 수정
`file_upload/verfiter.py `  - 수정
4. ssrf 모듈 2차 검증 로직 추가
`ssrf/analyzer.py` - 수정
`ssrf/module.py` - 수정
`ssrf/verify.py` - 추가

## 🧪 테스트 결과 (Testing & Verification)
mpa - ssrf
<img width="284" height="185" alt="image" src="https://github.com/user-attachments/assets/2290e15b-f1a4-4d96-9177-89c5b6b72a02" />
spa - ssrf
<img width="266" height="189" alt="image" src="https://github.com/user-attachments/assets/fa3c3ee0-732f-4163-a167-192ba0400ddb" />

## ✅ 다음 작업 (Next Step)
- [ ]  ssti spa 환경 테스트
- [ ]  -t all spa 환경 테스트
- [ ]  중간 발표 동적 크롤러 부분 작성
