### PR TITLE
[feat] SQLi 모듈 worker 고정 추가

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -20,6 +20,9 @@ def prepare_scan_context(args, surfaces):
         args.rps = 10
         args.workers = 2
         print("[SYSTEM] stored_xss 모듈 감지: 강제로 RPS 10, Worker 2로 하향 조정합니다.")
+    elif args.type == "sqli":
+        args.workers = 2
+        print("[SYSTEM] sqli 모듈 감지: 강제로 Worker 2로 하향 조정합니다.")
 
     selected_modules = select_modules(args)
     if not selected_modules:


### PR DESCRIPTION
## 📌 PR 목적 (What)
 SQLi 모듈의 Boolean Blind 탐지 중 동적 간섭이 발생하지 않도록 SQLi 모듈 실행 시 worker 2로 고정 추가.
## 🛠️ 주요 변경 사항 (How)
- runner.py:  SQLi 모듈은 설정된 값과 상관 없이 worker 2로 고정되도록 수정. 
## 🧪 테스트 결과 (Testing & Verification)
 worker 개수가 많을 때 발생하는 오탐 및 미탐 제거 확인
## ✅ 다음 작업 (Next Step)
- [ ] CI/CD 파이프라인 구현
