### PR TITLE
[chore] CI/ GHCR 자동 빌드 및 스캔 파이프라인 추가

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,70 @@
+name: Build and Push Scanner Image
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+      security-events: write   # Trivy SARIF 업로드용
+
+    steps:
+      - name: 1. 스캐너 소스코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: 2. 소문자 이미지명 세팅
+        id: image
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
+      - name: 3. Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
+      - name: 4. GHCR 로그인
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 5. 메타데이터 추출 (태그 자동 생성)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
+
+      - name: 6. 도커 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 7. Trivy 이미지 스캔 (실패해도 빌드 통과)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.image.outputs.name }}:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: 0
+
+      - name: 8. Trivy 결과를 GitHub Security 탭으로 업로드
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif


### PR DESCRIPTION
## 📌 PR 목적 (What)
타겟 페이지 측 파이프라인에서 스캐너 이미지를 손쉽게 다운로드(pull)하여 자동 취약점 진단을 수행할 수 있는 기반 마련

## 🛠️ 주요 변경 사항 (How)
- 트리거 조건 설정
develop 브랜치에 코드가 push되면 자동 실행
필요 시 GitHub 웹에서 수동 실행도 가능 (workflow_dispatch)
- 이미지 빌드 및 GHCR 업로드 자동화
GitHub이 자동 발급하는 GITHUB_TOKEN으로 GHCR 로그인 (별도 PAT 발급 불필요)
Dockerfile 기반으로 이미지 빌드 후 GHCR에 자동 푸시
- 이미지 태그 자동 관리
:latest — main 브랜치 빌드일 때만 갱신 (안정 버전)
:main, :develop — 브랜치명 태그
:sha-xxxxxxx — 커밋 해시 태그 (특정 시점 추적용)
→ 타겟 레포에서는 :latest를 pull하면 항상 최신 안정 버전 사용
- 이미지 보안 검증 (Trivy)
빌드된 스캐너 이미지 자체에 알려진 취약점(CVE)이 있는지 자동 스캔
결과를 GitHub Security 탭에 업로드해 시각적으로 확인 가능
빌드 차단은 하지 않도록 설정 (exit-code: 0, continue-on-error: true) — 베이스 이미지 CVE로 인해 파이프라인이 깨지는 것을 방지

## 🧪 테스트 결과 (Testing & Verification)
깃허브 Actions 환경에서 도커 로그인, 빌드, 푸시 과정 정상 작동 확인 예정 (본 PR 생성 후 Actions 탭 확인)

## 💡 리뷰어 참고 사항
GHCR 패키지 권한 설정은 별도로 한 번 수동 작업이 필요합니다 (yml로 처리 불가):
<Packages 탭 → modular-web-scanner → Package settings → Manage Actions access → 타겟 페이지 레포를 Read 권한으로 추가>
이 작업이 완료되어야 타겟 페이지 레포에서 이미지 pull 가능합니다.

## ✅ 다음 작업 (Next Step)
- [ ] 타겟 페이지 파이프라인(auto-scan.yml) 연동 작업
