### PR TITLE
[chore] 빌드 동시성 제어 및 Trivy 참조 수정, .dockerignore 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,81 @@
+# Git
+.git
+.gitignore
+.github/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# 가상환경
+venv/
+env/
+.venv/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# 환경 변수 (절대 이미지 포함 금지)
+.env
+.env.local
+.env.*.local
+*.env
+
+# 문서/설정
+README.md
+docs/
+LICENSE
+*.md
+
+# 테스트
+tests/
+test_*.py
+*_test.py
+
+# 로그
+*.log
+logs/
+
+# 도커 자체
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker-compose.*.yml
+
+# 빌드 산출물
+dist/
+build/
+*.egg-info/
+
+# 스캐너 실행 결과물
+scan_report.json
+scan_report_full.json
+*.report.json
+trivy-results.sarif
+*.sarif
+reports/
+output/
+results/
+
+# 커버리지
+.coverage
+coverage.xml
+.cache/

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "main", "develop" ]
   workflow_dispatch:
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true  
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -43,6 +47,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
 
       - name: 6. 도커 이미지 빌드 및 푸시
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -56,7 +61,7 @@ jobs:
         continue-on-error: true
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.image.outputs.name }}:${{ github.sha }}
+          image-ref: ${{ steps.image.outputs.name }}@${{ steps.build.outputs.digest }}
           format: sarif
           output: trivy-results.sarif
           severity: HIGH,CRITICAL


### PR DESCRIPTION
## 📌 PR 목적 (What)
스캐너 CI 파이프라인의 안정성과 효율성  향상

## 🛠️ 주요 변경 사항 (How)
### 1. Concurrency 설정 추가
- 같은 브랜치에 동시 push 발생 시 이전 빌드 자동 취소
- 빌드 순서 역전 현상 방지 (이전 빌드가 늦게 끝나면서 최신 코드를 덮어쓰는 문제)
### 2. Trivy 이미지 참조 오류 수정
- 기존: 커밋 SHA(`${{ github.sha }}`)로 참조 → 실제 태그(`:sha-xxxxxxx`)와 형식 불일치로 SARIF 업로드 실패
- 수정: 빌드 직후 생성된 이미지의 digest로 참조로 정확한 이미지 식별
- 동시 빌드 환경에서도 잘못된 이미지를 검증할 위험 제거
### 3. .dockerignore 추가
- 빌드 컨텍스트에서 불필요 파일 제외 (.git, __pycache__, .venv 등)
- 민감 정보 누출 방지 (.env 파일)
- 이미지 크기 최적화 및 빌드 속도 향상
 
## 🧪 테스트 결과 (Testing & Verification)
깃허브 Actions 환경에서 정상 작동 확인 예정 

## ✅ 다음 작업 (Next Step)
- [ ] CI/CD 연동 가이드 보완
